### PR TITLE
QED openPMD Tests: Specify H5 Backend

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1385,7 +1385,7 @@ tolerance = 1.e-14
 buildDir = .
 inputFile = Examples/Modules/qed/breit_wheeler/inputs_2d
 aux1File = Examples/Modules/qed/breit_wheeler/analysis_core.py
-runtime_params = diag1.format = openpmd
+runtime_params = diag1.format = openpmd diag1.openpmd_backend = h5
 dim = 2
 addToCompileString = QED=TRUE USE_OPENPMD=TRUE
 restartTest = 0
@@ -1403,7 +1403,7 @@ tolerance = 1.e-14
 buildDir = .
 inputFile = Examples/Modules/qed/breit_wheeler/inputs_3d
 aux1File = Examples/Modules/qed/breit_wheeler/analysis_core.py
-runtime_params = diag1.format = openpmd
+runtime_params = diag1.format = openpmd diag1.openpmd_backend = h5
 dim = 3
 addToCompileString = QED=TRUE USE_OPENPMD=TRUE
 restartTest = 0


### PR DESCRIPTION
We default to ADIOS `.bp` if available. Thus, specify HDF5 assumption when we run CI with openPMD and check for `.h5` output.