### PR TITLE
Doxygen: include `static` functions

### DIFF
--- a/Docs/Doxyfile
+++ b/Docs/Doxyfile
@@ -454,7 +454,7 @@ EXTRACT_PACKAGE        = NO
 # included in the documentation.
 # The default value is: NO.
 
-EXTRACT_STATIC         = NO
+EXTRACT_STATIC         = YES
 
 # If the EXTRACT_LOCAL_CLASSES tag is set to YES, classes (and structs) defined
 # locally in source files will be included in the documentation. If set to NO,


### PR DESCRIPTION
We use this for ODR-friendly specifications of public functions in ABLASTR.

https://stackoverflow.com/a/22103109