### PR TITLE
CI: NVHPC (CUDA)

### DIFF
--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -47,3 +47,44 @@ jobs:
         export WarpX_MPI=ON
         PYWARPX_LIB_DIR=$PWD/build_sp/lib python3 -m pip wheel .
         python3 -m pip install *.whl
+
+  build_nvhpc21-9-nvcc:
+    name: NVHPC@21.9 NVCC/NVC++ Release [tests]
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Dependencies
+      run: .github/workflows/dependencies/nvhpc.sh
+    - name: Build & Install
+      run: |
+        source /etc/profile.d/modules.sh
+        module load /opt/nvidia/hpc_sdk/modulefiles/nvhpc/21.9
+        which nvcc || echo "nvcc not in PATH!"
+        which nvc++ || echo "nvc++ not in PATH!"
+        which nvc || echo "nvc not in PATH!"
+        nvcc --version
+        nvc++ --version
+        nvc --version
+        cmake --version
+
+        export CC=$(which nvc)
+        export CXX=$(which nvc++)
+        export CUDACXX=$(which nvcc)
+        export CUDAHOSTCXX=${CXX}
+
+        cmake -S . -B build            \
+          -DCMAKE_VERBOSE_MAKEFILE=ON  \
+          -DWarpX_COMPUTE=CUDA         \
+          -DWarpX_EB=ON                \
+          -DWarpX_LIB=ON               \
+          -DAMReX_CUDA_ARCH=8.0        \
+          -DWarpX_OPENPMD=ON           \
+          -DWarpX_PSATD=ON             \
+          -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON \
+          -DAMReX_CUDA_ERROR_CAPTURE_THIS=ON
+        cmake --build build -j 2
+
+        python3 -m pip install --upgrade pip setuptools wheel
+        export WarpX_MPI=ON
+        PYWARPX_LIB_DIR=$PWD/build/lib python3 -m pip wheel .
+        python3 -m pip install *.whl

--- a/.github/workflows/dependencies/nvhpc.sh
+++ b/.github/workflows/dependencies/nvhpc.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# Copyright 2021 Axel Huebl
+#
+# License: BSD-3-Clause-LBNL
+
+set -eu -o pipefail
+
+sudo apt-get -qqq update
+sudo apt-get install -y \
+    build-essential     \
+    ca-certificates     \
+    cmake               \
+    environment-modules \
+    gnupg               \
+    pkg-config          \
+    wget
+
+wget -q https://developer.download.nvidia.com/hpc-sdk/21.9/nvhpc-21-9_21.9_amd64.deb \
+        https://developer.download.nvidia.com/hpc-sdk/21.9/nvhpc-2021_21.9_amd64.deb
+sudo apt-get update
+sudo apt-get install -y ./nvhpc-21-9_21.9_amd64.deb ./nvhpc-2021_21.9_amd64.deb
+rm -rf ./nvhpc-21-9_21.9_amd64.deb ./nvhpc-2021_21.9_amd64.deb
+
+# things should reside in /opt/nvidia/hpc_sdk now
+
+# activation via:
+#   source /etc/profile.d/modules.sh
+#   module load /opt/nvidia/hpc_sdk/modulefiles/nvhpc/21.9


### PR DESCRIPTION
Add NVHPC (21.9) CUDA builds to CI.
Uses the `nvcc -ccbin nvc++` compiler combination, as currently set by Cray systems with the `PrgEnv-nvidia` environment (e.g., Perlmutter at NERSC).