### PR TITLE
Regressions: remove tolerance

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -1866,7 +1866,6 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 analysisRoutine = Examples/analysis_default_regression.py
-tolerance = 2.e-14
 
 [PlasmaMirror]
 buildDir = .


### PR DESCRIPTION
We do `tolerance` and `abs_tolerance` checks via our checksums. This avoids that we need to build the AMReX plotfile tools (e.g., `fvarnames`) in CI, which:
- take long time to build
- use GNUmake
- fail to build on macOS M1

Thus, do not add these sections to CI tests. Slipped in again by a test, follow-up to #2789

Reference:
https://github.com/AMReX-Codes/regression_testing/blob/5654ae9be080add8bee6eab8d97ced580e6262a9/suite.py#L1014