### PR TITLE
[WIP] PSATD: less radial ghost cells by default in RZ

### DIFF
--- a/Regression/Checksum/benchmarks_json/Langmuir_multi_rz_psatd.json
+++ b/Regression/Checksum/benchmarks_json/Langmuir_multi_rz_psatd.json
@@ -1,27 +1,27 @@
 {
   "electrons": {
-    "particle_momentum_x": 3.676049145834066e-36,
-    "particle_momentum_y": 1.9957106001035657e-20,
-    "particle_momentum_z": 2.781227135136398e-20,
+    "particle_momentum_x": 3.653837024804828e-36,
+    "particle_momentum_y": 1.9957106001035645e-20,
+    "particle_momentum_z": 2.781227135136404e-20,
     "particle_position_x": 0.5289997910724913,
     "particle_position_y": 0.5888,
     "particle_theta": 92488.48772168353,
     "particle_weight": 81147583679.15044
   },
   "ions": {
-    "particle_momentum_x": 2.2630624271917214e-36,
-    "particle_momentum_y": 1.5421720860618741e-21,
-    "particle_momentum_z": 1.991711267334514e-21,
+    "particle_momentum_x": 2.01346468885643e-36,
+    "particle_momentum_y": 1.542172086061881e-21,
+    "particle_momentum_z": 1.9917112673344886e-21,
     "particle_position_x": 0.529000009838682,
     "particle_position_y": 0.5888000000000001,
     "particle_theta": 92488.48772168353,
     "particle_weight": 81147583679.15044
   },
   "lev=0": {
-    "Bt": 6.638466361224547,
-    "Er": 482850037231.61615,
-    "Ez": 665616861726.1182,
-    "jr": 894824890894164.2,
-    "jz": 1250754371134110.0
+    "Bt": 6.638466361225786,
+    "Er": 482850037231.61395,
+    "Ez": 665616861726.1184,
+    "jr": 894824890894163.9,
+    "jz": 1250754371134112.8
   }
 }

--- a/Regression/Checksum/benchmarks_json/Langmuir_multi_rz_psatd_current_correction.json
+++ b/Regression/Checksum/benchmarks_json/Langmuir_multi_rz_psatd_current_correction.json
@@ -1,30 +1,29 @@
 {
   "electrons": {
-    "particle_momentum_x": 3.059978628132309e-36,
-    "particle_momentum_y": 2.003371642665396e-20,
-    "particle_momentum_z": 2.785324114261674e-20,
+    "particle_momentum_x": 2.5968237330710883e-36,
+    "particle_momentum_y": 2.003371642665405e-20,
+    "particle_momentum_z": 2.785324114261682e-20,
     "particle_position_x": 0.5290000114309512,
     "particle_position_y": 0.5888000690527484,
     "particle_theta": 92488.48772168353,
     "particle_weight": 81147583679.15044
   },
   "ions": {
-    "particle_momentum_x": 1.4925140714935799e-36,
-    "particle_momentum_y": 1.4765381278752215e-21,
-    "particle_momentum_z": 1.9505526940463635e-21,
+    "particle_momentum_x": 5.251315768361218e-37,
+    "particle_momentum_y": 1.4765381278753347e-21,
+    "particle_momentum_z": 1.950552694046297e-21,
     "particle_position_x": 0.5290000097195765,
     "particle_position_y": 0.5887999999975628,
     "particle_theta": 92488.48772168353,
     "particle_weight": 81147583679.15044
   },
   "lev=0": {
-    "Bt": 6.632261581203373,
-    "Er": 478937338832.87415,
-    "Ez": 662607529111.8489,
-    "divE": 4.355808435163123e+17,
-    "jr": 893968704248372.6,
-    "jz": 1251505252231323.8,
-    "rho": 3856714.5961512737
+    "Bt": 6.632261581206746,
+    "Er": 478937338832.88135,
+    "Ez": 662607529111.8467,
+    "divE": 4.355808435163215e+17,
+    "jr": 893968704248374.9,
+    "jz": 1251505252231281.0,
+    "rho": 3856714.596151358
   }
 }
-

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -198,21 +198,29 @@ guardCellManager::Init (
         // currents in the latter case). This does not seem to be necessary in x and y,
         // where it still seems fine to set half the number of guard cells of the nodal case.
 
-        int ngFFt_x = (grid_type == GridType::Collocated) ? nox_fft : nox_fft / 2;
-        int ngFFt_y = (grid_type == GridType::Collocated) ? noy_fft : noy_fft / 2;
-        int ngFFt_z = (grid_type == GridType::Collocated || galilean) ? noz_fft : noz_fft / 2;
+        int ngFFT_x = (grid_type == GridType::Collocated) ? nox_fft : nox_fft / 2;
+        int ngFFT_y = (grid_type == GridType::Collocated) ? noy_fft : noy_fft / 2;
+        int ngFFT_z = (grid_type == GridType::Collocated || galilean) ? noz_fft : noz_fft / 2;
 
         const ParmParse pp_psatd("psatd");
-        utils::parser::queryWithParser(pp_psatd, "nx_guard", ngFFt_x);
-        utils::parser::queryWithParser(pp_psatd, "ny_guard", ngFFt_y);
-        utils::parser::queryWithParser(pp_psatd, "nz_guard", ngFFt_z);
+        utils::parser::queryWithParser(pp_psatd, "nx_guard", ngFFT_x);
+        utils::parser::queryWithParser(pp_psatd, "ny_guard", ngFFT_y);
+        utils::parser::queryWithParser(pp_psatd, "nz_guard", ngFFT_z);
 
 #if defined(WARPX_DIM_3D)
-        IntVect ngFFT = IntVect(ngFFt_x, ngFFt_y, ngFFt_z);
-#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-        IntVect ngFFT = IntVect(ngFFt_x, ngFFt_z);
+        IntVect ngFFT = IntVect(ngFFT_x, ngFFT_y, ngFFT_z);
+#elif defined(WARPX_DIM_XZ)
+        IntVect ngFFT = IntVect(ngFFT_x, ngFFT_z);
+#elif defined(WARPX_DIM_RZ)
+        // In RZ geometry, no domain decomposition along r,
+        // no need to account for extent of spectral stencil
+        int ngFFT_r = std::max(ng_alloc_EB[0], ng_alloc_J[0]);
+        ngFFT_r = std::max(ngFFT_r, ng_alloc_Rho[0]);
+        ngFFT_r = std::max(ngFFT_r, ng_alloc_F[0]);
+        ngFFT_r = std::max(ngFFT_r, ng_alloc_G[0]);
+        IntVect ngFFT = IntVect(ngFFT_r, ngFFT_z);
 #elif defined(WARPX_DIM_1D_Z)
-        IntVect ngFFT = IntVect(ngFFt_z);
+        IntVect ngFFT = IntVect(ngFFT_z);
 #endif
 
 #ifdef WARPX_DIM_RZ


### PR DESCRIPTION
In RZ geometry, there is no domain decomposition along r, hence no need to account for the extent of the spectral stencil along that direction. Note that some variables were also renamed from `ngFFt_...` to `ngFFT_...`, the lower-case `t` looked like a typo.

@RemiLehe @dpgrote 
Is this what you had in mind?