### PR TITLE
Docs: Summit Jupyter HDF5 Back

### DIFF
--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -16,12 +16,12 @@ If you are new to this system, **please see the following resources**:
 * `Jupyter service <https://jupyter.olcf.ornl.gov>`__
 * `Production directories <https://docs.olcf.ornl.gov/data/index.html#data-storage-and-transfers>`_:
 
-  * ``$PROJWORK/$proj/``: shared with all members of a project, purged every 90 days (recommended)
-  * ``$MEMBERWORK/$proj/``: single user, purged every 90 days (usually smaller quota)
-  * ``$WORLDWORK/$proj/``: shared with all users, purged every 90 days
+  * ``$PROJWORK/$proj/``: shared with all members of a project, purged every 90 days, GPFS (recommended)
+  * ``$MEMBERWORK/$proj/``: single user, purged every 90 days, GPFS (usually smaller quota)
+  * ``$WORLDWORK/$proj/``: shared with all users, purged every 90 days, GPFS
+  * ``/ccs/$proj/``: another, non-GPFS, file system for software and smaller data.
   * Note that the ``$HOME`` directory is mounted as read-only on compute nodes.
     That means you cannot run in your ``$HOME``.
-  * ``/ccs/$proj/``: another, non-GPFS, file system for software and smaller data.
 
 
 Installation

--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -21,6 +21,7 @@ If you are new to this system, **please see the following resources**:
   * ``$WORLDWORK/$proj/``: shared with all users, purged every 90 days
   * Note that the ``$HOME`` directory is mounted as read-only on compute nodes.
     That means you cannot run in your ``$HOME``.
+  * ``/ccs/$proj/``: another, non-GPFS, file system for software and smaller data.
 
 
 Installation
@@ -263,6 +264,9 @@ Known System Issues
    Sep 20th, 2022 (OLCFHELP-8992):
    The above **HDF5 Jupyter read** work-around for OLCFHELP-3685 does not work anymore, due to the way that GPFS is mounted via NSF on Jupyter nodes.
    As a work-around until this is fixed, please copy your HDF5 data to ``/ccs``, ``$HOME`` or use ADIOS2 BP instead of HDF5 files.
+
+   Jan 18th, 2023:
+   The work-around above works again with GPFS data.
 
 .. warning::
 

--- a/Docs/source/install/hpc/summit.rst
+++ b/Docs/source/install/hpc/summit.rst
@@ -261,15 +261,6 @@ Known System Issues
 
 .. warning::
 
-   Sep 20th, 2022 (OLCFHELP-8992):
-   The above **HDF5 Jupyter read** work-around for OLCFHELP-3685 does not work anymore, due to the way that GPFS is mounted via NSF on Jupyter nodes.
-   As a work-around until this is fixed, please copy your HDF5 data to ``/ccs``, ``$HOME`` or use ADIOS2 BP instead of HDF5 files.
-
-   Jan 18th, 2023:
-   The work-around above works again with GPFS data.
-
-.. warning::
-
    Aug 27th, 2021 (OLCFHELP-3442):
    Created simulation files and directories are no longer accessible by your team members, even if you create them on ``$PROJWORK``.
    Setting the proper "user mask" (``umask``) does not yet work to fix this.


### PR DESCRIPTION
The issues on OLCF Jupyter to read HDF5 data from GPFS production directories have been resolved. We can use the previous work-around again and reads will not get stuck.