### PR TITLE
libfabric 1.6+: Document SST Work-Arounds

### DIFF
--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -292,6 +292,18 @@ Known System Issues
 
 .. warning::
 
+   Related to the above issue, libfabric 1.6+ introduced a couple of breaking changes that break ADIOS2 SST (staging/streaming) workflows.
+   Details are discussed in `ADIOS2 issue #2887 <https://github.com/ornladios/ADIOS2/issues/2887>`__.
+
+   The following environment variables can be set as work-arounds, when working with ADIOS2 SST:
+
+   .. code-block:: bash
+
+      export FABRIC_IFACE=mlx5_0   # ADIOS SST: select interface (1 NIC on Summit)
+      export FI_OFI_RXM_USE_SRX=1  # libfabric: use shared receive context from MSG provider
+
+.. warning::
+
    Oct 12th, 2021 (OLCFHELP-4242):
    There is currently a problem with the pre-installed Jupyter extensions, which can lead to connection splits at long running analysis sessions.
 

--- a/Tools/BatchScripts/batch_summit.sh
+++ b/Tools/BatchScripts/batch_summit.sh
@@ -25,5 +25,14 @@ umask 0027
 # disable all the IBM optimized barriers and drop back to HCOLL or OMPI's barrier implementations
 export OMPI_MCA_coll_ibm_skip_barrier=true
 
+# libfabric 1.6+: limit the visible devices
+# Needed for ADIOS2 SST staging/streaming workflows since RHEL8 update
+#   https://github.com/ornladios/ADIOS2/issues/2887
+#export FABRIC_IFACE=mlx5_0   # ADIOS SST: select interface (1 NIC on Summit)
+#export FI_OFI_RXM_USE_SRX=1  # libfabric: use shared receive context from MSG provider
+
+# OpenMP: one thread per MPI rank and GPU
 export OMP_NUM_THREADS=1
+
+# run WarpX
 jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs --smpiargs="-gpu" <path/to/executable> <input file> > output.txt

--- a/Tools/BatchScripts/batch_summit_power9.sh
+++ b/Tools/BatchScripts/batch_summit_power9.sh
@@ -24,5 +24,14 @@ umask 0027
 # disable all the IBM optimized barriers and drop back to HCOLL or OMPI's barrier implementations
 export OMPI_MCA_coll_ibm_skip_barrier=true
 
+# libfabric 1.6+: limit the visible devices
+# Needed for ADIOS2 SST staging/streaming workflows since RHEL8 update
+#   https://github.com/ornladios/ADIOS2/issues/2887
+#export FABRIC_IFACE=mlx5_0   # ADIOS SST: select interface (1 NIC on Summit)
+#export FI_OFI_RXM_USE_SRX=1  # libfabric: use shared receive context from MSG provider
+
+# OpenMP: 21 threads per MPI rank
 export OMP_NUM_THREADS=21
+
+# run WarpX
 jsrun -n 2 -a 1 -c 21 -r 2 -l CPU-CPU -d packed -b rs <path/to/executable> <input file> > output.txt


### PR DESCRIPTION
Document work-arounds for libfabric 1.6+ on Cray systems when using data staging / streaming with ADIOS2 SST.

X-ref: https://github.com/ornladios/ADIOS2/issues/2887

- [x] Summit

## Follow-up

- [ ] Spock
- [ ] Perlmutter
- [ ] Cori