### PR TITLE
Summit (OLCF): No Prepend in `jsrun`

### DIFF
--- a/Tools/machines/summit-olcf/summit_power9.bsub
+++ b/Tools/machines/summit-olcf/summit_power9.bsub
@@ -48,8 +48,5 @@ EOL
 # OpenMP: 21 threads per MPI rank
 export OMP_NUM_THREADS=21
 
-# store out task host mapping: helps identify broken nodes at scale
-jsrun -n 2 -a 1 -c 21 -r 2 -e prepended hostname > task_host_mapping.txt
-
 # run WarpX
-jsrun -n 2 -a 1 -c 21 -r 2 -l CPU-CPU -d packed -b rs -e prepended <path/to/executable> <input file> > output.txt
+jsrun -n 2 -a 1 -c 21 -r 2 -l CPU-CPU -d packed -b rs <path/to/executable> <input file> > output.txt

--- a/Tools/machines/summit-olcf/summit_v100.bsub
+++ b/Tools/machines/summit-olcf/summit_v100.bsub
@@ -49,8 +49,5 @@ EOL
 # OpenMP: 1 thread per MPI rank
 export OMP_NUM_THREADS=1
 
-# store out task host mapping: helps identify broken nodes at scale
-jsrun -r 6 -a1 -g 1 -c 7 -e prepended hostname > task_host_mapping.txt
-
 # run WarpX
-jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs -e prepended --smpiargs="-gpu" <path/to/executable> <input file> > output.txt
+jsrun -r 6 -a 1 -g 1 -c 7 -l GPU-CPU -d packed -b rs --smpiargs="-gpu" <path/to/executable> <input file> > output.txt


### PR DESCRIPTION
AMReX now adds `hostname -f` information in backtraces, so we don't need this anymore.

Reverts #3040