### PR TITLE
[WIP] Remove particle counter in BTD

### DIFF
--- a/Source/Diagnostics/BTDiagnostics.H
+++ b/Source/Diagnostics/BTDiagnostics.H
@@ -380,8 +380,6 @@ private:
 
     /** Update total number of particles flushed for all species for ith snapshot */
     void UpdateTotalParticlesFlushed(int i_buffer);
-    /** Reset total number of particles in the particle buffer to 0 for ith snapshot */
-    void ResetTotalParticlesInBuffer(int i_buffer);
     /** Clear particle data stored in the particle buffer */
     void ClearParticleBuffer(int i_buffer);
     /** Redistributes particles to the buffer box array in the lab-frame */

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -124,7 +124,6 @@ void BTDiagnostics::DerivedInitData ()
     }
     m_particles_buffer.resize(m_num_buffers);
     m_totalParticles_flushed_already.resize(m_num_buffers);
-    m_totalParticles_in_buffer.resize(m_num_buffers);
 
     // check that simulation can fill all BTD snapshots
     const int lev = 0;
@@ -1047,7 +1046,6 @@ BTDiagnostics::Flush (int i_buffer)
     // if particles are selected for output then update and reset counters
     if (m_output_species_names.size() > 0) {
         UpdateTotalParticlesFlushed(i_buffer);
-        ResetTotalParticlesInBuffer(i_buffer);
         ClearParticleBuffer(i_buffer);
     }
     // Setting hi k-index for the next buffer, such that, the index is one less than the lo-index of previous buffer
