### PR TITLE
CPU CI: Always Serialize

### DIFF
--- a/Regression/WarpX-tests.ini
+++ b/Regression/WarpX-tests.ini
@@ -317,7 +317,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [Deuterium_Deuterium_Fusion_3D]
 buildDir = .
 inputFile = Examples/Tests/nuclear_fusion/inputs_deuterium_deuterium_3d
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+runtime_params =
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3
@@ -333,7 +333,7 @@ analysisRoutine = Examples/Tests/nuclear_fusion/analysis_two_product_fusion.py
 [Deuterium_Deuterium_Fusion_3D_intraspecies]
 buildDir = .
 inputFile = Examples/Tests/nuclear_fusion/inputs_deuterium_deuterium_3d_intraspecies
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+runtime_params =
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3
@@ -349,7 +349,7 @@ analysisRoutine = Examples/Tests/nuclear_fusion/analysis_deuterium_deuterium_3d_
 [Deuterium_Tritium_Fusion_3D]
 buildDir = .
 inputFile = Examples/Tests/nuclear_fusion/inputs_deuterium_tritium_3d
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+runtime_params =
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3
@@ -365,7 +365,7 @@ analysisRoutine = Examples/Tests/nuclear_fusion/analysis_two_product_fusion.py
 [Deuterium_Tritium_Fusion_RZ]
 buildDir = .
 inputFile = Examples/Tests/nuclear_fusion/inputs_deuterium_tritium_rz
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 warpx.abort_on_warning_threshold=high
+runtime_params = warpx.abort_on_warning_threshold=high
 dim = 2
 addToCompileString = USE_RZ=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=RZ
@@ -426,7 +426,7 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 0
-runtime_params = warpx.do_dynamic_scheduling=0 geometry.dims=2
+runtime_params = geometry.dims=2
 analysisRoutine = Examples/Tests/dive_cleaning/analysis.py
 analysisOutputImage = Comparison.png
 
@@ -444,7 +444,7 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 0
-runtime_params = warpx.do_dynamic_scheduling=0
+runtime_params =
 analysisRoutine = Examples/Tests/dive_cleaning/analysis.py
 analysisOutputImage = Comparison.png
 
@@ -887,7 +887,7 @@ analysisRoutine = Examples/Tests/nci_psatd_stability/analysis_galilean.py
 [galilean_rz_psatd]
 buildDir = .
 inputFile = Examples/Tests/nci_psatd_stability/inputs_rz
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 electrons.random_theta=0 ions.random_theta=0 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
+runtime_params = electrons.random_theta=0 ions.random_theta=0 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE BLAS_LIB=-lblas LAPACK_LIB=-llapack
 cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
@@ -1013,7 +1013,7 @@ analysisRoutine = Examples/Tests/AcceleratorLattice/analysis.py
 [initial_distribution]
 buildDir = .
 inputFile = Examples/Tests/initial_distribution/inputs
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+runtime_params =
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3
@@ -1080,7 +1080,7 @@ analysisRoutine = Examples/Tests/ion_stopping/analysis_ion_stopping.py
 [Langmuir_multi]
 buildDir = .
 inputFile = Examples/Tests/langmuir/inputs_3d
-runtime_params = warpx.do_dynamic_scheduling=0
+runtime_params =
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3
@@ -1099,7 +1099,7 @@ analysisOutputImage = langmuir_multi_analysis.png
 [Langmuir_fluid_1D]
 buildDir = .
 inputFile = Examples/Tests/langmuir_fluids/inputs_1d
-runtime_params = warpx.do_dynamic_scheduling=0
+runtime_params =
 dim = 1
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=1
@@ -1117,7 +1117,7 @@ analysisOutputImage = langmuir_fluid_multi_1d_analysis.png
 [Langmuir_fluid_RZ]
 buildDir = .
 inputFile = Examples/Tests/langmuir_fluids/inputs_rz
-runtime_params = warpx.do_dynamic_scheduling=0
+runtime_params =
 dim = 2
 addToCompileString = USE_RZ=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=RZ
@@ -1135,7 +1135,7 @@ analysisOutputImage = langmuir_fluid_rz_analysis.png
 [Langmuir_fluid_2D]
 buildDir = .
 inputFile = Examples/Tests/langmuir_fluids/inputs_2d
