### PR TITLE
Add Test: openPMD PICMI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,7 +28,7 @@ jobs:
         $env:PYWARPX_LIB_DIR="$(Get-Location | Foreach-Object { $_.Path })\build\lib\Debug\"
         python3 -m pip install . -vv --no-build-isolation
 
-        python3 Examples\Modules\gaussian_beam\PICMI_inputs_gaussian_beam.py
+        python3 Examples\Modules\gaussian_beam\PICMI_inputs_gaussian_beam.py --diagformat=openpmd
 
   build_win_clang:
     name: Clang C++17 w/ OMP w/o MPI
@@ -58,4 +58,4 @@ jobs:
         set "PYWARPX_LIB_DIR=%cd%\build\lib\"
         python3 -m pip install . -vv --no-build-isolation
 
-        python3 Examples\Modules\gaussian_beam\PICMI_inputs_gaussian_beam.py
+        python3 Examples\Modules\gaussian_beam\PICMI_inputs_gaussian_beam.py --diagformat=openpmd

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,7 +28,10 @@ jobs:
         $env:PYWARPX_LIB_DIR="$(Get-Location | Foreach-Object { $_.Path })\build\lib\Debug\"
         python3 -m pip install . -vv --no-build-isolation
 
-        python3 Examples\Modules\gaussian_beam\PICMI_inputs_gaussian_beam.py --diagformat=openpmd
+        python3 Examples\Modules\gaussian_beam\PICMI_inputs_gaussian_beam.py
+
+# TODO (needs debugging)
+# --diagformat=openpmd
 
   build_win_clang:
     name: Clang C++17 w/ OMP w/o MPI
@@ -58,4 +61,7 @@ jobs:
         set "PYWARPX_LIB_DIR=%cd%\build\lib\"
         python3 -m pip install . -vv --no-build-isolation
 
-        python3 Examples\Modules\gaussian_beam\PICMI_inputs_gaussian_beam.py --diagformat=openpmd
+        python3 Examples\Modules\gaussian_beam\PICMI_inputs_gaussian_beam.py
+
+# TODO (needs debugging)
+# --diagformat=openpmd

--- a/Examples/Modules/gaussian_beam/PICMI_inputs_gaussian_beam.py
+++ b/Examples/Modules/gaussian_beam/PICMI_inputs_gaussian_beam.py
@@ -1,5 +1,14 @@
 from pywarpx import picmi
 #from warp import picmi
+import argparse
+
+
+parser = argparse.ArgumentParser(description="Gaussian beam PICMI example")
+
+parser.add_argument('--diagformat', type=str,
+                    help='Format of the full diagnostics (plotfile, openpmd, ascent, sensei, ...)',
+                    default='plotfile')
+args = parser.parse_args()
 
 constants = picmi.constants
 
@@ -49,13 +58,15 @@ field_diag1 = picmi.FieldDiagnostic(name = 'diag1',
                                     grid = grid,
                                     period = 10,
                                     data_list = ['E', 'B', 'J', 'part_per_cell'],
+                                    format = args.diagformat,
                                     write_dir = '.',
                                     warpx_file_prefix = 'Python_gaussian_beam_plt')
 
 part_diag1 = picmi.ParticleDiagnostic(name = 'diag1',
                                       period = 10,
                                       species = [electrons, protons],
-                                      data_list = ['weighting', 'momentum'])
+                                      data_list = ['weighting', 'momentum'],
+                                      format = args.diagformat)
 
 sim = picmi.Simulation(solver = solver,
                        max_steps = 10,

--- a/Examples/Modules/gaussian_beam/PICMI_inputs_gaussian_beam.py
+++ b/Examples/Modules/gaussian_beam/PICMI_inputs_gaussian_beam.py
@@ -58,7 +58,7 @@ field_diag1 = picmi.FieldDiagnostic(name = 'diag1',
                                     grid = grid,
                                     period = 10,
                                     data_list = ['E', 'B', 'J', 'part_per_cell'],
-                                    format = args.diagformat,
+                                    warpx_format = args.diagformat,
                                     write_dir = '.',
                                     warpx_file_prefix = 'Python_gaussian_beam_plt')
 
@@ -66,7 +66,7 @@ part_diag1 = picmi.ParticleDiagnostic(name = 'diag1',
                                       period = 10,
                                       species = [electrons, protons],
                                       data_list = ['weighting', 'momentum'],
-                                      format = args.diagformat)
+                                      warpx_format = args.diagformat)
 
 sim = picmi.Simulation(solver = solver,
                        max_steps = 10,

--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1401,6 +1401,25 @@ particleTypes = electrons
 analysisRoutine = Examples/analysis_default_regression.py
 tolerance = 1.e-14
 
+[Python_gaussian_beam_opmd]
+buildDir = .
+inputFile = Examples/Modules/gaussian_beam/PICMI_inputs_gaussian_beam.py
+customRunCmd = python PICMI_inputs_gaussian_beam.py --diagformat=openpmd
+runtime_params =
+dim = 3
+addToCompileString = USE_OPENPMD=TRUE USE_PYTHON_MAIN=TRUE PYINSTALLOPTIONS="--user --prefix="
+restartTest = 0
+useMPI = 1
+numprocs = 2
+useOMP = 1
+numthreads = 1
+compileTest = 0
+doVis = 0
+compareParticles = 1
+particleTypes = electrons
+analysisRoutine =
+tolerance = 1.e-14
+
 [PlasmaAccelerationBoost2d]
 buildDir = .
 inputFile = Examples/Physics_applications/plasma_acceleration/inputs_2d_boost


### PR DESCRIPTION
- Gaussian Beam PICMI: Add openPMD Argument
  Add an `--diagformat` option to switch between plotfiles and openPMD for the Gaussian Beam PICMI example.

-  Regression Test: Add openPMD PICMI
- CI: openPMD + PICMI on Windows -> #2440