@@ -1356,10 +1354,8 @@ BTDiagnostics::InitializeParticleBuffer ()
     for (int i = 0; i < m_num_buffers; ++i) {
         m_particles_buffer[i].resize(m_output_species_names.size());
         m_totalParticles_flushed_already[i].resize(m_output_species_names.size());
-        m_totalParticles_in_buffer[i].resize(m_output_species_names.size());
         for (int isp = 0; isp < m_particles_buffer[i].size(); ++isp) {
             m_totalParticles_flushed_already[i][isp] = 0;
-            m_totalParticles_in_buffer[i][isp] = 0;
             m_particles_buffer[i][isp] = std::make_unique<PinnedMemoryParticleContainer>(WarpX::GetInstance().GetParGDB());
             const int idx = mpc.getSpeciesID(m_output_species_names[isp]);
             m_output_species[i].push_back(ParticleDiag(m_diag_name,
@@ -1382,21 +1378,19 @@ BTDiagnostics::PrepareParticleDataForOutput()
                 // Check if the zslice is in domain
                 bool ZSliceInDomain = GetZSliceInDomainFlag (i_buffer, lev);
                 if (ZSliceInDomain) {
-                    if ( m_totalParticles_in_buffer[i_buffer][i] == 0) {
-                        if (!m_do_back_transformed_fields || m_varnames_fields.size()==0) {
-                            if ( m_buffer_flush_counter[i_buffer] == 0) {
-                                DefineSnapshotGeometry(i_buffer, lev);
-                            }
-                            DefineFieldBufferMultiFab(i_buffer, lev);
+                    if (!m_do_back_transformed_fields || m_varnames_fields.size()==0) {
+                        if ( m_buffer_flush_counter[i_buffer] == 0) {
+                            DefineSnapshotGeometry(i_buffer, lev);
                         }
-                        amrex::Box particle_buffer_box = m_buffer_box[i_buffer];
-                        amrex::BoxArray buffer_ba( particle_buffer_box );
-                        buffer_ba.maxSize(m_max_box_size);
-                        amrex::DistributionMapping buffer_dmap(buffer_ba);
-                        m_particles_buffer[i_buffer][i]->SetParticleBoxArray(lev, buffer_ba);
-                        m_particles_buffer[i_buffer][i]->SetParticleDistributionMap(lev, buffer_dmap);
-                        m_particles_buffer[i_buffer][i]->SetParticleGeometry(lev, m_geom_snapshot[i_buffer][lev]);
+                        DefineFieldBufferMultiFab(i_buffer, lev);
                     }
+                    amrex::Box particle_buffer_box = m_buffer_box[i_buffer];
+                    amrex::BoxArray buffer_ba( particle_buffer_box );
+                    buffer_ba.maxSize(m_max_box_size);
+                    amrex::DistributionMapping buffer_dmap(buffer_ba);
+                    m_particles_buffer[i_buffer][i]->SetParticleBoxArray(lev, buffer_ba);
+                    m_particles_buffer[i_buffer][i]->SetParticleDistributionMap(lev, buffer_dmap);
+                    m_particles_buffer[i_buffer][i]->SetParticleGeometry(lev, m_geom_snapshot[i_buffer][lev]);
                 }
                 m_all_particle_functors[i]->PrepareFunctorData (
                                              i_buffer, ZSliceInDomain, m_old_z_boost[i_buffer],
@@ -1412,14 +1406,6 @@ BTDiagnostics::UpdateTotalParticlesFlushed(int i_buffer)
 {
     for (int isp = 0; isp < m_totalParticles_flushed_already[i_buffer].size(); ++isp) {
         m_totalParticles_flushed_already[i_buffer][isp] += m_particles_buffer[i_buffer][isp]->TotalNumberOfParticles();
-    }
-}
-
-void
-BTDiagnostics::ResetTotalParticlesInBuffer(int i_buffer)
-{
-    for (int isp = 0; isp < m_totalParticles_in_buffer[i_buffer].size(); ++isp) {
-        m_totalParticles_in_buffer[i_buffer][isp] = 0;
     }
 }
 

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.H
@@ -198,7 +198,7 @@ BackTransformParticleFunctor final : public ComputeParticleDiagFunctor
 public:
     BackTransformParticleFunctor(WarpXParticleContainer *pc_src, std::string species_name, int num_buffers);
     /** Computes the Lorentz transform of source particles to obtain lab-frame data in pc_dst*/
-    void operator () (PinnedMemoryParticleContainer& pc_dst, int &TotalParticleCounter, int i_buffer) const override;
+    void operator () (PinnedMemoryParticleContainer& pc_dst, int i_buffer) const override;
     void InitData() override;
     /** \brief Prepare data required to back-transform particle attribtutes for lab-frame snapshot, i_buffer
      *

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.cpp
@@ -78,7 +78,7 @@ BackTransformParticleFunctor::BackTransformParticleFunctor (
 
 
 void
-BackTransformParticleFunctor::operator () (PinnedMemoryParticleContainer& pc_dst, int &totalParticleCounter, int i_buffer) const
+BackTransformParticleFunctor::operator () (PinnedMemoryParticleContainer& pc_dst, int i_buffer) const
 {
     if (m_perform_backtransform[i_buffer] == 0) return;
     auto &warpx = WarpX::GetInstance();
@@ -149,7 +149,6 @@ BackTransformParticleFunctor::operator () (PinnedMemoryParticleContainer& pc_dst
             }
         }
     }
-    totalParticleCounter = pc_dst.TotalNumberOfParticles();
 }
 
 

--- a/Source/Diagnostics/ComputeDiagFunctors/ComputeParticleDiagFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/ComputeParticleDiagFunctor.H
@@ -52,7 +52,7 @@ public:
      *  \param[out] pc_dst  output particle container where the result is stored.
      *  \param[in] i_buffer snapshot index for which the particle buffer is processed
      */
-    virtual void operator () (PinnedMemoryParticleContainer& pc_dst, int &totalParticlesInBuffer, int i_buffer = 0) const = 0;
+    virtual void operator () (PinnedMemoryParticleContainer& pc_dst, int i_buffer = 0) const = 0;
     virtual void InitData () {}
 };
 

--- a/Source/Diagnostics/Diagnostics.H
+++ b/Source/Diagnostics/Diagnostics.H
@@ -240,8 +240,6 @@ protected:
      *  The first vector is for total number of snapshots and second vector loops
      *  over the total number of species selected for diagnostics.
      */
-    amrex::Vector< amrex::Vector <int> > m_totalParticles_in_buffer;
-
 };
 
 #endif // WARPX_DIAGNOSTICS_H_

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -463,7 +463,7 @@ Diagnostics::ComputeAndPack ()
         }
         // Call Particle functor
         for (int isp = 0; isp < m_all_particle_functors.size(); ++isp) {
-            m_all_particle_functors[isp]->operator()(*m_particles_buffer[i_buffer][isp], m_totalParticles_in_buffer[i_buffer][isp], i_buffer);
+            m_all_particle_functors[isp]->operator()(*m_particles_buffer[i_buffer][isp], i_buffer);
         }
     }
 


### PR DESCRIPTION
As discussed in past meetings with @RevathiJambunathan , the variable `m_totalParticles_in_buffer` is updated at each iteration (using expensive MPI calls) but is only used in one place in the code (which may not be critical).

This PR attempts to remove this variable.

TODO:
- [ ] Test performance on milestone case.