-runtime_params = warpx.do_dynamic_scheduling=0
+runtime_params =
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2 -DCMAKE_BUILD_TYPE=Debug
@@ -1153,7 +1153,7 @@ analysisOutputImage = langmuir_fluid_multi_2d_analysis.png
 [Langmuir_fluid_multi]
 buildDir = .
 inputFile = Examples/Tests/langmuir_fluids/inputs_3d
-runtime_params = warpx.do_dynamic_scheduling=0
+runtime_params =
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3
@@ -1456,7 +1456,7 @@ analysisOutputImage = langmuir_multi_2d_analysis.png
 [Langmuir_multi_nodal]
 buildDir = .
 inputFile = Examples/Tests/langmuir/inputs_3d
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.grid_type=collocated algo.current_deposition=direct
+runtime_params = warpx.grid_type=collocated algo.current_deposition=direct
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3
@@ -1608,7 +1608,7 @@ analysisOutputImage = Langmuir_multi_psatd_multiJ_nodal.png
 [Langmuir_multi_psatd_nodal]
 buildDir = .
 inputFile = Examples/Tests/langmuir/inputs_3d
-runtime_params = algo.maxwell_solver=psatd warpx.do_dynamic_scheduling=0 warpx.grid_type=collocated algo.current_deposition=direct warpx.cfl = 0.5773502691896258 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
+runtime_params = algo.maxwell_solver=psatd warpx.grid_type=collocated algo.current_deposition=direct warpx.cfl = 0.5773502691896258 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
@@ -1764,7 +1764,7 @@ aux1File = Regression/PostProcessingUtils/post_processing_utils.py
 [Langmuir_multi_single_precision]
 buildDir = .
 inputFile = Examples/Tests/langmuir/inputs_3d
-runtime_params = warpx.do_dynamic_scheduling=0
+runtime_params =
 dim = 3
 addToCompileString = PRECISION=FLOAT USE_SINGLE_PRECISION_PARTICLES=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PRECISION=SINGLE
@@ -1871,7 +1871,7 @@ analysisRoutine = Examples/Physics_applications/laser_acceleration/analysis_1d_f
 [LaserAccelerationBoost]
 buildDir = .
 inputFile = Examples/Physics_applications/laser_acceleration/inputs_2d_boost
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 amr.n_cell=64 512 max_step=300
+runtime_params = amr.n_cell=64 512 max_step=300
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -1996,7 +1996,7 @@ analysisOutputImage = laser_analysis.png
 [LaserInjection_1d]
 buildDir = .
 inputFile = Examples/Tests/laser_injection/inputs_1d_rt
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+runtime_params =
 dim = 1
 addToCompileString = USE_OPENPMD=TRUE QED=FALSE
 cmakeSetupOpts = -DWarpX_DIMS=1 -DWarpX_OPENPMD=ON -DWarpX_QED=OFF
@@ -2013,7 +2013,7 @@ analysisRoutine = Examples/Tests/laser_injection/analysis_1d.py
 [LaserInjection_2d]
 buildDir = .
 inputFile = Examples/Tests/laser_injection/inputs_2d_rt
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+runtime_params =
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -2032,7 +2032,7 @@ buildDir = .
 inputFile = Examples/Tests/laser_injection_from_file/analysis_2d_binary.py
 aux1File = Examples/Tests/laser_injection_from_file/inputs.2d_test_binary
 customRunCmd = ./analysis_2d_binary.py
-runtime_params = warpx.do_dynamic_scheduling=0
+runtime_params =
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -2051,7 +2051,7 @@ buildDir = .
 inputFile = Examples/Tests/laser_injection_from_file/analysis_3d.py
 aux1File = Examples/Tests/laser_injection_from_file/inputs.3d_test
 customRunCmd = ./analysis_3d.py
-runtime_params = warpx.do_dynamic_scheduling=0
+runtime_params =
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3
@@ -2070,7 +2070,7 @@ buildDir = .
 inputFile = Examples/Tests/laser_injection_from_file/analysis_1d.py
 aux1File = Examples/Tests/laser_injection_from_file/inputs.1d_test
 customRunCmd = ./analysis_1d.py
