### PR TITLE
Perlmutter: Specify "regular" QOS

### DIFF
--- a/Tools/machines/perlmutter-nersc/perlmutter.sbatch
+++ b/Tools/machines/perlmutter-nersc/perlmutter.sbatch
@@ -12,7 +12,7 @@
 #    note: <proj> must end on _g
 #SBATCH -A <proj>
 # for m3906_g LBNL/AMP users: for large runs, comment in
-##SBATCH -q early_science
+#SBATCH -q regular
 #SBATCH -C gpu
 #SBATCH -c 32
 #SBATCH --ntasks-per-node=4

--- a/Tools/machines/perlmutter-nersc/perlmutter.sbatch
+++ b/Tools/machines/perlmutter-nersc/perlmutter.sbatch
@@ -11,7 +11,6 @@
 #SBATCH -J WarpX
 #    note: <proj> must end on _g
 #SBATCH -A <proj>
-# for m3906_g LBNL/AMP users: for large runs, comment in
 #SBATCH -q regular
 #SBATCH -C gpu
 #SBATCH -c 32
@@ -19,24 +18,6 @@
 #SBATCH --gpus-per-node=4
 #SBATCH -o WarpX.o%j
 #SBATCH -e WarpX.e%j
-
-# ============
-# -N =                 nodes
-# -n =                 tasks (MPI ranks, usually = G)
-# -G =                 GPUs (full Perlmutter node, 4)
-# -c =                 CPU per task (128 total threads on CPU, 32 per GPU)
-#
-# --ntasks-per-node=   number of tasks (MPI ranks) per node (full node, 4)
-# --gpus-per-task=     number of GPUs per task (MPI rank) (full node, 4)
-# --gpus-per-node=     number of GPUs per node (full node, 4)
-#
-# --gpu-bind=single:1  sets only one GPU to be visible to each MPI rank
-#                         (quiets AMReX init warnings)
-#
-# Recommend using --ntasks-per-node=4, --gpus-per-task=1 and --gpu-bind=single:1,
-# as they are fixed values and allow for easy scaling with less adjustments.
-#
-# ============
 
 # GPU-aware MPI
 export MPICH_GPU_SUPPORT_ENABLED=1


### PR DESCRIPTION
Regular seems to be not the default (anymore), which blocks submissions >1hr.