### PR TITLE
Docs: Summit w/o Darshan

### DIFF
--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -52,6 +52,9 @@ We use the following modules and environments on the system (``$HOME/warpx.profi
    module load adios2/2.7.1
    module load hdf5/1.10.7
 
+   # often unstable at runtime with dependencies
+   module unload darshan-runtime
+
    # optional: for PSATD in RZ geometry support
    #   note: needs the ums modules above
    module load blaspp

--- a/Tools/BatchScripts/batch_summit.sh
+++ b/Tools/BatchScripts/batch_summit.sh
@@ -21,7 +21,5 @@
 # make output group-readable by default
 umask 0027
 
-source $HOME/warpx.profile
-
 export OMP_NUM_THREADS=1
 jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs --smpiargs="-gpu" <path/to/executable> <input file> > output.txt

--- a/Tools/BatchScripts/script_profiling_summit.sh
+++ b/Tools/BatchScripts/script_profiling_summit.sh
@@ -16,9 +16,9 @@
 # make output group-readable by default
 umask 0027
 
-module load pgi
-module load cuda/9.1.85
-module list
+#module load pgi
+#module load cuda/9.1.85
+#module list
 set -x
 
 omp=1


### PR DESCRIPTION
We see problems again at runtime with missing libs. We don't need Darshan by default, so let's unload it to make our stack more stable.

We also avoid sourcing the profile again in the batch script: we inherit the environment and modules loaded at submission.