### PR TITLE
Frontier/Crusher: rocFFT Cache Control

### DIFF
--- a/Docs/source/install/hpc/crusher.rst
+++ b/Docs/source/install/hpc/crusher.rst
@@ -106,3 +106,13 @@ Known System Issues
    .. code-block:: bash
 
       export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
+
+.. warning::
+
+   Sep 2nd, 2022 (OLCFDEV-1079):
+   rocFFT in ROCm 5.1+ tries to `write to a cache <https://rocfft.readthedocs.io/en/latest/library.html#runtime-compilation>`__ in the home area by default.
+   This does not scale, disable it via:
+
+   .. code-block:: bash
+
+      export ROCFFT_RTC_CACHE_PATH=/dev/null

--- a/Docs/source/install/hpc/frontier.rst
+++ b/Docs/source/install/hpc/frontier.rst
@@ -117,3 +117,13 @@ Known System Issues
    .. code-block:: bash
 
       export FI_MR_CACHE_MAX_COUNT=0  # libfabric disable caching
+
+.. warning::
+
+   Sep 2nd, 2022 (OLCFDEV-1079):
+   rocFFT in ROCm 5.1+ tries to `write to a cache <https://rocfft.readthedocs.io/en/latest/library.html#runtime-compilation>`__ in the home area by default.
+   This does not scale, disable it via:
+
+   .. code-block:: bash
+
+      export ROCFFT_RTC_CACHE_PATH=/dev/null

--- a/Tools/machines/crusher-olcf/submit.sh
+++ b/Tools/machines/crusher-olcf/submit.sh
@@ -19,10 +19,15 @@
 # (GCDs) for a total of 8 GCDs per node. The programmer can think of the 8 GCDs
 # as 8 separate GPUs, each having 64 GB of high-bandwidth memory (HBM2E).
 
-# note (5-16-22)
+# note (5-16-22, OLCFHELP-6888)
 # this environment setting is currently needed on Crusher to work-around a
 # known issue with Libfabric
 export FI_MR_CACHE_MAX_COUNT=0
+
+# note (9-2-22, OLCFDEV-1079)
+# this environment setting is needed to avoid that rocFFT writes a cache in
+# the home directory, which does not scale.
+export ROCFFT_RTC_CACHE_PATH=/dev/null
 
 export OMP_NUM_THREADS=8
 srun ./warpx inputs > output.txt

--- a/Tools/machines/frontier-olcf/submit.sh
+++ b/Tools/machines/frontier-olcf/submit.sh
@@ -28,6 +28,11 @@
 # known issue with Libfabric (both in the May and June PE)
 export FI_MR_CACHE_MAX_COUNT=0
 
+# note (9-2-22, OLCFDEV-1079)
+# this environment setting is needed to avoid that rocFFT writes a cache in
+# the home directory, which does not scale.
+export ROCFFT_RTC_CACHE_PATH=/dev/null
+
 export OMP_NUM_THREADS=1
 export WARPX_NMPI_PER_NODE=8
 export TOTAL_NMPI=$(( ${SLURM_JOB_NUM_NODES} * ${WARPX_NMPI_PER_NODE} ))


### PR DESCRIPTION
rocFFT in ROCm 5.1+ tries to [write to a cache](https://rocfft.readthedocs.io/en/latest/library.html#runtime-compilation) in the home area by default. This does not scale and caused timeouts for PSATD runs.