### PR TITLE
Spack Desktop: Simpler CUDA Visualization

### DIFF
--- a/Tools/machines/desktop/spack-ubuntu-cuda.yaml
+++ b/Tools/machines/desktop/spack-ubuntu-cuda.yaml
@@ -14,7 +14,8 @@
 #
 spack:
   specs:
-  - adios2
+  # https://github.com/ornladios/ADIOS2/issues/3332
+  - adios2 ~cuda
   - ascent +adios2 +python ~fortran ~shared
   - blaspp
   - boost

--- a/Tools/machines/desktop/spack-ubuntu-cuda.yaml
+++ b/Tools/machines/desktop/spack-ubuntu-cuda.yaml
@@ -15,7 +15,7 @@
 spack:
   specs:
   - adios2
-  - ascent +adios2 +python ~fortran
+  - ascent +adios2 +python ~fortran ~shared
   - blaspp
   - boost
   - ccache
@@ -37,6 +37,7 @@ spack:
   - py-setuptools
   - py-wheel
   - sensei +ascent ~catalyst +python
+  - vtk-m ~shared
 # This always enables DevilRay, which builds too long on CUDA and we mainly use VTK-m
 #  - ecp-data-vis-sdk +adios2 +ascent +hdf5 +sensei
 # skipped to save time: 3D post-processing

--- a/Tools/machines/desktop/spack-ubuntu-cuda.yaml
+++ b/Tools/machines/desktop/spack-ubuntu-cuda.yaml
@@ -15,11 +15,12 @@
 spack:
   specs:
   - adios2
+  - ascent +adios2 +python ~fortran
   - blaspp
   - boost
   - ccache
   - cmake
-  - ecp-data-vis-sdk +adios2 +ascent +hdf5 +sensei
+  - conduit ~fortran
   - cuda
   - fftw
   - hdf5
@@ -35,6 +36,9 @@ spack:
   - py-pip
   - py-setuptools
   - py-wheel
+  - sensei +ascent ~catalyst +python
+# This always enables DevilRay, which builds too long on CUDA and we mainly use VTK-m
+#  - ecp-data-vis-sdk +adios2 +ascent +hdf5 +sensei
 # skipped to save time: 3D post-processing
 #  - paraview +adios2 +python3 +qt
 # skipped to save time, because they are faster installed via pip afterwards


### PR DESCRIPTION
Reduce the dependencies for in situ vis, avoiding to build DevilRay in Ascent, which takes very long right now.
We mostly use Ascent with VTK-m for now.

Spack prep.:
```console
# create new development environment
spack env create warpx-cuda-dev Tools/machines/desktop/spack-ubuntu-cuda.yaml
spack env activate warpx-cuda-dev

# installation
spack install
python3 -m pip install jupyter matplotlib numpy openpmd-api openpmd-viewer pandas scipy virtualenv yt
```

Compiled full-feature WarpX on Ubuntu 20.04 with:
```console
# work-around for Ascent/VTK-m/Vis: only needed on Pascal GPUs?
#export CUDAFLAGS="-Xptxas --disable-optimizer-constants"
# confuses GCC 9.4.0 now during link logic

cmake -S . -B build -DWarpX_COMPUTE=CUDA -DWarpX_ASCENT=ON -DWarpX_EB=ON -DWarpX_PSATD=ON -DWarpX_QED_TABLE_GEN=ON -DWarpX_LIB=ON
cmake --build build -j 4
cmake --build build --target pip_install -j 4
```

Run:
```console
cd build/bin
cp ../../Examples/Physics_applications/laser_acceleration/ascent_actions.yaml .
cp ../../Examples/Physics_applications/laser_acceleration/inputs_3d .
cp ../../Examples/Physics_applications/laser_acceleration/PICMI_inputs_3d.py .

# app w/ ascent
./warpx inputs_3d amr.n_cell=64 64 256 diag1.intervals=10 diag1.format=ascent

# Python PICMI w/o ascent
./PICMI_inputs_3d.py
```
- [ ] output