-runtime_params = warpx.do_dynamic_scheduling=0
+runtime_params =
 dim = 1
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=1
@@ -2089,7 +2089,7 @@ buildDir = .
 inputFile = Examples/Tests/laser_injection_from_file/analysis_1d_boost.py
 aux1File = Examples/Tests/laser_injection_from_file/inputs.1d_boost_test
 customRunCmd = ./analysis_1d_boost.py
-runtime_params = warpx.do_dynamic_scheduling=0
+runtime_params =
 dim = 1
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=1
@@ -2108,7 +2108,7 @@ buildDir = .
 inputFile = Examples/Tests/laser_injection_from_file/analysis_2d.py
 aux1File = Examples/Tests/laser_injection_from_file/inputs.2d_test
 customRunCmd = ./analysis_2d.py
-runtime_params = warpx.do_dynamic_scheduling=0
+runtime_params =
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -2127,7 +2127,7 @@ buildDir = .
 inputFile = Examples/Tests/laser_injection_from_file/analysis_RZ.py
 aux1File = Examples/Tests/laser_injection_from_file/inputs.RZ_test
 customRunCmd = ./analysis_RZ.py
-runtime_params = warpx.do_dynamic_scheduling=0
+runtime_params =
 dim = 2
 addToCompileString = USE_RZ=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=RZ
@@ -2146,7 +2146,7 @@ buildDir = .
 inputFile = Examples/Tests/laser_injection_from_file/analysis_from_RZ_file.py
 aux1File = Examples/Tests/laser_injection_from_file/inputs.from_RZ_file_test
 customRunCmd = ./analysis_from_RZ_file.py
-runtime_params = warpx.do_dynamic_scheduling=0
+runtime_params =
 dim = 2
 addToCompileString = USE_RZ=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=RZ
@@ -2163,7 +2163,7 @@ doVis = 0
 [LaserIonAcc2d]
 buildDir = .
 inputFile = Examples/Physics_applications/laser_ion/inputs
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 amr.n_cell=384 512 max_step=100
+runtime_params = amr.n_cell=384 512 max_step=100
 dim = 2
 addToCompileString = USE_OPENPMD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_OPENPMD=ON
@@ -2263,7 +2263,7 @@ analysisRoutine = Examples/Tests/maxwell_hybrid_qed/analysis_Maxwell_QED_Hybrid.
 [momentum-conserving-gather]
 buildDir = .
 inputFile = Examples/Physics_applications/plasma_acceleration/inputs_2d
-runtime_params = amr.max_level=1 amr.n_cell=32 512 max_step=400 warpx.serialize_initial_conditions=1 warpx.do_dynamic_scheduling=0 algo.field_gathering=momentum-conserving
+runtime_params = amr.max_level=1 amr.n_cell=32 512 max_step=400 algo.field_gathering=momentum-conserving
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -2281,7 +2281,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [multi_J_rz_psatd]
 buildDir = .
 inputFile = Examples/Tests/multi_j/inputs_rz
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 warpx.abort_on_warning_threshold=medium psatd.J_in_time=linear
+runtime_params = warpx.abort_on_warning_threshold=medium psatd.J_in_time=linear
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
@@ -2344,7 +2344,7 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 0
-runtime_params = warpx.do_dynamic_scheduling=0
+runtime_params =
 analysisRoutine = Examples/Tests/initial_plasma_profile/analysis.py
 
 [particle_absorption]
@@ -2386,7 +2386,7 @@ analysisRoutine = Examples/Tests/boundaries/analysis.py
 buildDir = .
 inputFile = Examples/Tests/particle_fields_diags/inputs
 aux1File = Examples/Tests/particle_fields_diags/analysis_particle_diags_impl.py
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+runtime_params =
 dim = 3
 addToCompileString = USE_OPENPMD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_OPENPMD=ON
@@ -2404,7 +2404,7 @@ analysisRoutine = Examples/Tests/particle_fields_diags/analysis_particle_diags.p
 buildDir = .
 inputFile = Examples/Tests/particle_fields_diags/inputs
 aux1File = Examples/Tests/particle_fields_diags/analysis_particle_diags_impl.py
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+runtime_params =
 dim = 3
 addToCompileString = PRECISION=FLOAT USE_SINGLE_PRECISION_PARTICLES=TRUE USE_OPENPMD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PRECISION=SINGLE -DWarpX_OPENPMD=ON
