### PR TITLE
[WIP] OpenMP + load balance debugging

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1558,6 +1558,23 @@ compareParticles = 0
 analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_loadbalancecosts.py
 tolerance = 1e-12
 
+[reduced_diags_loadbalancecosts_heuristic_omp]
+buildDir = .
+inputFile = Examples/Tests/reduced_diags/inputs_loadbalancecosts
+runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_ics=1 algo.load_balance_costs_update=Heuristic warpx.load_balance_efficiency_ratio_threshold = 0.1
+dim = 3
+addToCompileString =
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 4
+compileTest = 0
+doVis = 0
+compareParticles = 0
+analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_loadbalancecosts.py
+tolerance = 1e-12
+
 [galilean_2d_psatd]
 buildDir = .
 inputFile = Examples/Tests/galilean/inputs_2d


### PR DESCRIPTION
A bug is revealed with OpenMP multithreading and load balancing with this commit: https://github.com/ECP-WarpX/WarpX/commit/d9d9721d80ff2f6ceda3c1a6e32e9ab31b7f81c6
This branch is for locating and fixing the bug, and providing a test to ensure the currently broken case is monitored in the future.

The crash does not appear consistently and may take multiple runs to appear (I've had ~15 before, but it is often less), which may be tricky to catch in a regression test.  The attached input (similar to the regression test) and can show the bug running on Summit CPUs:
```
export OMP_NUM_THREADS=7
jsrun -r 2 -a 1 -c 7 -l CPU-CPU -d packed -b rs <executable> <inputs> > output.txt
```
[inputs_bug](https://github.com/ECP-WarpX/WarpX/files/5772781/inputs_bug.txt)
[Backtrace.1.0](https://github.com/ECP-WarpX/WarpX/files/5772815/Backtrace.1.0.txt)

