### PR TITLE
Windows: FS Separator

### DIFF
--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -20,6 +20,7 @@
 #include <AMReX_BLassert.H>
 #include <AMReX_Config.H>
 #include <AMReX_Geometry.H>
+#include <AMReX_FileSystem.H>
 #include <AMReX_MultiFab.H>
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_ParmParse.H>
@@ -46,7 +47,7 @@ Diagnostics::BaseReadParameters ()
     auto & warpx = WarpX::GetInstance();
 
     amrex::ParmParse pp_diag_name(m_diag_name);
-    m_file_prefix = "diags/" + m_diag_name;
+    m_file_prefix = "diags" + amrex::FileSystem::DirectorySeparator() + m_diag_name;
     pp_diag_name.query("file_prefix", m_file_prefix);
     queryWithParser(pp_diag_name, "file_min_digits", m_file_min_digits);
     pp_diag_name.query("format", m_format);

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -20,7 +20,6 @@
 #include <AMReX_BLassert.H>
 #include <AMReX_Config.H>
 #include <AMReX_Geometry.H>
-#include <AMReX_FileSystem.H>
 #include <AMReX_MultiFab.H>
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_ParmParse.H>
@@ -47,7 +46,7 @@ Diagnostics::BaseReadParameters ()
     auto & warpx = WarpX::GetInstance();
 
     amrex::ParmParse pp_diag_name(m_diag_name);
-    m_file_prefix = "diags" + amrex::FileSystem::DirectorySeparator() + m_diag_name;
+    m_file_prefix = "diags/" + m_diag_name;
     pp_diag_name.query("file_prefix", m_file_prefix);
     queryWithParser(pp_diag_name, "file_min_digits", m_file_min_digits);
     pp_diag_name.query("format", m_format);

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -22,6 +22,7 @@
 #include <AMReX_Config.H>
 #include <AMReX_FArrayBox.H>
 #include <AMReX_FabArray.H>
+#include <AMReX_FileSystem.H>
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_IntVect.H>
 #include <AMReX_MFIter.H>
@@ -289,7 +290,7 @@ namespace detail
         }
     }
 #endif // WARPX_USE_OPENPMD
-}
+} // namespace detail
 
 #ifdef WARPX_USE_OPENPMD
 WarpXOpenPMDPlot::WarpXOpenPMDPlot (
@@ -330,7 +331,7 @@ WarpXOpenPMDPlot::~WarpXOpenPMDPlot ()
 std::string
 WarpXOpenPMDPlot::GetFileName (std::string& filepath)
 {
-  filepath.append("/");
+  filepath.append(amrex::FileSystem::DirectorySeparator());
   std::string filename = "openpmd";
   //
   // OpenPMD supports timestepped names
@@ -385,7 +386,7 @@ void WarpXOpenPMDPlot::CloseStep (bool isBTD, bool isLastBTDFlush)
             std::string filepath = m_dirPrefix;
             std::string const filename = GetFileName(filepath);
 
-            std::ofstream pv_helper_file(m_dirPrefix + "/paraview.pmd");
+            std::ofstream pv_helper_file(m_dirPrefix + amrex::FileSystem::DirectorySeparator() + "paraview.pmd");
             pv_helper_file << filename << std::endl;
             pv_helper_file.close();
         }


### PR DESCRIPTION
Fix the openPMD warning:
```
Filepaths on WINDOWS platforms may not contain slashes '/'!
Replacing with backslashes '\' unconditionally!
```

Related to #1776 
~~Depends on https://github.com/AMReX-Codes/amrex/pull/2405~~