@@ -2701,7 +2701,7 @@ analysisRoutine = Examples/Tests/photon_pusher/analysis_photon_pusher.py
 [PlasmaAccelerationBoost2d]
 buildDir = .
 inputFile = Examples/Physics_applications/plasma_acceleration/inputs_2d_boost
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 amr.n_cell=64 256 max_step=20
+runtime_params = amr.n_cell=64 256 max_step=20
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -2717,7 +2717,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [PlasmaAccelerationBoost3d]
 buildDir = .
 inputFile = Examples/Physics_applications/plasma_acceleration/inputs_3d_boost
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 amr.n_cell=64 64 128 max_step=5
+runtime_params = amr.n_cell=64 64 128 max_step=5
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3
@@ -2733,7 +2733,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [PlasmaAccelerationBoost3d_hybrid]
 buildDir = .
 inputFile = Examples/Physics_applications/plasma_acceleration/inputs_3d_boost
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 amr.n_cell=64 64 128 max_step=25 warpx.grid_type=hybrid warpx.do_current_centering=0
+runtime_params = amr.n_cell=64 64 128 max_step=25 warpx.grid_type=hybrid warpx.do_current_centering=0
 dim = 3
 addToCompileString =
 restartTest = 0
@@ -2748,7 +2748,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [PlasmaAccelerationMR]
 buildDir = .
 inputFile = Examples/Physics_applications/plasma_acceleration/inputs_2d
-runtime_params = amr.max_level=1 amr.n_cell=32 512 max_step=400 warpx.serialize_initial_conditions=1 warpx.do_dynamic_scheduling=0
+runtime_params = amr.max_level=1 amr.n_cell=32 512 max_step=400
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -2820,7 +2820,7 @@ analysisRoutine = Examples/Tests/plasma_lens/analysis.py
 [PlasmaMirror]
 buildDir = .
 inputFile = Examples/Physics_applications/plasma_mirror/inputs_2d
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 amr.n_cell=256 128 max_step=20
+runtime_params = amr.n_cell=256 128 max_step=20
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -2852,7 +2852,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [pml_psatd_rz]
 buildDir = .
 inputFile = Examples/Tests/pml/inputs_rz
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 warpx.cfl=0.7 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
+runtime_params = warpx.cfl=0.7 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 2
 addToCompileString = USE_RZ=TRUE USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=RZ -DWarpX_PSATD=ON
@@ -2868,7 +2868,7 @@ analysisRoutine = Examples/Tests/pml/analysis_pml_psatd_rz.py
 [pml_x_ckc]
 buildDir = .
 inputFile = Examples/Tests/pml/inputs_2d
-runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_solver=ckc
+runtime_params = algo.maxwell_solver=ckc
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -2884,7 +2884,7 @@ analysisRoutine = Examples/Tests/pml/analysis_pml_ckc.py
 [pml_x_galilean]
 buildDir = .
 inputFile = Examples/Tests/pml/inputs_2d
-runtime_params = algo.maxwell_solver=psatd psatd.update_with_rho=1 warpx.do_dynamic_scheduling=0 diag1.fields_to_plot=Ex Ey Ez Bx By Bz rho divE warpx.cfl=0.7071067811865475 warpx.do_pml_dive_cleaning=1 warpx.do_pml_divb_cleaning=1 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium psatd.v_galilean=0. 0. 0.99 warpx.grid_type=collocated
+runtime_params = algo.maxwell_solver=psatd psatd.update_with_rho=1 diag1.fields_to_plot=Ex Ey Ez Bx By Bz rho divE warpx.cfl=0.7071067811865475 warpx.do_pml_dive_cleaning=1 warpx.do_pml_divb_cleaning=1 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium psatd.v_galilean=0. 0. 0.99 warpx.grid_type=collocated
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -2900,7 +2900,7 @@ analysisRoutine = Examples/Tests/pml/analysis_pml_psatd.py
 [pml_x_psatd]
 buildDir = .
 inputFile = Examples/Tests/pml/inputs_2d
