### PR TITLE
Diagnostics Interval: Non-Optional Input

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1761,10 +1761,9 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     Name of each diagnostics.
     example: ``diagnostics.diags_names = diag1 my_second_diag``.
 
-* ``<diag_name>.intervals`` (`string` optional, default `0`)
+* ``<diag_name>.intervals`` (`string`)
     Using the `Intervals parser`_ syntax, this string defines the timesteps at which data is dumped.
     Use a negative number or 0 to disable data dumping.
-    This is ``0`` (disabled) by default.
     example: ``diag1.intervals = 10,20:25:1``.
     Note that by default the last timestep is dumped regardless of this parameter. This can be
     changed using the parameter ``<diag_name>.dump_last_timestep`` described below.
@@ -2325,7 +2324,7 @@ Reduced Diagnostics
         so the time of the diagnostic may be long
         depending on the simulation size.
 
-* ``<reduced_diags_name>.intervals`` (`string`) optional (default ``1``)
+* ``<reduced_diags_name>.intervals`` (`string`)
     Using the `Intervals Parser`_ syntax, this string defines the timesteps at which reduced
     diagnostics are written to file.
 

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -80,7 +80,7 @@ FullDiagnostics::ReadParameters ()
         m_format == "sensei",
         "<diag>.format must be plotfile or openpmd or checkpoint or ascent or sensei");
     std::vector<std::string> intervals_string_vec = {"0"};
-    pp_diag_name.queryarr("intervals", intervals_string_vec);
+    pp_diag_name.getarr("intervals", intervals_string_vec);
     m_intervals = IntervalsParser(intervals_string_vec);
     bool raw_specified = pp_diag_name.query("plot_raw_fields", m_plot_raw_fields);
     raw_specified += pp_diag_name.query("plot_raw_fields_guards", m_plot_raw_fields_guards);

--- a/Source/Diagnostics/ReducedDiags/ReducedDiags.cpp
+++ b/Source/Diagnostics/ReducedDiags/ReducedDiags.cpp
@@ -56,7 +56,7 @@ ReducedDiags::ReducedDiags (std::string rd_name)
 
     // read reduced diags intervals
     std::vector<std::string> intervals_string_vec = {"1"};
-    pp_rd_name.queryarr("intervals", intervals_string_vec);
+    pp_rd_name.getarr("intervals", intervals_string_vec);
     m_intervals = IntervalsParser(intervals_string_vec);
 
     // read separator


### PR DESCRIPTION
The defaults were `0` (diags) and `1` (reduced diags). These defaults can lead to user-mistakes (forgetting the parameter) and neither `0` nor every step `1` are sensible defaults. Thus, require the user to set this parameter in all cases?

@dpgrote do we need to change something in PICMI, too?

Related to #2449 

- [x] ready for merge after developer meeting discussion on Nov 2nd