### PR TITLE
Python 3.8+

### DIFF
--- a/Docs/source/developers/gnumake/python.rst
+++ b/Docs/source/developers/gnumake/python.rst
@@ -3,7 +3,7 @@
 Installing WarpX as a Python package
 ====================================
 
-A full Python installation of WarpX can be done, which includes a build of all of the C++ code, or a pure Python version can be made which only installs the Python scripts. WarpX requires Pythone version 3.7 or newer.
+A full Python installation of WarpX can be done, which includes a build of all of the C++ code, or a pure Python version can be made which only installs the Python scripts. WarpX requires Python version 3.8 or newer.
 
 For a full Python installation of WarpX
 ---------------------------------------

--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -32,7 +32,7 @@ Optional dependencies include:
 - `SENSEI 4.0.0+ <https://sensei-insitu.org>`__: for in situ analysis and visualization
 - `CCache <https://ccache.dev>`__: to speed up rebuilds (For CUDA support, needs version 3.7.9+ and 4.2+ is recommended)
 - `Ninja <https://ninja-build.org>`__: for faster parallel compiles
-- `Python 3.7+ <https://www.python.org>`__
+- `Python 3.8+ <https://www.python.org>`__
 
   - `mpi4py <https://mpi4py.readthedocs.io>`__
   - `numpy <https://numpy.org>`__

--- a/Docs/source/usage/python.rst
+++ b/Docs/source/usage/python.rst
@@ -4,7 +4,7 @@ Python (PICMI)
 ==============
 
 WarpX uses the `PICMI standard <https://github.com/picmi-standard/picmi>`__ for its Python input files.
-Python version 3.7 or newer is required.
+Python version 3.8 or newer is required.
 
 Example input files can be found in :ref:`the examples section <usage-examples>`.
 In the input file, instances of classes are created defining the various aspects of the simulation.

--- a/Python/setup.py
+++ b/Python/setup.py
@@ -60,6 +60,6 @@ setup(name = 'pywarpx',
       description = """Wrapper of WarpX""",
       package_data = package_data,
       install_requires = ['numpy', 'picmistandard==0.26.0', 'periodictable'],
-      python_requires = '>=3.7',
+      python_requires = '>=3.8',
       zip_safe=False
 )

--- a/setup.py
+++ b/setup.py
@@ -312,7 +312,7 @@ setup(
     cmdclass=cmdclass,
     # scripts=['warpx_1d', 'warpx_2d', 'warpx_rz', 'warpx_3d'],
     zip_safe=False,
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     # tests_require=['pytest'],
     install_requires=install_requires,
     # see: src/bindings/python/cli
@@ -336,10 +336,10 @@ setup(
         'Topic :: Scientific/Engineering :: Physics',
         'Programming Language :: C++',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         ('License :: OSI Approved :: '
          'BSD License'), # TODO: use real SPDX: BSD-3-Clause-LBNL
     ],


### PR DESCRIPTION
Python 3.7 went EOL last month. Time to bump up our supported versions to 3.8+ as well.