### PR TITLE
Docs: Repo Vis Link

### DIFF
--- a/Docs/source/developers/repo_organization.rst
+++ b/Docs/source/developers/repo_organization.rst
@@ -10,7 +10,7 @@ All the WarpX source code is located in ``Source/``.
 All sub-directories have a pretty straightforward name.
 The PIC loop is part of the WarpX class, in function ``WarpX::EvolveEM`` implemented in ``Source/WarpXEvolveEM.cpp``.
 The core of the PIC loop (i.e., without diagnostics etc.) is in ``WarpX::OneStep_nosub`` (when subcycling is OFF) or ``WarpX::OneStep_sub1`` (when subcycling is ON, with method 1).
-Here is a `visual representation <https://octo-repo-visualization.vercel.app/?repo=ECP-WarpX%2FWarpX>`__ of the repository structure.
+Here is a `visual representation <https://mango-dune-07a8b7110.1.azurestaticapps.net/?repo=ECP-WarpX%2FWarpX>`__ of the repository structure.
 
 
 Code organization


### PR DESCRIPTION
The old repo vis link was broken. [This seems to be the new service endpoint.
](https://twitter.com/axccl/status/1600658807189045248)
Thx to @aeriforme for spotting the broken link.