### PR TITLE
Fix EB: CUDA Lambda Visibility

### DIFF
--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1143,15 +1143,15 @@ private:
 
     void InitEB ();
 
+public:
     void ComputeEdgeLengths ();
     void ComputeFaceAreas ();
     void ScaleEdges ();
     void ScaleAreas ();
     void ComputeDistanceToEB ();
 
-    void ScrapeParticles ();
-
 private:
+    void ScrapeParticles ();
 
     void PushPSATD ();
 


### PR DESCRIPTION
Fix compile error in embedded boundaries for GPUs.

CUDA:
```
error #3196-D: The enclosing parent function ("ComputeEdgeLengths") for an extended __device__ lambda cannot have private or protected access within its class
```
For:
- `ComputeEdgeLengths`
- `ComputeFaceAreas`
- `ScaleEdges`
- `ScaleAreas`

Seen with #2170