### PR TITLE
SpectralFieldDataRZ: Missing Utils Include

### DIFF
--- a/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.cpp
@@ -7,6 +7,7 @@
 #include "SpectralFieldDataRZ.H"
 
 #include "WarpX.H"
+#include "Utils/WarpXUtil.H"
 
 using amrex::operator""_rt;
 


### PR DESCRIPTION
First seen in #2994
```
  /home/runner/work/WarpX/WarpX/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.cpp:412:21: error: use of undeclared identifier 'WarpXUtilLoadBalance'
      bool do_costs = WarpXUtilLoadBalance::doCosts(cost, field_mf.boxArray(), field_mf.DistributionMap());
                      ^
```