### PR TITLE
Doxygen: Fix Diags, FieldSolver, Parallelization & Particles

### DIFF
--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.H
@@ -64,6 +64,7 @@ public:
      * \param[in] z_slice_in_domain if the z-slice at current_z_boost is within
      *            the boosted-frame and lab-frame domain.
      *            The fields are sliced and back-transformed only if this value is true.
+     * \param[in] current_z_boost   current z coordinate in the boosted-frame
      * \param[in] buffer_box        Box with index-space in lab-frame for the ith buffer
      * \param[in] k_index_zlab      k-index in the lab-frame corresponding to the
      *            current z co-ordinate in the lab-frame for the ith buffer.

--- a/Source/Diagnostics/ComputeDiagFunctors/CellCenterFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/CellCenterFunctor.H
@@ -13,11 +13,12 @@ CellCenterFunctor final : public ComputeDiagFunctor
 {
 public:
     /** Constructor.
+     *
      * \param[in] mf_src source multifab.
      * \param[in] lev level of multifab. Used for averaging in rz.
      * \param[in] crse_ratio for interpolating field values from the simulation MultiFab, src_mf,
                   to the output diagnostic MultiFab, mf_dst.
-     * \param[in] convert_RZmodes2cartesian (in cylindrical) whether to
+     * \param[in] convertRZmodes2cartesian (in cylindrical) whether to
      *            sum all modes in mf_src before cell-centering into dst multifab.
      * \param[in] ncomp Number of component of mf_src to cell-center in dst multifab.
      */

--- a/Source/Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor.H
@@ -19,11 +19,11 @@ public:
     //** Virtual Destructor to handle clean destruction of derived classes */
     virtual ~ComputeDiagFunctor() = default;
     /** Compute a field and store the result in mf_dst
+     *
      * \param[out] mf_dst output MultiFab where the result is written
      * \param[in] dcomp first component of mf_dst in which the result is written
-     * \param[in] ncomp number of components of mf_dst to update
-     * \param[in] crse_ratio for interpolating field values from simulation MultiFab, mf_src,
-                  to the output diagnostic MultiFab, mf_dst.
+     *            to the output diagnostic MultiFab, mf_dst.
+     * \param[in] i_buffer index of a back-transformed snapshot
      */
     virtual void operator() (amrex::MultiFab& mf_dst, int dcomp, const int i_buffer = 0) const = 0;
     /** Number of component from the input multifab to write to the output
@@ -38,6 +38,7 @@ public:
      * \param[in] z_slice_in_domain if the z-slice at current_z_boost is within
      *            the boosted-frame and lab-frame domain.
      *            The fields are sliced and back-transformed only if this value is true.
+     * \param[in] current_z_boost current z coordinate in the boosted-frame
      * \param[in] buffer_box     Box with index-space in lab-frame for the ith buffer
      * \param[in] k_index_zlab   k-index in the lab-frame corresponding to the
      *                           current z co-ordinate in the lab-frame for the ith buffer.

--- a/Source/Diagnostics/ComputeDiagFunctors/DivEFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/DivEFunctor.H
@@ -17,8 +17,9 @@ public:
     /** Constructor.
      * \param[in] arr_mf_src source multifabs (3 elements for x y z).
      * \param[in] lev level of multifab.
-     * \param[in] crse_ratio for interpolating field values from simulation MultiFabs
-                  to the output diagnostic MultiFab mf_dst
+     * \param[in] crse_ratio coarsening ratio for interpolation of field values
+     *                       from simulation MultiFabs to the output MultiFab mf_dst
+     * \param[in] convertRZmodes2cartesian if true, all RZ modes are averaged into one component
      * \param[in] ncomp Number of component of mf_src to cell-center in dst multifab.
      */
     DivEFunctor(const std::array<const amrex::MultiFab* const, 3> arr_mf_src, const int lev, const amrex::IntVect crse_ratio,

--- a/Source/Diagnostics/Diagnostics.H
+++ b/Source/Diagnostics/Diagnostics.H
@@ -66,6 +66,7 @@ public:
     virtual bool DoComputeAndPack(int step, bool force_flush=false) = 0;
     /** whether to flush at this time step
      * \param[in] step current time step
+     * \param[in] i_buffer index of the buffer data to be flushed.
      * \param[in] force_flush if true, return true for any step
      * \return bool, whether to flush
      */
@@ -107,7 +108,7 @@ protected:
      *
      * \param[in] step current time step
      */
-    virtual void MovingWindowAndGalileanDomainShift (int /*step*/) {}
+    virtual void MovingWindowAndGalileanDomainShift (int step) { amrex::ignore_unused(step); }
     /** Name of diagnostics: runtime parameter given in the input file. */
     std::string m_diag_name;
     /** Prefix for output directories */

--- a/Source/Diagnostics/FlushFormats/FlushFormatSensei.H
+++ b/Source/Diagnostics/FlushFormats/FlushFormatSensei.H
@@ -38,9 +38,10 @@ public:
     FlushFormatSensei(const FlushFormatSensei &) = delete;
     void operator=(const FlushFormatSensei &) = delete;
 
-    /** \breif Construct.
-     * \parm[in] amr_mesh an AmrMesh instance
-     * \parm[in] diag_name ParmParse scope string.
+    /** Construct.
+     *
+     * \param[in] amr_mesh an AmrMesh instance
+     * \param[in] diag_name ParmParse scope string.
      */
     FlushFormatSensei (amrex::AmrMesh *amr_mesh, std::string diag_name);
 

--- a/Source/Diagnostics/FullDiagnostics.H
+++ b/Source/Diagnostics/FullDiagnostics.H
@@ -33,6 +33,7 @@ private:
     bool DoComputeAndPack (int step, bool force_flush=false) override;
     /** whether to flush at this time step
      * \param[in] step current time step
+     * \param[in] i_buffer index of a back-transformed snapshot
      * \param[in] force_flush if true, return true for any step
      * \return bool, whether to flush
      */
@@ -53,6 +54,7 @@ private:
       * lo and hi and coarsening ratio. This MultiFab may have a different BoxArray and
       * DistributionMap than field MultiFabs in the simulation.
       *
+      * \param[in] i_buffer index of a back-transformed snapshot
       * \param[in] lev level on which source multifabs are defined
       */
     void InitializeFieldBufferData ( int i_buffer, int lev ) override;

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/ComovingPsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/ComovingPsatdAlgorithm.H
@@ -55,6 +55,7 @@ class ComovingPsatdAlgorithm : public SpectralBaseAlgorithm
          * base class \c SpectralBaseAlgorithm and cannot be overridden by further
          * derived classes.
          *
+         * \param[in]     lev        The mesh-refinement level
          * \param[in,out] field_data All fields in Fourier space
          * \param[in,out] current    Array of unique pointers to \c MultiFab storing
          *                           the three components of the current density
@@ -71,6 +72,7 @@ class ComovingPsatdAlgorithm : public SpectralBaseAlgorithm
          * base class \c SpectralBaseAlgorithm and cannot be overridden by further
          * derived classes.
          *
+         * \param[in]     lev        The mesh-refinement level
          * \param[in,out] field_data All fields in Fourier space
          * \param[in,out] current    Array of unique pointers to \c MultiFab storing
          *                           the three components of the current density

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/GalileanPsatdAlgorithmRZ.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/GalileanPsatdAlgorithmRZ.H
@@ -35,6 +35,7 @@ class GalileanPsatdAlgorithmRZ : public SpectralBaseAlgorithmRZ
          * base class \c SpectralBaseAlgorithmRZ (qualifier \c override) and cannot be
          * overridden by further derived classes (qualifier \c final).
          *
+         * \param[in]     lev        mesh-refinement level
          * \param[in,out] field_data all fields in Fourier space
          * \param[in,out] current    two-dimensional array of unique pointers to MultiFab
          *                           storing the three components of the current density
@@ -51,6 +52,7 @@ class GalileanPsatdAlgorithmRZ : public SpectralBaseAlgorithmRZ
          * base class \c SpectralBaseAlgorithmRZ and cannot be overridden by further
          * derived classes.
          *
+         * \param[in]     lev        mesh-refinement level
          * \param[in,out] field_data All fields in Fourier space
          * \param[in,out] current    Array of unique pointers to \c MultiFab storing
          *                           the three components of the current density

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PMLPsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PMLPsatdAlgorithm.H
@@ -52,6 +52,7 @@ class PMLPsatdAlgorithm : public SpectralBaseAlgorithm
          * base class \c SpectralBaseAlgorithm and cannot be overridden by further
          * derived classes.
          *
+         * \param[in]     lev        The mesh-refinement level
          * \param[in,out] field_data All fields in Fourier space
          * \param[in,out] current    Array of unique pointers to \c MultiFab storing
          *                           the three components of the current density
@@ -69,6 +70,7 @@ class PMLPsatdAlgorithm : public SpectralBaseAlgorithm
          * base class \c SpectralBaseAlgorithm and cannot be overridden by further
          * derived classes.
          *
+         * \param[in]     lev        The mesh-refinement level
          * \param[in,out] field_data All fields in Fourier space
          * \param[in,out] current    Array of unique pointers to \c MultiFab storing
          *                           the three components of the current density

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
@@ -38,7 +38,7 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
          * \param[in] norder_y order of the spectral solver along y
          * \param[in] norder_z order of the spectral solver along z
          * \param[in] nodal whether the E and B fields are defined on a fully nodal grid or a Yee grid
-         * \param[in] fill_guards Update the guard cells (in addition to the valid cell) when pushing the fields in time
+         * \param[in] fill_guards Update the guard cells (in addition to the valid cells) when pushing the fields in time
          * \param[in] v_galilean Galilean velocity (three-dimensional array)
          * \param[in] dt time step of the simulation
          * \param[in] update_with_rho whether the update equation for E uses rho or not

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
@@ -38,15 +38,15 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
          * \param[in] norder_y order of the spectral solver along y
          * \param[in] norder_z order of the spectral solver along z
          * \param[in] nodal whether the E and B fields are defined on a fully nodal grid or a Yee grid
-         * \param[in] fill_guards ...?
+         * \param[in] fill_guards Update the guard cells (in addition to the valid cell) when pushing the fields in time
          * \param[in] v_galilean Galilean velocity (three-dimensional array)
          * \param[in] dt time step of the simulation
          * \param[in] update_with_rho whether the update equation for E uses rho or not
          * \param[in] time_averaging whether to use time averaging for large time steps
          * \param[in] J_linear_in_time whether to use two currents computed at the beginning and the end
          *            of the time interval (instead of using one current computed at half time)
-         * \param[in] dive_cleaning ...?
-         * \param[in] divb_cleaning ...?
+         * \param[in] dive_cleaning Update F as part of the field update, so that errors in divE=rho propagate away at the speed of light
+         * \param[in] divb_cleaning Update G as part of the field update, so that errors in divB=0 propagate away at the speed of light
          */
         PsatdAlgorithm (
             const SpectralKSpace& spectral_kspace,

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithm.H
@@ -38,12 +38,15 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
          * \param[in] norder_y order of the spectral solver along y
          * \param[in] norder_z order of the spectral solver along z
          * \param[in] nodal whether the E and B fields are defined on a fully nodal grid or a Yee grid
+         * \param[in] fill_guards ...?
          * \param[in] v_galilean Galilean velocity (three-dimensional array)
          * \param[in] dt time step of the simulation
          * \param[in] update_with_rho whether the update equation for E uses rho or not
          * \param[in] time_averaging whether to use time averaging for large time steps
          * \param[in] J_linear_in_time whether to use two currents computed at the beginning and the end
          *            of the time interval (instead of using one current computed at half time)
+         * \param[in] dive_cleaning ...?
+         * \param[in] divb_cleaning ...?
          */
         PsatdAlgorithm (
             const SpectralKSpace& spectral_kspace,
@@ -114,6 +117,7 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
          * base class \c SpectralBaseAlgorithm and cannot be overridden by further
          * derived classes.
          *
+         * \param[in]     lev        The mesh-refinement level
          * \param[in,out] field_data All fields in Fourier space
          * \param[in,out] current    Array of unique pointers to \c MultiFab storing
          *                           the three components of the current density
@@ -132,6 +136,7 @@ class PsatdAlgorithm : public SpectralBaseAlgorithm
          * base class \c SpectralBaseAlgorithm and cannot be overridden by further
          * derived classes.
          *
+         * \param[in]     lev        The mesh-refinement level
          * \param[in,out] field_data All fields in Fourier space
          * \param[in,out] current    Array of unique pointers to \c MultiFab storing
          *                           the three components of the current density

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmRZ.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmRZ.H
@@ -38,6 +38,7 @@ class PsatdAlgorithmRZ : public SpectralBaseAlgorithmRZ
          * base class \c SpectralBaseAlgorithmRZ and cannot be overridden by further
          * derived classes.
          *
+         * \param[in]     lev        The mesh-refinement level
          * \param[in,out] field_data All fields in Fourier space
          * \param[in,out] current    Array of unique pointers to \c MultiFab storing
          *                           the three components of the current density
@@ -55,6 +56,7 @@ class PsatdAlgorithmRZ : public SpectralBaseAlgorithmRZ
          * base class \c SpectralBaseAlgorithmRZ and cannot be overridden by further
          * derived classes.
          *
+         * \param[in]     lev        The mesh-refinement level
          * \param[in,out] field_data All fields in Fourier space
          * \param[in,out] current    Array of unique pointers to \c MultiFab storing
          *                           the three components of the current density

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/SpectralBaseAlgorithm.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/SpectralBaseAlgorithm.H
@@ -48,6 +48,7 @@ class SpectralBaseAlgorithm
          * (<a href="https://doi.org/10.1016/j.jcp.2013.03.010"> Vay et al, 2013</a>).
          * This virtual function is pure and must be defined in derived classes.
          *
+         * \param[in]     lev        The mesh-refinement level
          * \param[in,out] field_data All fields in Fourier space
          * \param[in,out] current    Array of unique pointers to \c MultiFab storing
          *                           the three components of the current density
@@ -63,6 +64,7 @@ class SpectralBaseAlgorithm
          * (<a href="https://doi.org/10.1016/j.jcp.2013.03.010"> Vay et al, 2013</a>).
          * This virtual function is pure and must be defined in derived classes.
          *
+         * \param[in]     lev        The mesh-refinement level
          * \param[in,out] field_data All fields in Fourier space
          * \param[in,out] current    Array of unique pointers to \c MultiFab storing
          *                           the three components of the current density

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/SpectralBaseAlgorithmRZ.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/SpectralBaseAlgorithmRZ.H
@@ -33,6 +33,7 @@ class SpectralBaseAlgorithmRZ
          * (<a href="https://doi.org/10.1016/j.jcp.2013.03.010"> Vay et al, 2013</a>).
          * This virtual function is pure and must be defined in derived classes.
          *
+         * \param[in]     lev        The mesh-refinement level
          * \param[in,out] field_data All fields in Fourier space
          * \param[in,out] current    Array of unique pointers to \c MultiFab storing
          *                           the three components of the current density
@@ -55,6 +56,7 @@ class SpectralBaseAlgorithmRZ
          * (<a href="https://doi.org/10.1016/j.jcp.2013.03.010"> Vay et al, 2013</a>).
          * This virtual function is pure and must be defined in derived classes.
          *
+         * \param[in]     lev        The mesh-refinement level
          * \param[in,out] field_data All fields in Fourier space
          * \param[in,out] current    Array of unique pointers to \c MultiFab storing
          *                           the three components of the current density

--- a/Source/FieldSolver/SpectralSolver/SpectralSolver.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolver.H
@@ -47,7 +47,7 @@ class SpectralSolver
          * \param[in] norder_y spectral order along y
          * \param[in] norder_z spectral order along z
          * \param[in] nodal whether the spectral solver is applied to a nodal or staggered grid
-         * \param[in] fill_guards ...?
+         * \param[in] fill_guards Update the guard cells (in addition to the valid cell) when pushing the fields in time
          * \param[in] v_galilean three-dimensional vector containing the components of the Galilean
          *                       velocity for the standard or averaged Galilean PSATD solvers
          * \param[in] v_comoving three-dimensional vector containing the components of the comoving

--- a/Source/FieldSolver/SpectralSolver/SpectralSolver.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolver.H
@@ -47,7 +47,7 @@ class SpectralSolver
          * \param[in] norder_y spectral order along y
          * \param[in] norder_z spectral order along z
          * \param[in] nodal whether the spectral solver is applied to a nodal or staggered grid
-         * \param[in] fill_guards Update the guard cells (in addition to the valid cell) when pushing the fields in time
+         * \param[in] fill_guards Update the guard cells (in addition to the valid cells) when pushing the fields in time
          * \param[in] v_galilean three-dimensional vector containing the components of the Galilean
          *                       velocity for the standard or averaged Galilean PSATD solvers
          * \param[in] v_comoving three-dimensional vector containing the components of the comoving

--- a/Source/FieldSolver/SpectralSolver/SpectralSolver.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolver.H
@@ -47,6 +47,7 @@ class SpectralSolver
          * \param[in] norder_y spectral order along y
          * \param[in] norder_z spectral order along z
          * \param[in] nodal whether the spectral solver is applied to a nodal or staggered grid
+         * \param[in] fill_guards ...?
          * \param[in] v_galilean three-dimensional vector containing the components of the Galilean
          *                       velocity for the standard or averaged Galilean PSATD solvers
          * \param[in] v_comoving three-dimensional vector containing the components of the comoving
@@ -123,6 +124,7 @@ class SpectralSolver
          * by its derived classes (e.g. PsatdAlgorithm, GalileanAlgorithm), from
          * objects of class SpectralSolver through the private unique pointer \c algorithm
          *
+         * \param[in]     lev     The mesh refinement level
          * \param[in,out] current three-dimensional array of unique pointers to MultiFab
          *                        storing the three components of the current density
          * \param[in]     rho     unique pointer to MultiFab storing the charge density
@@ -139,6 +141,7 @@ class SpectralSolver
          * derived classes, from objects of class SpectralSolver through the private
          * unique pointer \c algorithm.
          *
+         * \param[in]     lev     The mesh refinement level
          * \param[in,out] current Array of unique pointers to \c MultiFab storing
          *                        the three components of the current density
          */

--- a/Source/FieldSolver/SpectralSolver/SpectralSolverRZ.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralSolverRZ.H
@@ -98,6 +98,7 @@ class SpectralSolverRZ
          * by its derived classes (e.g. PsatdAlgorithmRZ), from
          * objects of class SpectralSolverRZ through the private unique pointer \c algorithm
          *
+         * \param[in]     lev     The mesh refinement level
          * \param[in,out] current two-dimensional array of unique pointers to MultiFab
          *                        storing the three components of the current density
          * \param[in]     rho     unique pointer to MultiFab storing the charge density
@@ -111,6 +112,7 @@ class SpectralSolverRZ
          * derived classes, from objects of class SpectralSolverRZ through the private
          * unique pointer \c algorithm.
          *
+         * \param[in]     lev     The mesh refinement level
          * \param[in,out] current Array of unique pointers to \c MultiFab storing
          * the three components of the current density
          */

--- a/Source/Parallelization/GuardCellManager.H
+++ b/Source/Parallelization/GuardCellManager.H
@@ -24,11 +24,12 @@ public:
     /**
      * \brief Initialize number of guard cells depending on the options used.
      *
+     * \param dt time step
+     * \param dx cell spacing
      * \param do_subcycling bool, whether to use subcycling
      * \param do_fdtd_nci_corr bool, whether to use Godfrey NCI corrector
      * \param do_nodal bool, whether the field solver is nodal
      * \param do_moving_window bool, whether to use moving window
-     * \param aux_is_nodal bool, true if the aux grid is nodal
      * \param moving_window_dir direction of moving window
      * \param nox order of current deposition
      * \param nox_fft order of PSATD in x direction
@@ -37,6 +38,13 @@ public:
      * \param nci_corr_stencil stencil of NCI corrector
      * \param maxwell_solver_id if of Maxwell solver
      * \param max_level max level of the simulation
+     * \param v_galilean ...?
+     * \param v_comoving ...?
+     * \param safe_guard_cells ...?
+     * \param do_electrostatic ...?
+     * \param do_multi_J ...?
+     * \param fft_do_time_averaging ...?
+     * \param ref_ratios mesh refinement ratios between mesh-refinement levels
      */
     void Init(
         const amrex::Real dt,

--- a/Source/Parallelization/GuardCellManager.H
+++ b/Source/Parallelization/GuardCellManager.H
@@ -38,12 +38,12 @@ public:
      * \param nci_corr_stencil stencil of NCI corrector
      * \param maxwell_solver_id if of Maxwell solver
      * \param max_level max level of the simulation
-     * \param v_galilean ...?
-     * \param v_comoving ...?
-     * \param safe_guard_cells ...?
-     * \param do_electrostatic ...?
-     * \param do_multi_J ...?
-     * \param fft_do_time_averaging ...?
+     * \param v_galilean Velocity used in the Galilean PSATD scheme
+     * \param v_comoving Velocity used in the comoving PSATD scheme
+     * \param safe_guard_cells Run in safe mode, exchanging more guard cells, and more often in the PIC loop (for debugging).
+     * \param do_electrostatic Whether to run in electrostatic mode i.e. solving the Poisson equation instead of the Maxwell equations.
+     * \param do_multi_J Whether to use the multi-J PSATD scheme
+     * \param fft_do_time_averaging Whether to average the E and B field in time (with PSATD) before interpolating them onto the macro-particles
      * \param ref_ratios mesh refinement ratios between mesh-refinement levels
      */
     void Init(

--- a/Source/Parallelization/KernelTimer.H
+++ b/Source/Parallelization/KernelTimer.H
@@ -9,6 +9,9 @@
 
 #include "WarpX.H"
 
+#include <AMReX.H>
+#include <AMReX_REAL.H>
+
 // #ifdef WARPX_USE_GPUCLOCK
 
 #include <climits>
@@ -30,7 +33,7 @@ public:
     (const bool do_timing, amrex::Real* cost)
         : m_do_timing(do_timing)
 #else
-    (const bool, amrex::Real*)
+    (const bool do_timing, amrex::Real* cost)
 #endif
     {
 #if (defined AMREX_USE_GPU)
@@ -51,6 +54,8 @@ public:
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE( m_do_timing == false,
                                           "`algo.load_balance_costs_update = gpuclock` requires to compile with `-DWarpX_GPUCLOCK=ON`.");
 #   endif // WARPX_USE_GPUCLOCK
+#else  // AMREX_USE_GPU
+        amrex::ignore_unused(do_timing, cost);
 #endif // AMREX_USE_GPU
     }
 

--- a/Source/Particles/Collision/BackgroundMCCCollision.H
+++ b/Source/Particles/Collision/BackgroundMCCCollision.H
@@ -46,6 +46,7 @@ public:
     /** Perform MCC ionization interactions
      *
      * @param[in] lev the mesh-refinement level
+     * @param[in,out] cost pointer to (load balancing) cost corresponding to box where present particles are ionized.
      * @param[in,out] species1,species2 reference to species container used to inject
      * new particles
      *

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusionFunc.H
@@ -110,16 +110,16 @@ public:
      *
      * @param[in] I1s,I2s is the start index for I1,I2 (inclusive).
      * @param[in] I1e,I2e is the stop index for I1,I2 (exclusive).
-     * @param[in] I1 and I2 are the index arrays. They determine all elements that will be used.
-     * @param[in] soa_1 and soa_2 contain the struct of array data of the two species
-     * @param[in] m1 and m2 are masses.
+     * @param[in] I1,I2 index arrays. They determine all elements that will be used.
+     * @param[in] soa_1,soa_2 contain the struct of array data of the two species
+     * @param[in] m1,m2 are masses.
      * @param[in] dt is the time step length between two collision calls.
      * @param[in] dV is the volume of the corresponding cell.
      * @param[in] cell_start_pair is the start index of the pairs in that cell.
      * @param[out] p_mask is a mask that will be set to true if a fusion event occurs for a given
      * pair. It is only needed here to store information that will be used later on when actually
      * creating the product particles.
-     * @param[out] p_pair_indices_1 and p_pair_indices_2 are arrays that store the indices of the
+     * @param[out] p_pair_indices_1,p_pair_indices_2 arrays that store the indices of the
      * particles of a given pair. They are only needed here to store information that will be used
      * later on when actually creating the product particles.
      * @param[out] p_pair_reaction_weight stores the weight of the product particles. It is only

--- a/Source/Particles/Collision/BinaryCollision/PairWiseCoulombCollisionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/PairWiseCoulombCollisionFunc.H
@@ -58,9 +58,10 @@ public:
      *
      * @param[in] I1s,I2s is the start index for I1,I2 (inclusive).
      * @param[in] I1e,I2e is the stop index for I1,I2 (exclusive).
-     * @param[in] I1 and I2 are the index arrays. They determine all elements that will be used.
-     * @param[in, out] soa_1 and soa_2 contain the struct of array data of the two species.
-     * @param[in] q1 and q2 are charges. m1 and m2 are masses.
+     * @param[in] I1,I2 index arrays. They determine all elements that will be used.
+     * @param[in,out] soa_1,soa_2 contain the struct of array data of the two species.
+     * @param[in] q1,q2 are charges.
+     * @param[in] m1,m2 are masses.
      * @param[in] dt is the time step length between two collision calls.
      * @param[in] dV is the volume of the corresponding cell.
      * @param[in] engine the random engine.

--- a/Source/Particles/Collision/MCCScattering.H
+++ b/Source/Particles/Collision/MCCScattering.H
@@ -196,7 +196,8 @@ public:
     *
     * @param[in] energy_cost energy cost of ionization
     * @param[in] mass1 mass of the colliding species
-    * @param[in] ion_vel_std ...?
+    * @param[in] ion_vel_std standard deviation of ion velocity distribution; for
+    *                        a Maxwellian distribution it should equal sqrt(kB*T/m)
     */
     ImpactIonizationTransformFunc(
         amrex::Real energy_cost, amrex::Real mass1, amrex::Real ion_vel_std

--- a/Source/Particles/Collision/MCCScattering.H
+++ b/Source/Particles/Collision/MCCScattering.H
@@ -134,6 +134,7 @@ public:
     *
     * @param[in] ptd particle tile data
     * @param[in] i particle index
+    * @param[in] engine the random number state and factory
     * @return true if a collision occurs, false otherwise
     */
     template <typename PData>
@@ -195,6 +196,7 @@ public:
     *
     * @param[in] energy_cost energy cost of ionization
     * @param[in] mass1 mass of the colliding species
+    * @param[in] ion_vel_std ...?
     */
     ImpactIonizationTransformFunc(
         amrex::Real energy_cost, amrex::Real mass1, amrex::Real ion_vel_std

--- a/Source/Particles/Collision/MCCScattering.H
+++ b/Source/Particles/Collision/MCCScattering.H
@@ -196,7 +196,8 @@ public:
     *
     * @param[in] energy_cost energy cost of ionization
     * @param[in] mass1 mass of the colliding species
-    * @param[in] ion_vel_std standard deviation of ion velocity distribution; for
+    * @param[in] standard deviation of ion velocity distribution for each velocity
+                 direction; for a Maxwellian distribution it should equal sqrt(kB*T/m)
     *                        a Maxwellian distribution it should equal sqrt(kB*T/m)
     */
     ImpactIonizationTransformFunc(

--- a/Source/Particles/ElementaryProcess/QEDPairGeneration.H
+++ b/Source/Particles/ElementaryProcess/QEDPairGeneration.H
@@ -85,6 +85,17 @@ public:
     * lookup tables. Therefore, it should be rather lightweight to copy.
     *
     * @param[in] generate_functor functor to be called to determine the properties of the generated pairs
+    * @param[in] a_pti ...?
+    * @param[in] lev   the mesh-refinement level
+    * @param[in] ngE   ...?
+    * @param[in] exfab ...?
+    * @param[in] eyfab ...?
+    * @param[in] ezfab ...?
+    * @param[in] bxfab ...?
+    * @param[in] byfab ...?
+    * @param[in] bzfab ...?
+    * @param[in] v_galilean ...?
+    * @param[in] a_offset ...?
     */
     PairGenerationTransformFunc(BreitWheelerGeneratePairs const generate_functor,
                                 const WarpXParIter& a_pti, int lev, amrex::IntVect ngE,

--- a/Source/Particles/ElementaryProcess/QEDPairGeneration.H
+++ b/Source/Particles/ElementaryProcess/QEDPairGeneration.H
@@ -87,7 +87,7 @@ public:
     * @param[in] generate_functor functor to be called to determine the properties of the generated pairs
     * @param[in] a_pti particle iterator to iterate over photons undergoing QED pair generation process
     * @param[in] lev   the mesh-refinement level
-    * @param[in] ngE   ...?
+    * @param[in] ngE   number of guard cells allocated for the E and B MultiFabs
     * @param[in] exfab constant reference to the FArrayBox of the x component of the electric field
     * @param[in] eyfab constant reference to the FArrayBox of the y component of the electric field
     * @param[in] ezfab constant reference to the FArrayBox of the z component of the electric field

--- a/Source/Particles/ElementaryProcess/QEDPairGeneration.H
+++ b/Source/Particles/ElementaryProcess/QEDPairGeneration.H
@@ -85,15 +85,15 @@ public:
     * lookup tables. Therefore, it should be rather lightweight to copy.
     *
     * @param[in] generate_functor functor to be called to determine the properties of the generated pairs
-    * @param[in] a_pti ...?
+    * @param[in] a_pti particle iterator to iterate over photons undergoing QED pair generation process
     * @param[in] lev   the mesh-refinement level
     * @param[in] ngE   ...?
-    * @param[in] exfab ...?
-    * @param[in] eyfab ...?
-    * @param[in] ezfab ...?
-    * @param[in] bxfab ...?
-    * @param[in] byfab ...?
-    * @param[in] bzfab ...?
+    * @param[in] exfab constant reference to the FArrayBox of the x component of the electric field
+    * @param[in] eyfab constant reference to the FArrayBox of the y component of the electric field
+    * @param[in] ezfab constant reference to the FArrayBox of the z component of the electric field
+    * @param[in] bxfab constant reference to the FArrayBox of the x component of the magnetic field
+    * @param[in] byfab constant reference to the FArrayBox of the y component of the magnetic field
+    * @param[in] bzfab constant reference to the FArrayBox of the z component of the magnetic field
     * @param[in] v_galilean ...?
     * @param[in] a_offset ...?
     */

--- a/Source/Particles/ElementaryProcess/QEDPairGeneration.H
+++ b/Source/Particles/ElementaryProcess/QEDPairGeneration.H
@@ -95,7 +95,7 @@ public:
     * @param[in] byfab constant reference to the FArrayBox of the y component of the magnetic field
     * @param[in] bzfab constant reference to the FArrayBox of the z component of the magnetic field
     * @param[in] v_galilean vector components of the Galilean velocity (used with the Galilean PSATD solver)
-    * @param[in] a_offset ...?
+    * @param[in] a_offset offset to apply to the particle indices
     */
     PairGenerationTransformFunc(BreitWheelerGeneratePairs const generate_functor,
                                 const WarpXParIter& a_pti, int lev, amrex::IntVect ngE,

--- a/Source/Particles/ElementaryProcess/QEDPairGeneration.H
+++ b/Source/Particles/ElementaryProcess/QEDPairGeneration.H
@@ -94,7 +94,7 @@ public:
     * @param[in] bxfab constant reference to the FArrayBox of the x component of the magnetic field
     * @param[in] byfab constant reference to the FArrayBox of the y component of the magnetic field
     * @param[in] bzfab constant reference to the FArrayBox of the z component of the magnetic field
-    * @param[in] v_galilean ...?
+    * @param[in] v_galilean vector components of the Galilean velocity (used with the Galilean PSATD solver)
     * @param[in] a_offset ...?
     */
     PairGenerationTransformFunc(BreitWheelerGeneratePairs const generate_functor,

--- a/Source/Particles/ElementaryProcess/QEDPhotonEmission.H
+++ b/Source/Particles/ElementaryProcess/QEDPhotonEmission.H
@@ -98,14 +98,14 @@ public:
     * @param[in] emission_functor functor to generate photons and update momentum of the source particles
     * @param[in] a_pti particle iterator to iterate over electrons or positrons undergoing QED photon emission process
     * @param[in] lev   the mesh-refinement level
-    * @param[in] ngE   ...?
+    * @param[in] ngE   number of guard cells allocated for the E and B MultiFabs
     * @param[in] exfab constant reference to the FArrayBox of the x component of the electric field
     * @param[in] eyfab constant reference to the FArrayBox of the y component of the electric field
     * @param[in] ezfab constant reference to the FArrayBox of the z component of the electric field
     * @param[in] bxfab constant reference to the FArrayBox of the x component of the magnetic field
     * @param[in] byfab constant reference to the FArrayBox of the y component of the magnetic field
     * @param[in] bzfab constant reference to the FArrayBox of the z component of the magnetic field
-    * @param[in] v_galilean ...?
+    * @param[in] v_galilean vector components of the Galilean velocity (used with the Galilean PSATD solver)
     * @param[in] a_offset ...?
     */
     PhotonEmissionTransformFunc (

--- a/Source/Particles/ElementaryProcess/QEDPhotonEmission.H
+++ b/Source/Particles/ElementaryProcess/QEDPhotonEmission.H
@@ -106,7 +106,7 @@ public:
     * @param[in] byfab constant reference to the FArrayBox of the y component of the magnetic field
     * @param[in] bzfab constant reference to the FArrayBox of the z component of the magnetic field
     * @param[in] v_galilean vector components of the Galilean velocity (used with the Galilean PSATD solver)
-    * @param[in] a_offset ...?
+    * @param[in] a_offset offset to apply to the particle indices
     */
     PhotonEmissionTransformFunc (
         QuantumSynchrotronGetOpticalDepth opt_depth_functor,

--- a/Source/Particles/ElementaryProcess/QEDPhotonEmission.H
+++ b/Source/Particles/ElementaryProcess/QEDPhotonEmission.H
@@ -96,15 +96,15 @@ public:
     * @param[in] opt_depth_functor functor to re-initialize the optical depth of the source particles
     * @param[in] opt_depth_runtime_comp index of the optical depth component of the source species
     * @param[in] emission_functor functor to generate photons and update momentum of the source particles
-    * @param[in] a_pti ...?
+    * @param[in] a_pti particle iterator to iterate over electrons or positrons undergoing QED photon emission process
     * @param[in] lev   the mesh-refinement level
     * @param[in] ngE   ...?
-    * @param[in] exfab ...?
-    * @param[in] eyfab ...?
-    * @param[in] ezfab ...?
-    * @param[in] bxfab ...?
-    * @param[in] byfab ...?
-    * @param[in] bzfab ...?
+    * @param[in] exfab constant reference to the FArrayBox of the x component of the electric field
+    * @param[in] eyfab constant reference to the FArrayBox of the y component of the electric field
+    * @param[in] ezfab constant reference to the FArrayBox of the z component of the electric field
+    * @param[in] bxfab constant reference to the FArrayBox of the x component of the magnetic field
+    * @param[in] byfab constant reference to the FArrayBox of the y component of the magnetic field
+    * @param[in] bzfab constant reference to the FArrayBox of the z component of the magnetic field
     * @param[in] v_galilean ...?
     * @param[in] a_offset ...?
     */

--- a/Source/Particles/ElementaryProcess/QEDPhotonEmission.H
+++ b/Source/Particles/ElementaryProcess/QEDPhotonEmission.H
@@ -96,6 +96,17 @@ public:
     * @param[in] opt_depth_functor functor to re-initialize the optical depth of the source particles
     * @param[in] opt_depth_runtime_comp index of the optical depth component of the source species
     * @param[in] emission_functor functor to generate photons and update momentum of the source particles
+    * @param[in] a_pti ...?
+    * @param[in] lev   the mesh-refinement level
+    * @param[in] ngE   ...?
+    * @param[in] exfab ...?
+    * @param[in] eyfab ...?
+    * @param[in] ezfab ...?
+    * @param[in] bxfab ...?
+    * @param[in] byfab ...?
+    * @param[in] bzfab ...?
+    * @param[in] v_galilean ...?
+    * @param[in] a_offset ...?
     */
     PhotonEmissionTransformFunc (
         QuantumSynchrotronGetOpticalDepth opt_depth_functor,

--- a/Source/Particles/ElementaryProcess/QEDSchwingerProcess.H
+++ b/Source/Particles/ElementaryProcess/QEDSchwingerProcess.H
@@ -28,6 +28,8 @@ struct SchwingerFilterFunc
      * @param[in] i index of the cell in the first direction.
      * @param[in] j index of the cell in the second direction.
      * @param[in] k index of the cell in the third direction.
+     * @param[in] engine the random number state and factory
+     * @return ...?
      */
     template <typename FABs>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Source/Particles/ElementaryProcess/QEDSchwingerProcess.H
+++ b/Source/Particles/ElementaryProcess/QEDSchwingerProcess.H
@@ -29,7 +29,7 @@ struct SchwingerFilterFunc
      * @param[in] j index of the cell in the second direction.
      * @param[in] k index of the cell in the third direction.
      * @param[in] engine the random number state and factory
-     * @return ...?
+     * @return the number of pairs created in the cell.
      */
     template <typename FABs>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -93,8 +93,8 @@ struct ParserFilter
 {
     /** constructor
      * \param a_is_active whether the test is active
-     * \param a_filter_parser ...?
-     * \param a_mass ...?
+     * \param a_filter_parser parser taking t, x, y, z, ux, uy, and uz, and returning a value > 0.5 for selected particle
+     * \param a_mass mass of the particle species
      */
     ParserFilter(bool a_is_active, amrex::ParserExecutor<7> const& a_filter_parser,
                  amrex::Real a_mass)

--- a/Source/Particles/Filter/FilterFunctors.H
+++ b/Source/Particles/Filter/FilterFunctors.H
@@ -40,11 +40,14 @@ struct RandomFilter
     /**
      * \brief draw random number, return 1 if number < m_fraction, 1 otherwise
      * \param p one particle
+     * \param engine the random number state and factory
      * \return whether or not the particle is selected
      */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    bool operator () (const SuperParticleType& /*p*/, const amrex::RandomEngine& engine) const noexcept
+    bool operator () (const SuperParticleType& p, const amrex::RandomEngine& engine) const noexcept
     {
+        amrex::ignore_unused(p);
+
         if ( !m_is_active ) return 1;
         else if ( amrex::Random(engine) < m_fraction ) return 1;
         else return 0;
@@ -90,6 +93,8 @@ struct ParserFilter
 {
     /** constructor
      * \param a_is_active whether the test is active
+     * \param a_filter_parser ...?
+     * \param a_mass ...?
      */
     ParserFilter(bool a_is_active, amrex::ParserExecutor<7> const& a_filter_parser,
                  amrex::Real a_mass)
@@ -150,7 +155,6 @@ struct GeometryFilter
     /**
      * \brief return 1 if the partcile is within the region described by the RealBox
      * \param p one particle
-     * \param rb RealBox
      * \return whether or not the particle is inside the region defined by m_domain
      */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Source/Particles/Gather/FieldGather.H
+++ b/Source/Particles/Gather/FieldGather.H
@@ -420,7 +420,7 @@ void doGatherShapeN (const amrex::ParticleReal xp,
  * \tparam depos_order         deposition order
  * \tparam lower_in_v          lower shape order in parallel direction (Galerkin)
  * \param getPosition          A functor for returning the particle position.
- * \param getExternalEBField   A functor for assigning the external E and B fields.
+ * \param getExternalEB        A functor for assigning the external E and B fields.
  * \param Exp,Eyp,Ezp          Pointer to array of electric field on particles.
  * \param Bxp,Byp,Bzp          Pointer to array of magnetic field on particles.
  * \param exfab,eyfab,ezfab    Array4 of the electric field, either full array or tile.

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -101,7 +101,7 @@ public:
      * \param t current physical time
      * \param dt time step by which particles are advanced
      * \param a_dt_type type of time step (used for sub-cycling)
-     * \param skip_deposition ...?
+     * \param skip_deposition Skip the charge and current deposition.
      *
      * Evolve iterates over particle iterator (each box) and performs filtering,
      * field gather, particle push and current deposition for all particles

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -101,6 +101,7 @@ public:
      * \param t current physical time
      * \param dt time step by which particles are advanced
      * \param a_dt_type type of time step (used for sub-cycling)
+     * \param skip_deposition ...?
      *
      * Evolve iterates over particle iterator (each box) and performs filtering,
      * field gather, particle push and current deposition for all particles
@@ -302,7 +303,6 @@ public:
     * \brief This function determines if resampling should be done for the current species, and
     * if so, performs the resampling.
     *
-    * @param[in] resampler the Resampling object used for resampling.
     * @param[in] timestep the current timestep.
     */
     void resample (const int timestep) override final;

--- a/Source/Particles/Pusher/CopyParticleAttribs.H
+++ b/Source/Particles/Pusher/CopyParticleAttribs.H
@@ -39,7 +39,7 @@ struct CopyParticleAttribs
     /** \brief Construct a new functor
      *
      * \param a_pti iterator to the tile containing the macroparticles
-     * \param a_tmp holder for the temporary particle data
+     * \param tmp_particle_data holder for the temporary particle data
      * \param a_offset offset to apply when reading / writing particle data
      *        This is needed because when we use field gather buffers we don't
      *        always start at the particle with index 0.


### PR DESCRIPTION
Fix doxygen warnings related to #2482: typos, missing and extraneous parameters, etc.