### PR TITLE
[WIP] Moving window: do not shift fields for electrostatic solver

### DIFF
--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -154,6 +154,10 @@ WarpX::MoveWindow (const int step, bool move_j)
     constexpr auto dont_update_cost = false; //We can't update cost for PML
 
     // Shift the mesh fields
+    // (only for electromagnetic solvers, for which the history of the
+    // fields matter ; for other solvers, the fields are recomputed from
+    // at each iteration)
+    if (electromagnetic_solver_id != ElectromagneticSolverAlgo::None) {
     for (int lev = 0; lev <= finest_level; ++lev) {
 
         if (lev > 0) {
@@ -290,6 +294,7 @@ WarpX::MoveWindow (const int step, bool move_j)
                 }
             }
         }
+    }
     }
 
     // Continuously inject plasma in new cells (by default only on level 0)


### PR DESCRIPTION
For electromagnetic solvers, we need to shift the fields with the moving window, since the fields are re-used (updated) from timestep to timestep.

However, for other solvers, the fields are recomputed from scratch. In this case, we do not need to shift the fields.

TODO: 
- [ ] Check what should be done for the hybrid PIC solver.
- [ ] Add an automated test