-runtime_params = algo.maxwell_solver=psatd psatd.update_with_rho=1 warpx.do_dynamic_scheduling=0 diag1.fields_to_plot = Ex Ey Ez Bx By Bz rho divE warpx.cfl = 0.7071067811865475 warpx.do_pml_dive_cleaning=0 warpx.do_pml_divb_cleaning=0 chk.file_prefix=pml_x_psatd_chk chk.file_min_digits=5 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
+runtime_params = algo.maxwell_solver=psatd psatd.update_with_rho=1 diag1.fields_to_plot = Ex Ey Ez Bx By Bz rho divE warpx.cfl = 0.7071067811865475 warpx.do_pml_dive_cleaning=0 warpx.do_pml_divb_cleaning=0 chk.file_prefix=pml_x_psatd_chk chk.file_min_digits=5 psatd.current_correction=0 warpx.abort_on_warning_threshold=medium
 dim = 2
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_PSATD=ON
@@ -2917,7 +2917,7 @@ analysisRoutine = Examples/Tests/pml/analysis_pml_psatd.py
 [pml_x_yee]
 buildDir = .
 inputFile = Examples/Tests/pml/inputs_2d
-runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_solver=yee chk.file_prefix=pml_x_yee_chk chk.file_min_digits=5
+runtime_params = algo.maxwell_solver=yee chk.file_prefix=pml_x_yee_chk chk.file_min_digits=5
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -2934,7 +2934,7 @@ analysisRoutine = Examples/Tests/pml/analysis_pml_yee.py
 [pml_x_yee_eb]
 buildDir = .
 inputFile = Examples/Tests/pml/inputs_2d
-runtime_params = warpx.do_dynamic_scheduling=0 algo.maxwell_solver=yee chk.file_prefix=pml_x_yee_eb_chk chk.file_min_digits=5
+runtime_params = algo.maxwell_solver=yee chk.file_prefix=pml_x_yee_eb_chk chk.file_min_digits=5
 dim = 2
 addToCompileString = USE_EB=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_EB=ON
@@ -2951,7 +2951,7 @@ analysisRoutine = Examples/Tests/pml/analysis_pml_yee.py
 [Proton_Boron_Fusion_2D]
 buildDir = .
 inputFile = Examples/Tests/nuclear_fusion/inputs_proton_boron_2d
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+runtime_params =
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -2967,7 +2967,7 @@ analysisRoutine = Examples/Tests/nuclear_fusion/analysis_proton_boron_fusion.py
 [Proton_Boron_Fusion_3D]
 buildDir = .
 inputFile = Examples/Tests/nuclear_fusion/inputs_proton_boron_3d
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+runtime_params =
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3
@@ -3706,7 +3706,7 @@ analysisRoutine = Examples/analysis_default_regression.py
 [Python_reduced_diags_loadbalancecosts_timers]
 buildDir = .
 inputFile = Examples/Tests/reduced_diags/PICMI_inputs_loadbalancecosts.py
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 algo.load_balance_costs_update=Timers
+runtime_params = algo.load_balance_costs_update=Timers
 customRunCmd = python3 PICMI_inputs_loadbalancecosts.py
 dim = 3
 addToCompileString = USE_PYTHON_MAIN=TRUE
@@ -3975,7 +3975,7 @@ analysisRoutine =  Examples/Tests/radiation_reaction/test_const_B_analytical/ana
 buildDir = .
 inputFile = Examples/Tests/reduced_diags/inputs
 aux1File = Examples/Tests/reduced_diags/analysis_reduced_diags_impl.py
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+runtime_params =
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3
@@ -3992,7 +3992,7 @@ analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags.py
 [reduced_diags_loadbalancecosts_heuristic]
 buildDir = .
 inputFile = Examples/Tests/reduced_diags/inputs_loadbalancecosts
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 algo.load_balance_costs_update=Heuristic
+runtime_params = algo.load_balance_costs_update=Heuristic
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3
@@ -4009,7 +4009,7 @@ analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_loadbalanc
 [reduced_diags_loadbalancecosts_timers]
 buildDir = .
 inputFile = Examples/Tests/reduced_diags/inputs_loadbalancecosts
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 algo.load_balance_costs_update=Timers
+runtime_params = algo.load_balance_costs_update=Timers
 dim = 3
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=3
@@ -4026,7 +4026,7 @@ analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_loadbalanc
 [reduced_diags_loadbalancecosts_timers_psatd]
 buildDir = .
 inputFile = Examples/Tests/reduced_diags/inputs_loadbalancecosts
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1 algo.load_balance_costs_update=Timers
+runtime_params = algo.load_balance_costs_update=Timers
 dim = 3
 addToCompileString = USE_PSATD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PSATD=ON
