### PR TITLE
Summit: Fix BLAS++/LAPACK++ Modules

### DIFF
--- a/Tools/machines/summit-olcf/summit_warpx.profile.example
+++ b/Tools/machines/summit-olcf/summit_warpx.profile.example
@@ -13,8 +13,8 @@ module load cuda/11.3.1
 module load ccache
 
 # optional: for PSATD in RZ geometry support
-module load blaspp/2021.04.01
-module load lapackpp/2021.04.00
+module load blaspp/2021.04.01-cpu
+module load lapackpp/2021.04.00-cpu
 
 # optional: for PSATD support (CPU only)
 #module load fftw/3.3.9


### PR DESCRIPTION
These modules are by default using GPU support, which points to CUDA 11.0. Due to C++17 compiler bugs in that early CUDA release, we cannot use that version and pull in circular dependencies to two different CUDA toolkit versions as soon as we use BLAS++ & LAPACK++: when compiling PSATD+RZ.

Nonetheless, we do not use BLAS++/LAPACK++ on GPU yet anyway. Thus, we can simply use the CPU versions of those modules.