### PR TITLE
Fix Doxygen Warnings

### DIFF
--- a/Source/AcceleratorLattice/LatticeElementFinder.H
+++ b/Source/AcceleratorLattice/LatticeElementFinder.H
@@ -158,7 +158,7 @@ struct LatticeElementFinderDevice
      * @param[in] a_pti specifies the grid where the finder is defined
      * @param[in] a_offset particle index offset needed to access particle info
      * @param[in] accelerator_lattice a reference to the accelerator lattice at the refinement level
-     * @param[in] The host level instance of the element finder that this is associated with
+     * @param[in] h_finder The host level instance of the element finder that this is associated with
      */
     void
     InitLatticeElementFinderDevice (WarpXParIter const& a_pti, int const a_offset,
@@ -192,7 +192,7 @@ struct LatticeElementFinderDevice
      * \brief Gather the field for the particle from the lattice elements
      *
      * @param[in] i the particle index
-     * @param[out] field_Ex, ..., the gathered E and B fields
+     * @param[out] field_Ex,field_Ey,field_Ez,field_Bx,field_By,field_Bz the gathered E and B fields
      */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void operator () (const long i,

--- a/Source/AcceleratorLattice/LatticeElements/Drift.H
+++ b/Source/AcceleratorLattice/LatticeElements/Drift.H
@@ -23,7 +23,7 @@ struct Drift
      * \brief Read in an element and add it to the lists
      *
      * @param[in] pp_element The ParmParse instance to read in the data
-     * @param[in/out] z_location The current z location in the lattice
+     * @param[inout] z_location The current z location in the lattice
      */
     void
     AddElement (amrex::ParmParse & pp_element, amrex::ParticleReal & z_location);

--- a/Source/AcceleratorLattice/LatticeElements/HardEdgedPlasmaLens.H
+++ b/Source/AcceleratorLattice/LatticeElements/HardEdgedPlasmaLens.H
@@ -34,7 +34,7 @@ struct HardEdgedPlasmaLens
      * \brief Read in an element and add it to the lists
      *
      * @param[in] pp_element The ParmParse instance to read in the data
-     * @param[in/out] z_location The current z location in the lattice
+     * @param[inout] z_location The current z location in the lattice
      */
     void
     AddElement (amrex::ParmParse & pp_element, amrex::ParticleReal & z_location);

--- a/Source/AcceleratorLattice/LatticeElements/HardEdgedQuadrupole.H
+++ b/Source/AcceleratorLattice/LatticeElements/HardEdgedQuadrupole.H
@@ -34,7 +34,7 @@ struct HardEdgedQuadrupole
      * \brief Read in an element and add it to the lists
      *
      * @param[in] pp_element The ParmParse instance to read in the data
-     * @param[in/out] z_location The current z location in the lattice
+     * @param[inout] z_location The current z location in the lattice
      */
     void
     AddElement (amrex::ParmParse & pp_element, amrex::ParticleReal & z_location);

--- a/Source/AcceleratorLattice/LatticeElements/HardEdged_K.H
+++ b/Source/AcceleratorLattice/LatticeElements/HardEdged_K.H
@@ -20,7 +20,7 @@
  * @param[in] zpvdt the estimated future location of the particle, z + v*dt
  * @param[in] zs the start of the lattice element
  * @param[in] ze the end of the lattice element
- * @param[out] the fraction is returned
+ * @return the fraction is returned
  */
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 amrex::ParticleReal hard_edged_fraction(const amrex::ParticleReal z,

--- a/Source/AcceleratorLattice/LatticeElements/LatticeElementBase.H
+++ b/Source/AcceleratorLattice/LatticeElements/LatticeElementBase.H
@@ -31,7 +31,7 @@ struct LatticeElementBase
      * \brief Read in an element base data and add it to the lists
      *
      * @param[in] pp_element The ParmParse instance to read in the data
-     * @param[in/out] z_location The current z location in the lattice
+     * @param[inout] z_location The current z location in the lattice
      */
     void
     AddElementBase(amrex::ParmParse & pp_element, amrex::ParticleReal & z_location);

--- a/Source/Particles/Collision/BinaryCollision/Coulomb/PairWiseCoulombCollisionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/Coulomb/PairWiseCoulombCollisionFunc.H
@@ -40,9 +40,11 @@ public:
      * \brief Constructor of the PairWiseCoulombCollisionFunc class
      *
      * @param[in] collision_name the name of the collision
+     * @param[in] mypc the particle container (unused)
+     * @param[in] isSameSpecies true if this is an intra-species colission
      */
     PairWiseCoulombCollisionFunc (const std::string collision_name,
-                                  MultiParticleContainer const * const /*mypc*/,
+                                  [[maybe_unused]] MultiParticleContainer const * const mypc,
                                   const bool isSameSpecies)
     {
         using namespace amrex::literals;


### PR DESCRIPTION
Fix a few Doxygen warnings.
Pulled out of the infrastructure update in #3560 that currently seems to hang.