### PR TITLE
std::ifstream: Defensive Patterns

### DIFF
--- a/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
+++ b/Source/Diagnostics/BTD_Plotfile_Header_Impl.cpp
@@ -27,8 +27,11 @@ BTDPlotfileHeaderImpl::ReadHeaderData ()
     amrex::Vector<char> HeaderCharPtr;
     amrex::Long fileLength(0), fileLengthPadded(0);
     std::ifstream iss;
+    iss.exceptions(std::ios_base::failbit | std::ios_base::badbit);
 
     iss.open(m_Header_path.c_str(), std::ios::in);
+    if(!iss) amrex::Abort("Failed to load BTD MultiFabHeader");
+
     iss.seekg(0, std::ios::end);
     fileLength = static_cast<std::streamoff>(iss.tellg());
     iss.seekg(0, std::ios::beg);
@@ -178,8 +181,11 @@ BTDMultiFabHeaderImpl::ReadMultiFabHeader ()
     amrex::Vector<char> HeaderCharPtr;
     amrex::Long fileLength(0), fileLengthPadded(0);
     std::ifstream iss;
+    iss.exceptions(std::ios_base::failbit | std::ios_base::badbit);
 
     iss.open(m_Header_path.c_str(), std::ios::in);
+    if(!iss) amrex::Abort("Failed to load BTD MultiFabHeader");
+
     iss.seekg(0, std::ios::end);
     fileLength = static_cast<std::streamoff>(iss.tellg());
     iss.seekg(0, std::ios::beg);

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
@@ -296,6 +296,8 @@ void LoadBalanceCosts::WriteToFile (int step) const
         // open the data-containing file
         std::string fileDataName = m_path + m_rd_name + "." + m_extension;
         std::ifstream ifs(fileDataName, std::ifstream::in);
+        if(!ifs) Abort("Failed to load balance file");
+        ifs.exceptions(std::ios_base::failbit | std::ios_base::badbit);
 
         // Fill in the tmp costs file with data, padded with NaNs
         for (std::string lineIn; std::getline(ifs, lineIn);)

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
@@ -297,7 +297,7 @@ void LoadBalanceCosts::WriteToFile (int step) const
         std::string fileDataName = m_path + m_rd_name + "." + m_extension;
         std::ifstream ifs(fileDataName, std::ifstream::in);
         if(!ifs) Abort("Failed to load balance file");
-        ifs.exceptions(std::ios_base::failbit | std::ios_base::badbit);
+        ifs.exceptions(std::ios_base::badbit); // | std::ios_base::failbit
 
         // Fill in the tmp costs file with data, padded with NaNs
         for (std::string lineIn; std::getline(ifs, lineIn);)

--- a/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileFromTXYEFile.cpp
@@ -144,6 +144,7 @@ WarpXLaserProfiles::FromTXYEFileLaserProfile::parse_txye_file(std::string txye_f
     if(ParallelDescriptor::IOProcessor()){
         std::ifstream inp(txye_file_name, std::ios::binary);
         if(!inp) Abort("Failed to open txye file");
+        inp.exceptions(std::ios_base::failbit | std::ios_base::badbit);
 
         //Uniform grid flag
         char flag;
@@ -291,6 +292,8 @@ WarpXLaserProfiles::FromTXYEFileLaserProfile::read_data_t_chuck(int t_begin, int
         //Read data chunk
         std::ifstream inp(m_params.txye_file_name, std::ios::binary);
         if(!inp) Abort("Failed to open txye file");
+        inp.exceptions(std::ios_base::failbit | std::ios_base::badbit);
+
         auto skip_amount = 1 +
             3*sizeof(uint32_t) +
             m_params.t_coords.size()*sizeof(double) +

--- a/Source/Particles/Collision/MCCProcess.cpp
+++ b/Source/Particles/Collision/MCCProcess.cpp
@@ -97,17 +97,15 @@ MCCProcess::readCrossSectionFile (
                                   amrex::Gpu::HostVector<amrex::Real>& sigmas )
 {
     std::ifstream infile(cross_section_file);
-    if(!infile) amrex::Abort("Failed to open readCrossSectionFile file");
-    infile.exceptions(std::ios_base::failbit | std::ios_base::badbit);
+    if(!infile.is_open()) amrex::Abort("Failed to open cross-section data file");
 
     double energy, sigma;
     while (infile >> energy >> sigma) {
         energies.push_back(energy);
         sigmas.push_back(sigma);
     }
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(energies.size() > 1,
-        "Failed to read cross-section data from file."
-    );
+    if (infile.bad()) amrex::Abort("Failed to read cross-section data from file.");
+    infile.close();
 }
 
 void

--- a/Source/Particles/Collision/MCCProcess.cpp
+++ b/Source/Particles/Collision/MCCProcess.cpp
@@ -97,6 +97,9 @@ MCCProcess::readCrossSectionFile (
                                   amrex::Gpu::HostVector<amrex::Real>& sigmas )
 {
     std::ifstream infile(cross_section_file);
+    if(!infile) amrex::Abort("Failed to open readCrossSectionFile file");
+    infile.exceptions(std::ios_base::failbit | std::ios_base::badbit);
+
     double energy, sigma;
     while (infile >> energy >> sigma) {
         energies.push_back(energy);


### PR DESCRIPTION
Add failure handling if inputs in `std::ifstream`s cannot be opened or have problems seek-ing through them.

This should catch I/O errors early.