### PR TITLE
CMake: More Robust git STRIP

### DIFF
--- a/cmake/WarpXFunctions.cmake
+++ b/cmake/WarpXFunctions.cmake
@@ -286,7 +286,7 @@ function(get_source_version NAME SOURCE_DIR)
         execute_process(COMMAND git describe --abbrev=12 --dirty --always --tags
             WORKING_DIRECTORY ${SOURCE_DIR}
             OUTPUT_VARIABLE _tmp)
-        string( STRIP ${_tmp} _tmp)
+        string( STRIP "${_tmp}" _tmp)
     endif()
 
     # Is there a CMake project version?


### PR DESCRIPTION
Sometimes a `git` executable can be found but is unusable.
Quoting the result for empty strings makes the build logic more robust in such scenarios.

Mitigates:
```
CMake Error at cmake/WarpXFunctions.cmake:289 (string):
  string sub-command STRIP requires two arguments.
Call Stack (most recent call first):
  CMakeLists.txt:256 (get_source_version)
```

Provoked via: Mixing of brew and Spack (git from brew + Spack env with `export DYLD_LIBRARY_PATH=/Users/axel/src/spack/var/spack/environments/warpx-dev/.spack-env/view/lib`)