### PR TITLE
Fix: Pre-Installed AMReX w/ CUDA

### DIFF
--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -257,6 +257,10 @@ macro(find_amrex)
         list(APPEND CMAKE_MODULE_PATH "${AMReX_DIR}/AMReXCMakeModules")
 
         message(STATUS "AMReX: Found version '${AMReX_VERSION}'")
+
+        if(WarpX_COMPUTE STREQUAL CUDA)
+            enable_language(CUDA)
+        endif()
     endif()
 endmacro()
 


### PR DESCRIPTION
Fix CMake language activation with pre-installed AMReX using the CUDA backend.

CMake configure error was:
```
...
-- pyAMReX: Found version '24.02'
-- Found Git: /usr/bin/git (found version "2.34.1") 
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY - Success
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY - Success
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success

CMake Error at CMakeLists.txt:461 (target_compile_features):
  target_compile_features no known features for CUDA compiler
  ""
  version .
...
```

Related to https://github.com/AMReX-Codes/pyamrex/issues/252