### PR TITLE
[WIP] Fix rho diagnostic, when mesh refinement is on

### DIFF
--- a/Source/Diagnostics/ComputeDiagFunctors/RhoFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/RhoFunctor.cpp
@@ -43,7 +43,7 @@ RhoFunctor::operator() ( amrex::MultiFab& mf_dst, const int dcomp, const int /*i
     rho_fp.resize(nlevs_max);
     rho_buf.resize(nlevs_max);
     const int ng_rho = warpx.get_ng_depos_rho().max();
-    for (int lev=0; lev<=warpx.maxLevel(); lev++) {
+    for (int lev=m_lev; lev<=warpx.maxLevel(); lev++) {
         // Allocate rho_fp
         const amrex::DistributionMapping& dm = warpx.DistributionMap(lev);
         amrex::BoxArray nba = warpx.boxArray(lev);
@@ -51,7 +51,7 @@ RhoFunctor::operator() ( amrex::MultiFab& mf_dst, const int dcomp, const int /*i
         rho_fp[lev] = std::make_unique<amrex::MultiFab>(nba,dm,WarpX::ncomps,ng_rho);
         rho_fp[lev]->setVal(0.0);
         // Allocate rho_cp
-        if (lev>0) {
+        if (lev>m_lev) {
             nba.coarsen(warpx.refRatio(lev-1));
             rho_cp[lev] = std::make_unique<amrex::MultiFab>(nba,dm,WarpX::ncomps,ng_rho);
         }
@@ -78,7 +78,7 @@ RhoFunctor::operator() ( amrex::MultiFab& mf_dst, const int dcomp, const int /*i
 
     // Handle parallel transfers of guard cells,
     // summation between levels, and filtering
-    warpx.SyncRho(rho_fp, rho_cp, rho_buf);
+    warpx.SyncRho(rho_fp, rho_cp, rho_buf, m_lev);
 
     // Select the correct level
     std::unique_ptr<amrex::MultiFab>& rho = rho_fp[m_lev];

--- a/Source/Diagnostics/ComputeDiagFunctors/RhoFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/RhoFunctor.cpp
@@ -33,8 +33,29 @@ RhoFunctor::RhoFunctor (const int lev,
 void
 RhoFunctor::operator() ( amrex::MultiFab& mf_dst, const int dcomp, const int /*i_buffer*/ ) const
 {
+    // Prepare temporary MultiFabs, in order to sum across levels
     auto& warpx = WarpX::GetInstance();
-    std::unique_ptr<amrex::MultiFab> rho;
+    const int nlevs_max = warpx.maxLevel() + 1;
+    amrex::Vector< std::unique_ptr<amrex::MultiFab> > rho_fp;
+    amrex::Vector< std::unique_ptr<amrex::MultiFab> > rho_cp;
+    amrex::Vector< std::unique_ptr<amrex::MultiFab> > rho_buf;
+    rho_cp.resize(nlevs_max);
+    rho_fp.resize(nlevs_max);
+    rho_buf.resize(nlevs_max);
+    const int ng_rho = warpx.get_ng_depos_rho().max();
+    for (int lev=0; lev<=warpx.maxLevel(); lev++) {
+        // Allocate rho_fp
+        const amrex::DistributionMapping& dm = warpx.DistributionMap(lev);
+        amrex::BoxArray nba = warpx.boxArray(lev);
+        nba.surroundingNodes();
+        rho_fp[lev] = std::make_unique<amrex::MultiFab>(nba,dm,WarpX::ncomps,ng_rho);
+        rho_fp[lev]->setVal(0.0);
+        // Allocate rho_cp
+        if (lev>0) {
+            nba.coarsen(warpx.refRatio(lev-1));
+            rho_cp[lev] = std::make_unique<amrex::MultiFab>(nba,dm,WarpX::ncomps,ng_rho);
+        }
+    }
 
     // Deposit charge density
     // Call this with local=true since the parallel transfers will be handled
@@ -43,17 +64,24 @@ RhoFunctor::operator() ( amrex::MultiFab& mf_dst, const int dcomp, const int /*i
     // Dump total rho
     if (m_species_index == -1) {
         auto& mypc = warpx.GetPartContainer();
-        rho = mypc.GetChargeDensity(m_lev, true);
+        for (int lev=m_lev; lev<=warpx.finestLevel(); lev++) {
+            rho_fp[lev] = mypc.GetChargeDensity(m_lev, true);
+        }
     }
     // Dump rho per species
     else {
         auto& mypc = warpx.GetPartContainer().GetParticleContainer(m_species_index);
-        rho = mypc.GetChargeDensity(m_lev, true);
+        for (int lev=m_lev; lev<=warpx.finestLevel(); lev++) {
+            rho_fp[lev] = mypc.GetChargeDensity(m_lev, true);
+        }
     }
 
-    // Handle the parallel transfers of guard cells and
-    // apply the filtering if requested.
-    warpx.ApplyFilterandSumBoundaryRho(m_lev, m_lev, *rho, 0, rho->nComp());
+    // Handle parallel transfers of guard cells,
+    // summation between levels, and filtering
+    warpx.SyncRho(rho_fp, rho_cp, rho_buf);
+
+    // Select the correct level
+    std::unique_ptr<amrex::MultiFab>& rho = rho_fp[m_lev];
 
 #if (defined WARPX_DIM_RZ) && (defined WARPX_USE_PSATD)
     // Apply k-space filtering when using the PSATD solver

--- a/Source/Diagnostics/ComputeDiagFunctors/RhoFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/RhoFunctor.cpp
@@ -65,14 +65,14 @@ RhoFunctor::operator() ( amrex::MultiFab& mf_dst, const int dcomp, const int /*i
     if (m_species_index == -1) {
         auto& mypc = warpx.GetPartContainer();
         for (int lev=m_lev; lev<=warpx.finestLevel(); lev++) {
-            rho_fp[lev] = mypc.GetChargeDensity(m_lev, true);
+            rho_fp[lev] = mypc.GetChargeDensity(lev, true);
         }
     }
     // Dump rho per species
     else {
         auto& mypc = warpx.GetPartContainer().GetParticleContainer(m_species_index);
         for (int lev=m_lev; lev<=warpx.finestLevel(); lev++) {
-            rho_fp[lev] = mypc.GetChargeDensity(m_lev, true);
+            rho_fp[lev] = mypc.GetChargeDensity(lev, true);
         }
     }
 

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -1024,7 +1024,8 @@ void
 WarpX::SyncRho (
     const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& charge_fp,
     const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& charge_cp,
-    const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& charge_buffer)
+    const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& charge_buffer,
+    const int bottom_level)
 {
     WARPX_PROFILE("WarpX::SyncRho()");
 
@@ -1034,7 +1035,7 @@ WarpX::SyncRho (
     // See comments in WarpX::SyncCurrent for an explanation of the algorithm.
 
     std::unique_ptr<MultiFab> mf_comm; // for communication between levels
-    for (int lev = finest_level; lev >= 0; --lev)
+    for (int lev = finest_level; lev >= bottom_level; --lev)
     {
         if (lev < finest_level)
         {
@@ -1065,7 +1066,7 @@ WarpX::SyncRho (
             ApplyFilterandSumBoundaryRho(lev+1, lev, *charge_cp[lev+1], 0, ncomp);
         }
 
-        if (lev > 0)
+        if (lev > bottom_level)
         {
             // On a fine level, we need to coarsen the data onto the coarse
             // level. This needs to be done before filtering because

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -852,7 +852,8 @@ public:
     void SyncRho (
         const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& charge_fp,
         const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& charge_cp,
-        const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& charge_buffer);
+        const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& charge_buffer,
+        const int bottom_level=0);
 
     amrex::Vector<int> getnsubsteps () const {return nsubsteps;}
     int getnsubsteps (int lev) const {return nsubsteps[lev];}


### PR DESCRIPTION
While the diagnostics for the fields E, B, J directly access the `MultiFab` used in the PIC loop, the diagnostic for `rho` instead redeposits the charge density (this is because `rho` is not always needed in the PIC loop, and is therefore not always allocated). 

However, inside the diagnostic functor that deposits `rho`, the communication across MR levels was not done properly. As a result, on the `dev` branch, the diagnostic of `rho` typically shows an empty patch (see example below, which uses [this script](https://github.com/ECP-WarpX/WarpX/blob/development/Examples/Physics_applications/laser_acceleration/inputs_2d) with `max_step=1000`). This PR fixes the issue by properly depositing the charge on each level, and by calling the function `SyncRho`.

<img width="769" alt="Screenshot 2023-07-14 at 1 46 52 PM" src="https://github.com/ECP-WarpX/WarpX/assets/6685781/72b7d2bb-1e42-4ed1-9ba1-efa43838ad21">

TODO:
- [ ] Add automated test
- [ ] Add documentation/explanation for the parameter `bottom_level`