### PR TITLE
Wheel: Separate Directory

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -40,10 +40,7 @@ jobs:
 
         python3 -m pip install --upgrade pip setuptools wheel
         if(!$?) { Exit $LASTEXITCODE }
-        python3 -m pip install --upgrade cmake
-        if(!$?) { Exit $LASTEXITCODE }
-        $env:PYWARPX_LIB_DIR="$(Get-Location | Foreach-Object { $_.Path })\build\lib\Debug\"
-        python3 -m pip install . -vv --no-build-isolation
+        cmake --build build --config Debug --target pip_install
         if(!$?) { Exit $LASTEXITCODE }
 
         python3 Examples\Modules\gaussian_beam\PICMI_inputs_gaussian_beam.py
@@ -90,10 +87,7 @@ jobs:
 
         python3 -m pip install --upgrade pip setuptools wheel
         if errorlevel 1 exit 1
-        python3 -m pip install --upgrade cmake
-        if errorlevel 1 exit 1
-        set "PYWARPX_LIB_DIR=%cd%\build\lib\"
-        python3 -m pip install . -vv --no-build-isolation
+        cmake --build build --config Release --target pip_install
         if errorlevel 1 exit 1
 
         python3 Examples\Modules\gaussian_beam\PICMI_inputs_gaussian_beam.py --diagformat=openpmd

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -436,10 +436,10 @@ if(WarpX_LIB)
 
     # build the wheel by re-using the shared library we build
     add_custom_target(${WarpX_CUSTOM_TARGET_PREFIX}pip_wheel
-        ${CMAKE_COMMAND} -E rm -f ${WarpX_BINARY_DIR}/pywarpx*whl
+        ${CMAKE_COMMAND} -E rm -f -r warpx-whl
         COMMAND
-            ${CMAKE_COMMAND} -E env PYWARPX_LIB_DIR=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
-                python3 -m pip wheel -v --no-build-isolation ${WarpX_SOURCE_DIR}
+            ${CMAKE_COMMAND} -E env PYWARPX_LIB_DIR=$<TARGET_FILE_DIR:shared>
+                python3 -m pip wheel -v --no-build-isolation --no-deps --wheel-dir=warpx-whl ${WarpX_SOURCE_DIR}
         WORKING_DIRECTORY
             ${WarpX_BINARY_DIR}
         DEPENDS
@@ -463,7 +463,7 @@ if(WarpX_LIB)
     # because otherwise pip would also force reinstall all dependencies.
     add_custom_target(${WarpX_CUSTOM_TARGET_PREFIX}pip_install
         ${CMAKE_COMMAND} -E env WARPX_MPI=${WarpX_MPI}
-            python3 -m pip install --force-reinstall --no-deps ${PYINSTALLOPTIONS} ${WarpX_BINARY_DIR}/pywarpx*whl
+            python3 -m pip install --force-reinstall --no-index --no-deps ${PYINSTALLOPTIONS} --find-links=warpx-whl pywarpx
         WORKING_DIRECTORY
             ${WarpX_BINARY_DIR}
         DEPENDS

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include README.md LEGAL.txt LICENSE.txt
 include pyproject.toml
-include requirements.txt
+include requirements.txt requirements_mpi.txt
 global-include CMakeLists.txt *.cmake *.in
 recursive-include Source *
 recursive-include Python *


### PR DESCRIPTION
The `pip_install` target did not yet work on Windows, because it has no universal wildcard `*` support for our pip install logic.

Fix this by creating the wheel in a sub-directory and installing it by "finding all wheels for `pywarpx` in a given prefix".

- Avoid wildcards by using a separate directory.
- Avoid downloading deps during `wheel` build again.
- Fix Manifest: follow-up to #3265