### PR TITLE
Docs: serialize_ics

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -788,7 +788,8 @@ Particle initialization
     this species.
 
 * ``warpx.serialize_ics`` (`0 or 1`)
-    Whether or not to use OpenMP threading for particle initialization.
+    Serialize the initial conditions for reproducible testing.
+    Mainly whether or not to use OpenMP threading for particle initialization.
 
 * ``<species>.do_field_ionization`` (`0` or `1`) optional (default `0`)
     Do field ionization for this species (using the ADK theory).

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -195,7 +195,7 @@ public:
     static bool use_filter;
     static bool use_kspace_filter;
     static bool use_filter_compensation;
-    static bool serialize_ics;
+    static bool serialize_ics; //! Serialize the initial conditions
 
     // Back transformation diagnostic
     static bool do_back_transformed_diagnostics;


### PR DESCRIPTION
- slightly more user-facing info / context
- add doxygen string to member variable

Thanks @RemiLehe for the explanation of the `ics` abbreviation :+1: 