### PR TITLE
Doc: Gitter -> Discussions

### DIFF
--- a/Docs/source/index.rst
+++ b/Docs/source/index.rst
@@ -22,7 +22,7 @@ In addition, WarpX is also a *multi-platform code* and runs on Linux, macOS and 
 Contact us
 ^^^^^^^^^^
 
-If you are starting using WarpX, or if you have a user question, please pop in our `Gitter chat room <https://gitter.im/ECP-WarpX/community>`__ and get in touch with the community.
+If you are starting using WarpX, or if you have a user question, please pop in our `discussions page <https://github.com/ECP-WarpX/WarpX/discussions>`__ and get in touch with the community.
 
 The `WarpX GitHub repo <https://github.com/ECP-WarpX/WarpX>`__ is the main communication platform.
 Have a look at the action icons on the top right of the web page: feel free to watch the repo if you want to receive updates, or to star the repo to support the project.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Documentation Status](https://readthedocs.org/projects/warpx/badge/?version=latest)](https://warpx.readthedocs.io/en/latest/?badge=latest)
 [![Spack Version](https://img.shields.io/spack/v/warpx)](https://spack.readthedocs.io/en/latest/package_list.html#warpx)
 [![Conda Version](https://img.shields.io/conda/vn/conda-forge/warpx)](https://anaconda.org/conda-forge/warpx)
-[![Gitter](https://badges.gitter.im/ECP-WarpX/community.svg)](https://gitter.im/ECP-WarpX/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)  
+[![Discussions](https://img.shields.io/badge/chat-discussions-turquoise.svg)](https://github.com/ECP-WarpX/WarpX/discussions)  
 [![Supported Platforms](https://img.shields.io/badge/platforms-linux%20|%20osx%20|%20win-blue)](https://warpx.readthedocs.io/en/latest/install/users.html)
 [![GitHub commits since last release](https://img.shields.io/github/commits-since/ECP-WarpX/WarpX/latest/development.svg)](https://github.com/ECP-WarpX/WarpX/compare/development)
 [![Exascale Computing Project](https://img.shields.io/badge/supported%20by-ECP-orange)](https://www.exascaleproject.org/research/)
@@ -32,7 +32,7 @@ WarpX scales to the world's largest supercomputers and was awarded the [2022 ACM
 In order to learn how to install and run the code, please see the online documentation:
 https://warpx.readthedocs.io
 
-To contact the developers, feel free to open an issue on this repo, or visit our Gitter room at https://gitter.im/ECP-WarpX/community
+To contact the developers, feel free to open an issue on this repo, or visit our discussions page at https://github.com/ECP-WarpX/WarpX/discussions
 
 ## Contributing
 


### PR DESCRIPTION
As discussed last week, we have a hard time tracking the Gitter chat and organizing threads in it. GitHub discussions should simplify that.