### PR TITLE
Docs: Fix PICMI Builds

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -14,7 +14,7 @@ python3 -m pip install -r Docs/requirements.txt
 
 ### Compiling the documentation
 
-`cd` into this directory and type
+`cd` into the `Docs/` directory and type
 ```
 make html
 ```

--- a/Docs/requirements.txt
+++ b/Docs/requirements.txt
@@ -5,7 +5,7 @@
 # License: BSD-3-Clause-LBNL
 
 # WarpX PICMI bindings w/o C++ component (used for autoclass docs)
--e ../Python
+-e Python
 breathe
 # docutils 0.17 breaks HTML tags & RTD theme
 # https://github.com/sphinx-doc/sphinx/issues/9001

--- a/Docs/source/developers/documentation.rst
+++ b/Docs/source/developers/documentation.rst
@@ -52,18 +52,19 @@ Building the documentation
 --------------------------
 
 To build the documentation on your local computer, you will need to install Doxygen as well as the Python module `breathe`.
-First, change into ``Docs/`` and install the Python requirements:
+First, make sure you are in the root directory of WarpX's source and install the Python requirements:
 
 .. code-block:: sh
 
-    cd Docs/
-    python3 -m pip install -r requirements.txt
+    python3 -m pip install -r Docs/requirements.txt
 
 You will also need Doxygen (macOS: ``brew install doxygen``; Ubuntu: ``sudo apt install doxygen``).
 
 Then, to compile the documentation, use
 
 .. code-block:: sh
+
+    cd Docs/
 
     make html
     # This will first compile the Doxygen documentation (execute doxygen)


### PR DESCRIPTION
Unbreak the RTD build. We need to do this all relative to the root directory.