### PR TITLE
Tools: Update Copyright String

### DIFF
--- a/Tools/DevUtils/update_copyright.sh
+++ b/Tools/DevUtils/update_copyright.sh
@@ -102,10 +102,9 @@ do
         truncate -s 0 tmp.txt
     fi
     # Write copyright
-    echo "$pattern1 Copyright $year_string $authors_list
+    echo "$pattern1 This file is part of WarpX.
 $pattern2
-$pattern2 This file is part of WarpX.
-$pattern2
+$pattern2 Authors: $authors_list
 $pattern2 License: BSD-3-Clause-LBNL$pattern3" >> tmp.txt
     # If no shebang, put first line after Copyright
     if [ "${first_line:0:2}" != "#!" ]; then


### PR DESCRIPTION
Use a modern, short version referring our license model and keep per-file authorship notes.

This tool uses the git history, so might include more people than still present.
The alternative, git blame, might exclude still present authors due to reformatting changes.