### PR TITLE
Cleanup: rocFFT Includes

### DIFF
--- a/Source/FieldSolver/SpectralSolver/AnyFFT.H
+++ b/Source/FieldSolver/SpectralSolver/AnyFFT.H
@@ -14,9 +14,6 @@
 #if defined(AMREX_USE_CUDA)
 #  include <cufft.h>
 #elif defined(AMREX_USE_HIP)
-// cstddef: work-around for ROCm/rocFFT <=4.3.0
-// https://github.com/ROCmSoftwarePlatform/rocFFT/blob/rocm-4.3.0/library/include/rocfft.h#L36-L42
-#  include <cstddef>
 #  if __has_include(<rocfft/rocfft.h>)  // ROCm 5.3+
 #    include <rocfft/rocfft.h>
 #  else

--- a/Source/Utils/WarpXrocfftUtil.cpp
+++ b/Source/Utils/WarpXrocfftUtil.cpp
@@ -10,9 +10,6 @@
 #include <AMReX_Config.H>
 
 #if defined(AMREX_USE_HIP) && defined(WARPX_USE_PSATD)
-// cstddef: work-around for ROCm/rocFFT <=4.3.0
-// https://github.com/ROCmSoftwarePlatform/rocFFT/blob/rocm-4.3.0/library/include/rocfft.h#L36-L42
-#  include <cstddef>
 #  if __has_include(<rocfft/rocfft.h>)  // ROCm 5.3+
 #    include <rocfft/rocfft.h>
 #  else


### PR DESCRIPTION
Newer versions fixed the include issue that required us to use `<cstddef>` includes before including rocFFT. Fixed with >4.3.

Follow-up to #3906