@@ -4044,7 +4044,7 @@ analysisRoutine = Examples/Tests/reduced_diags/analysis_reduced_diags_loadbalanc
 buildDir = .
 inputFile = Examples/Tests/reduced_diags/inputs
 aux1File = Examples/Tests/reduced_diags/analysis_reduced_diags_impl.py
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+runtime_params =
 dim = 3
 addToCompileString = PRECISION=FLOAT USE_SINGLE_PRECISION_PARTICLES=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=3 -DWarpX_PRECISION=SINGLE
@@ -4090,7 +4090,7 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 0
-runtime_params = warpx.do_dynamic_scheduling=0
+runtime_params =
 analysisRoutine = Examples/Tests/relativistic_space_charge_initialization/analysis.py
 analysisOutputImage = Comparison.png
 
@@ -4170,7 +4170,7 @@ analysisRoutine = Examples/Tests/restart/analysis_restart.py
 [RigidInjection_BTD]
 buildDir = .
 inputFile = Examples/Tests/rigid_injection/inputs_2d_BoostedFrame
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+runtime_params =
 dim = 2
 addToCompileString = USE_OPENPMD=TRUE
 cmakeSetupOpts = -DWarpX_DIMS=2 -DWarpX_OPENPMD=ON
@@ -4188,7 +4188,7 @@ analysisRoutine = Examples/Tests/rigid_injection/analysis_rigid_injection_Booste
 [RigidInjection_lab]
 buildDir = .
 inputFile = Examples/Tests/rigid_injection/inputs_2d_LabFrame
-runtime_params = warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1
+runtime_params =
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2
@@ -4297,7 +4297,7 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 0
-runtime_params = warpx.do_dynamic_scheduling=0
+runtime_params =
 analysisRoutine = Examples/Tests/space_charge_initialization/analysis.py
 analysisOutputImage = Comparison.png
 
@@ -4315,14 +4315,14 @@ numthreads = 1
 compileTest = 0
 doVis = 0
 compareParticles = 0
-runtime_params = warpx.do_dynamic_scheduling=0 geometry.dims=2
+runtime_params = geometry.dims=2
 analysisRoutine = Examples/Tests/space_charge_initialization/analysis.py
 analysisOutputImage = Comparison.png
 
 [subcyclingMR]
 buildDir = .
 inputFile = Examples/Tests/subcycling/inputs_2d
-runtime_params = warpx.serialize_initial_conditions=1 warpx.do_dynamic_scheduling=0
+runtime_params =
 dim = 2
 addToCompileString =
 cmakeSetupOpts = -DWarpX_DIMS=2

--- a/Regression/prepare_file_ci.py
+++ b/Regression/prepare_file_ci.py
@@ -62,7 +62,7 @@ if ci_psatd:
     text = re.sub('USE_PSATD=FALSE',
                   '', text)
 
-# Ccache
+# CCache
 if ci_ccache:
     text = re.sub('addToCompileString =',
                   'addToCompileString = USE_CCACHE=TRUE ', text)
@@ -76,6 +76,14 @@ text = re.sub('runtime_params =',
               'amrex.fpe_trap_invalid=1 amrex.fpe_trap_zero=1 amrex.fpe_trap_overflow=1 '+
               'warpx.always_warn_immediately=1 warpx.abort_on_warning_threshold=low',
               text)
+
+# Add runtime options for CPU:
+# > serialize initial conditions and no dynamic scheduling in OpenMP
+if arch == 'CPU':
+    text = re.sub('runtime_params =',
+                  'runtime_params = '+
+                  'warpx.do_dynamic_scheduling=0 warpx.serialize_initial_conditions=1',
+                  text)
 
 # Use less/more cores for compiling, e.g. public CI only provides 2 cores
 if ci_num_make_jobs is not None:


### PR DESCRIPTION
Always add
- `warpx.do_dynamic_scheduling=0`
- `warpx.serialize_initial_conditions=1`

to CPU CI jobs, so we cannot forget it when it matters (e.g., random numbers in distributions).