### PR TITLE
CI: No Draft CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
Do not run CodeQL scans on *Draft* PRs, since its code annotations can be noisy for drafts.