### PR TITLE
User-Specified Used Inputs File

### DIFF
--- a/Docs/source/usage/how_to_run.rst
+++ b/Docs/source/usage/how_to_run.rst
@@ -99,7 +99,7 @@ On an :ref:`HPC system <install-hpc>`, you would instead submit the :ref:`job sc
 By default, WarpX will write a status update to the terminal (``stdout``).
 On :ref:`HPC systems <install-hpc>`, we usually store a copy of this in a file called ``outputs.txt``.
 
-We also store by default an exact copy of all explicitly and implicitly used inputs parameters in a file called ``warpx_used_inputs``.
+We also store by default an exact copy of all explicitly and implicitly used inputs parameters in a file called ``warpx_used_inputs`` (this file name can be changed).
 This is important for reproducibility, since as we wrote in the previous paragraph, the options in the input file can be extended and overwritten from the command line.
 
 :ref:`Further configured diagnostics <running-cpp-parameters-diagnostics>` are explained in the next sections.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -5,6 +5,10 @@ Input Parameters
 
 .. note::
 
+   WarpX input options are read via AMReX `ParmParse <https://amrex-codes.github.io/amrex/docs_html/Basics.html#parmparse>`__.
+
+.. note::
+
    The AMReX parser (see :ref:`running-cpp-parameters-parser`) is used for the right-hand-side of all input parameters that consist of one or more integers or floats, so expressions like ``<species_name>.density_max = "2.+1."`` and/or using user-defined constants are accepted.
 
 .. _running-cpp-parameters-overall:
@@ -23,6 +27,10 @@ Overall simulation parameters
     The maximum physical time of the simulation. Can be provided instead of ``max_step``. If both
     ``max_step`` and ``stop_time`` are provided, both criteria are used and the simulation stops
     when the first criterion is hit.
+
+* ``warpx.used_inputs_file`` (`string`; default: ``warpx_used_inputs``)
+    Name of a file that WarpX writes to archive the used inputs.
+    The context of this file will contain an exact copy of all explicitly and implicitly used inputs parameters, including those :ref:`extended and overwritten from the command line <usage_run>`.
 
 * ``warpx.gamma_boost`` (`float`)
     The Lorentz factor of the boosted frame in which the simulation is run.

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -349,8 +349,12 @@ WarpX::PrintMainPICparameters ()
 }
 
 void
-WarpX::WriteUsedInputsFile (std::string const & filename) const
+WarpX::WriteUsedInputsFile () const
 {
+    std::string filename = "warpx_used_inputs";
+    ParmParse pp_warpx("warpx");
+    pp_warpx.queryAdd("used_inputs_file", filename);
+
     ablastr::utils::write_used_inputs_file(filename);
 }
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -453,7 +453,7 @@ public:
     void PrintMainPICparameters ();
 
     /** Write a file that record all inputs: inputs file + command line options */
-    void WriteUsedInputsFile (std::string const & filename = "warpx_used_inputs") const;
+    void WriteUsedInputsFile () const;
 
     /** Print dt and dx,dy,dz */
     void PrintDtDxDyDz ();


### PR DESCRIPTION
Allow users to overwrite the default for the "used inputs" file that we write. Close #3319

Follow-up to #3132 #3234.
CC @ppiot @n01r 