### PR TITLE
Evolve Loop: Simplify

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -70,9 +70,6 @@ WarpX::Evolve (int numsteps)
     // Note that the default argument is numsteps = -1
     const int numsteps_max = (numsteps < 0)?(max_step):(istep[0] + numsteps);
 
-    bool early_params_checked = false; // check typos in inputs after step 1
-    bool exit_loop_due_to_interrupt_signal = false;
-
     static Real evolve_time = 0;
 
     const int step_begin = istep[0];
@@ -81,7 +78,7 @@ WarpX::Evolve (int numsteps)
         WARPX_PROFILE("WarpX::Evolve::step");
         const auto evolve_time_beg_step = static_cast<Real>(amrex::second());
 
-        //Check and clear signal flags and asynchronously broadcast them from process 0
+        // Check and clear signal flags and asynchronously broadcast them from process 0
         SignalHandling::CheckSignals();
 
         multi_diags->NewIteration();
@@ -92,90 +89,29 @@ WarpX::Evolve (int numsteps)
         }
         ExecutePythonCallback("beforestep");
 
-        amrex::LayoutData<amrex::Real>* cost = WarpX::getCosts(0);
-        if (cost) {
-            if (step > 0 && load_balance_intervals.contains(step+1))
-            {
-                LoadBalance();
+        CheckLoadBalance(step);
 
-                // Reset the costs to 0
-                ResetCosts();
-            }
-            for (int lev = 0; lev <= finest_level; ++lev)
-            {
-                cost = WarpX::getCosts(lev);
-                if (cost && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
-                {
-                    // Perform running average of the costs
-                    // (Giving more importance to most recent costs; only needed
-                    // for timers update, heuristic load balance considers the
-                    // instantaneous costs)
-                    for (const auto& i : cost->IndexArray())
-                    {
-                        (*cost)[i] *= (1._rt - 2._rt/load_balance_intervals.localPeriod(step+1));
-                    }
-                }
-            }
-        }
-
-        if (evolve_scheme == EvolveScheme::Explicit) {
-            // At the beginning, we have B^{n} and E^{n}.
-            // Particles have p^{n} and x^{n}.
-            // is_synchronized is true.
-
-            if (is_synchronized) {
-                // Not called at each iteration, so exchange all guard cells
-                FillBoundaryE(guard_cells.ng_alloc_EB);
-                FillBoundaryB(guard_cells.ng_alloc_EB);
-
-                UpdateAuxilaryData();
-                FillBoundaryAux(guard_cells.ng_UpdateAux);
-                // on first step, push p by -0.5*dt
-                for (int lev = 0; lev <= finest_level; ++lev)
-                {
-                    mypc->PushP(lev, -0.5_rt*dt[lev],
-                                *Efield_aux[lev][0],*Efield_aux[lev][1],*Efield_aux[lev][2],
-                                *Bfield_aux[lev][0],*Bfield_aux[lev][1],*Bfield_aux[lev][2]);
-                }
-                is_synchronized = false;
-
-            } else {
-                // Beyond one step, we have E^{n} and B^{n}.
-                // Particles have p^{n-1/2} and x^{n}.
-                // E and B: enough guard cells to update Aux or call Field Gather in fp and cp
-                // Need to update Aux on lower levels, to interpolate to higher levels.
-
-                // E and B are up-to-date inside the domain only
-                FillBoundaryE(guard_cells.ng_FieldGather);
-                FillBoundaryB(guard_cells.ng_FieldGather);
-                if (electrostatic_solver_id == ElectrostaticSolverAlgo::None) {
-                    if (fft_do_time_averaging)
-                    {
-                        FillBoundaryE_avg(guard_cells.ng_FieldGather);
-                        FillBoundaryB_avg(guard_cells.ng_FieldGather);
-                    }
-                    // TODO Remove call to FillBoundaryAux before UpdateAuxilaryData?
-                    if (WarpX::electromagnetic_solver_id != ElectromagneticSolverAlgo::PSATD) {
-                        FillBoundaryAux(guard_cells.ng_UpdateAux);
-                    }
-                }
-                UpdateAuxilaryData();
-                FillBoundaryAux(guard_cells.ng_UpdateAux);
-            }
+        if (evolve_scheme == EvolveScheme::Explicit)
+        {
+            ExplicitEBUpdate();
         }
 
         // If needed, deposit the initial ion charge and current densities that
         // will be used to update the E-field in Ohm's law.
         if (step == step_begin &&
             electromagnetic_solver_id == ElectromagneticSolverAlgo::HybridPIC
-        ) { HybridPICDepositInitialRhoAndJ(); }
+        ) {
+            HybridPICDepositInitialRhoAndJ();
+        }
 
         // Run multi-physics modules:
         // ionization, Coulomb collisions, QED
         doFieldIonization();
+
         ExecutePythonCallback("beforecollisions");
         mypc->doCollisions( cur_time, dt[0] );
         ExecutePythonCallback("aftercollisions");
+
 #ifdef WARPX_QED
         doQEDEvents();
         mypc->doQEDSchwinger();
@@ -186,6 +122,7 @@ WarpX::Evolve (int numsteps)
 
         ExecutePythonCallback("particleinjection");
 
+        // TOOD: move out
         if (evolve_scheme == EvolveScheme::ImplicitPicard ||
             evolve_scheme == EvolveScheme::SemiImplicitPicard) {
             OneStep_ImplicitPicard(cur_time);
@@ -229,12 +166,13 @@ WarpX::Evolve (int numsteps)
         mypc->doResampling(istep[0]+1, verbose);
 
         if (evolve_scheme == EvolveScheme::Explicit) {
-            if (num_mirrors>0){
-                applyMirrors(cur_time);
-                // E : guard cells are NOT up-to-date
-                // B : guard cells are NOT up-to-date
-            }
+            applyMirrors(cur_time);
+            // E : guard cells are NOT up-to-date
+            // B : guard cells are NOT up-to-date
+        }
 
+        // TODO: move out
+        if (evolve_scheme == EvolveScheme::Explicit) {
             if (cur_time + dt[0] >= stop_time - 1.e-3*dt[0] || step == numsteps_max-1) {
                 // At the end of last step, push p by 0.5*dt to synchronize
                 FillBoundaryE(guard_cells.ng_FieldGather);
@@ -284,49 +222,7 @@ WarpX::Evolve (int numsteps)
             }
         }
 
-        mypc->ContinuousFluxInjection(cur_time, dt[0]);
-
-        mypc->ApplyBoundaryConditions();
-
-        // interact the particles with EB walls (if present)
-#ifdef AMREX_USE_EB
-        mypc->ScrapeParticles(amrex::GetVecOfConstPtrs(m_distance_to_eb));
-#endif
-
-        m_particle_boundary_buffer->gatherParticles(*mypc, amrex::GetVecOfConstPtrs(m_distance_to_eb));
-
-        // Non-Maxwell solver: particles can move by an arbitrary number of cells
-        if( electromagnetic_solver_id == ElectromagneticSolverAlgo::None ||
-            electromagnetic_solver_id == ElectromagneticSolverAlgo::HybridPIC )
-        {
-            mypc->Redistribute();
-        }
-        else
-        {
-            // Electromagnetic solver: due to CFL condition, particles can
-            // only move by one or two cells per time step
-            if (max_level == 0) {
-                int num_redistribute_ghost = num_moved;
-                if ((m_v_galilean[0]!=0) or (m_v_galilean[1]!=0) or (m_v_galilean[2]!=0)) {
-                    // Galilean algorithm ; particles can move by up to 2 cells
-                    num_redistribute_ghost += 2;
-                } else {
-                    // Standard algorithm ; particles can move by up to 1 cell
-                    num_redistribute_ghost += 1;
-                }
-                mypc->RedistributeLocal(num_redistribute_ghost);
-            }
-            else {
-                mypc->Redistribute();
-            }
-        }
-
-        if (sort_intervals.contains(step+1)) {
-            if (verbose) {
-                amrex::Print() << Utils::TextMsg::Info("re-sorting particles");
-            }
-            mypc->SortParticlesByBin(sort_bin_size);
-        }
+        InjectRedistributeScapeParticles(step, cur_time, num_moved);
 
         // Field solve step for electrostatic or hybrid-PIC solvers
         if( electrostatic_solver_id != ElectrostaticSolverAlgo::None ||
@@ -377,15 +273,7 @@ WarpX::Evolve (int numsteps)
         ExecutePythonCallback("afterdiagnostics");
 
         // inputs: unused parameters (e.g. typos) check after step 1 has finished
-        if (!early_params_checked) {
-            amrex::Print() << "\n"; // better: conditional \n based on return value
-            amrex::ParmParse::QueryUnusedInputs();
-
-            //Print the warning list right after the first step.
-            amrex::Print() <<
-                ablastr::warn_manager::GetWMInstance().PrintGlobalWarnings("FIRST STEP");
-            early_params_checked = true;
-        }
+        checkEarlyUnusedParams();
 
         // create ending time stamp for calculating elapsed time each iteration
         const auto evolve_time_end_step = static_cast<Real>(amrex::second());
@@ -401,20 +289,18 @@ WarpX::Evolve (int numsteps)
                       << " s; Avg. per step = " << evolve_time/(step-step_begin+1) << " s\n\n";
         }
 
-        exit_loop_due_to_interrupt_signal = SignalHandling::TestAndResetActionRequestFlag(SignalHandling::SIGNAL_REQUESTS_BREAK);
-        if (cur_time >= stop_time - 1.e-3*dt[0] || exit_loop_due_to_interrupt_signal) {
+        if (checkStopSimulation(cur_time)) {
             break;
         }
+    } // End loop on time steps
 
-        // End loop on time steps
-    }
     // This if statement is needed for PICMI, which allows the Evolve routine to be
     // called multiple times, otherwise diagnostics will be done at every call,
     // regardless of the diagnostic period parameter provided in the inputs.
     if (istep[0] == max_step || (stop_time - 1.e-3*dt[0] <= cur_time && cur_time < stop_time + dt[0])
-        || exit_loop_due_to_interrupt_signal) {
+        || m_exit_loop_due_to_interrupt_signal) {
         multi_diags->FilterComputePackFlushLastTimestep( istep[0] );
-        if (exit_loop_due_to_interrupt_signal) { ExecutePythonCallback("onbreaksignal"); }
+        if (m_exit_loop_due_to_interrupt_signal) { ExecutePythonCallback("onbreaksignal"); }
     }
 }
 
@@ -524,6 +410,127 @@ WarpX::OneStep_nosub (Real cur_time)
     } // !PSATD
 
     ExecutePythonCallback("afterEsolve");
+}
+
+bool WarpX::checkStopSimulation (amrex::Real cur_time)
+{
+    m_exit_loop_due_to_interrupt_signal = SignalHandling::TestAndResetActionRequestFlag(SignalHandling::SIGNAL_REQUESTS_BREAK);
+    if (cur_time >= stop_time - 1.e-3*dt[0] || m_exit_loop_due_to_interrupt_signal) {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+void WarpX::checkEarlyUnusedParams()
+{
+    if (!m_early_params_checked) {
+        amrex::Print() << "\n"; // better: conditional \n based on return value
+        amrex::ParmParse::QueryUnusedInputs();
+
+        // Print the warning list right after the first step.
+        amrex::Print() << ablastr::warn_manager::GetWMInstance().PrintGlobalWarnings("FIRST STEP");
+        m_early_params_checked = true;
+    }
+}
+
+void WarpX::ExplicitEBUpdate ()
+{
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(evolve_scheme == EvolveScheme::Explicit,
+        "Cannot call WarpX::ExplicitEBUpdate wihtout Explicit evolve scheme set!");
+
+    // At the beginning, we have B^{n} and E^{n}.
+    // Particles have p^{n} and x^{n}.
+    // is_synchronized is true.
+
+    if (is_synchronized) {
+        // Not called at each iteration, so exchange all guard cells
+        FillBoundaryE(guard_cells.ng_alloc_EB);
+        FillBoundaryB(guard_cells.ng_alloc_EB);
+
+        UpdateAuxilaryData();
+        FillBoundaryAux(guard_cells.ng_UpdateAux);
+        // on first step, push p by -0.5*dt
+        for (int lev = 0; lev <= finest_level; ++lev)
+        {
+            mypc->PushP(lev, -0.5_rt*dt[lev],
+                        *Efield_aux[lev][0],*Efield_aux[lev][1],*Efield_aux[lev][2],
+                        *Bfield_aux[lev][0],*Bfield_aux[lev][1],*Bfield_aux[lev][2]);
+        }
+        is_synchronized = false;
+
+    } else {
+        // Beyond one step, we have E^{n} and B^{n}.
+        // Particles have p^{n-1/2} and x^{n}.
+        // E and B: enough guard cells to update Aux or call Field Gather in fp and cp
+        // Need to update Aux on lower levels, to interpolate to higher levels.
+
+        // E and B are up-to-date inside the domain only
+        FillBoundaryE(guard_cells.ng_FieldGather);
+        FillBoundaryB(guard_cells.ng_FieldGather);
+        if (electrostatic_solver_id == ElectrostaticSolverAlgo::None) {
+            if (fft_do_time_averaging)
+            {
+                FillBoundaryE_avg(guard_cells.ng_FieldGather);
+                FillBoundaryB_avg(guard_cells.ng_FieldGather);
+            }
+            // TODO Remove call to FillBoundaryAux before UpdateAuxilaryData?
+            if (WarpX::electromagnetic_solver_id != ElectromagneticSolverAlgo::PSATD) {
+                FillBoundaryAux(guard_cells.ng_UpdateAux);
+            }
+        }
+        UpdateAuxilaryData();
+        FillBoundaryAux(guard_cells.ng_UpdateAux);
+    }
+}
+
+void WarpX::InjectRedistributeScapeParticles (int step, amrex::Real cur_time, int num_moved)
+{
+    mypc->ContinuousFluxInjection(cur_time, dt[0]);
+
+    mypc->ApplyBoundaryConditions();
+
+    // interact the particles with EB walls (if present)
+#ifdef AMREX_USE_EB
+    mypc->ScrapeParticles(amrex::GetVecOfConstPtrs(m_distance_to_eb));
+#endif
+
+    m_particle_boundary_buffer->gatherParticles(*mypc, amrex::GetVecOfConstPtrs(m_distance_to_eb));
+
+    // Non-Maxwell solver: particles can move by an arbitrary number of cells
+    if( electromagnetic_solver_id == ElectromagneticSolverAlgo::None ||
+        electromagnetic_solver_id == ElectromagneticSolverAlgo::HybridPIC )
+    {
+        mypc->Redistribute();
+    }
+    else
+    {
+        // Electromagnetic solver: due to CFL condition, particles can
+        // only move by one or two cells per time step
+        if (max_level == 0) {
+            int num_redistribute_ghost = num_moved;
+            if ((m_v_galilean[0]!=0) or (m_v_galilean[1]!=0) or (m_v_galilean[2]!=0)) {
+                // Galilean algorithm ; particles can move by up to 2 cells
+                num_redistribute_ghost += 2;
+            } else {
+                // Standard algorithm ; particles can move by up to 1 cell
+                num_redistribute_ghost += 1;
+            }
+            mypc->RedistributeLocal(num_redistribute_ghost);
+        }
+        else {
+            mypc->Redistribute();
+        }
+    }
+
+    if (sort_intervals.contains(step+1)) {
+        if (verbose) {
+            amrex::Print() << Utils::TextMsg::Info("re-sorting particles");
+        }
+        mypc->SortParticlesByBin(sort_bin_size);
+    }
 }
 
 void WarpX::SyncCurrentAndRho ()
@@ -1054,8 +1061,13 @@ WarpX::PushParticlesandDeposit (int lev, amrex::Real cur_time, DtType a_dt_type,
  * The mirror normal direction has to be parallel to the z axis.
  */
 void
-WarpX::applyMirrors(Real time)
+WarpX::applyMirrors (Real time)
 {
+    // something to do?
+    if (num_mirrors == 0) {
+        return;
+    }
+
     // Loop over the mirrors
     for(int i_mirror=0; i_mirror<num_mirrors; ++i_mirror)
     {

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -225,7 +225,7 @@ WarpX::Evolve (int numsteps)
             }
         }
 
-        InjectRedistributeScapeParticles(step, cur_time, num_moved);
+        HandleParticlesAtBoundaries(step, cur_time, num_moved);
 
         // Field solve step for electrostatic or hybrid-PIC solvers
         if( electrostatic_solver_id != ElectrostaticSolverAlgo::None ||
@@ -484,7 +484,7 @@ void WarpX::ExplicitFillBoundaryEBUpdateAux ()
     }
 }
 
-void WarpX::InjectRedistributeScapeParticles (int step, amrex::Real cur_time, int num_moved)
+void WarpX::HandleParticlesAtBoundaries (int step, amrex::Real cur_time, int num_moved)
 {
     mypc->ContinuousFluxInjection(cur_time, dt[0]);
 

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -125,7 +125,7 @@ WarpX::Evolve (int numsteps)
 
         ExecutePythonCallback("particleinjection");
 
-        // TOOD: move out
+        // TODO: move out
         if (evolve_scheme == EvolveScheme::ImplicitPicard ||
             evolve_scheme == EvolveScheme::SemiImplicitPicard) {
             OneStep_ImplicitPicard(cur_time);

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -421,13 +421,8 @@ WarpX::OneStep_nosub (Real cur_time)
 bool WarpX::checkStopSimulation (amrex::Real cur_time)
 {
     m_exit_loop_due_to_interrupt_signal = SignalHandling::TestAndResetActionRequestFlag(SignalHandling::SIGNAL_REQUESTS_BREAK);
-    if (cur_time >= stop_time - 1.e-3*dt[0] || m_exit_loop_due_to_interrupt_signal) {
-        return true;
-    }
-    else
-    {
-        return false;
-    }
+    return (cur_time >= stop_time - 1.e-3*dt[0])  ||
+        m_exit_loop_due_to_interrupt_signal;
 }
 
 void WarpX::checkEarlyUnusedParams ()

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -59,7 +59,10 @@ WarpX::CheckLoadBalance (int step)
         // Reset the costs to 0
         ResetCosts();
     }
-    RescaleCosts(step);
+    if (!costs.empty())
+    {
+        RescaleCosts(step);
+    }
 }
 
 void
@@ -432,12 +435,17 @@ WarpX::ResetCosts ()
 void
 WarpX::RescaleCosts (int step)
 {
-    AMREX_ALWAYS_ASSERT(!costs.empty());
-    AMREX_ALWAYS_ASSERT(costs[0] != nullptr);
+    // rescale is only used for timers
+    if (WarpX::load_balance_costs_update_algo != LoadBalanceCostsUpdateAlgo::Timers)
+    {
+        return;
+    }
+
+    AMREX_ALWAYS_ASSERT(costs.size() == finest_level + 1);
 
     for (int lev = 0; lev <= finest_level; ++lev)
     {
-        if (costs[lev] && WarpX::load_balance_costs_update_algo == LoadBalanceCostsUpdateAlgo::Timers)
+        if (costs[lev])
         {
             // Perform running average of the costs
             // (Giving more importance to most recent costs; only needed

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1462,9 +1462,6 @@ private:
     //! Author of an input file / simulation setup
     std::string m_authors;
 
-    //! check typos in inputs after step 1
-    bool m_early_params_checked = false;
-
     amrex::Vector<int> istep;      // which step?
     amrex::Vector<int> nsubsteps;  // how many substeps on each level?
 
@@ -1771,7 +1768,7 @@ private:
      * At the beginning, we have B^{n} and E^{n}.
      * Particles have p^{n} and x^{n}.
      */
-    void ExplicitEBUpdate ();
+    void ExplicitFillBoundaryEBUpdateAux ();
 
     void PushPSATD ();
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1751,7 +1751,7 @@ private:
      */
     void checkEarlyUnusedParams ();
 
-    /** Perform essential particle house keeping
+    /** Perform essential particle house keeping at boundaries
      *
      * Inject, communicate, scape and sort particles.
      *
@@ -1759,7 +1759,7 @@ private:
      * @param cur_time current time
      * @param num_moved number of cells the moving window moved
      */
-    void InjectRedistributeScapeParticles (int step, amrex::Real cur_time, int num_moved);
+    void HandleParticlesAtBoundaries (int step, amrex::Real cur_time, int num_moved);
 
     void ScrapeParticles ();
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1753,7 +1753,7 @@ private:
 
     /** Perform essential particle house keeping at boundaries
      *
-     * Inject, communicate, scape and sort particles.
+     * Inject, communicate, scrape and sort particles.
      *
      * @param step current step
      * @param cur_time current time

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -663,12 +663,25 @@ public:
 
     static amrex::Real quantum_xi_c2;
 
+    /** Check and potentially compute load balancing
+     */
+    void CheckLoadBalance (int step);
+
     /** \brief perform load balance; compute and communicate new `amrex::DistributionMapping`
      */
     void LoadBalance ();
+
     /** \brief resets costs to zero
      */
     void ResetCosts ();
+
+    /** Perform running average of the LB costs
+     *
+     * Only needed for timers cost update, heuristic load balance considers the
+     * instantaneous costs.
+     * This gives more importance to most recent costs.
+     */
+    void RescaleCosts (int step);
 
     /** \brief returns the load balance interval
      */
@@ -1449,6 +1462,9 @@ private:
     //! Author of an input file / simulation setup
     std::string m_authors;
 
+    //! check typos in inputs after step 1
+    bool m_early_params_checked = false;
+
     amrex::Vector<int> istep;      // which step?
     amrex::Vector<int> nsubsteps;  // how many substeps on each level?
 
@@ -1722,7 +1738,40 @@ private:
         return *m_field_factory[lev];
     }
 
+    /** Stop the simulation at the end of the current step due to a received Unix signal?
+     */
+    bool m_exit_loop_due_to_interrupt_signal = false;
+
+    /** Stop the simulation at the end of the current step?
+     */
+    [[nodiscard]]
+    bool checkStopSimulation (amrex::Real cur_time);
+
+    /** Print Unused Parameter Warnings after Step 1
+     *
+     * Instead of waiting for a simulation to end, we already do an early "unused parameter check"
+     * after step 1 to inform users early of potential issues with their simulation setup.
+     */
+    void checkEarlyUnusedParams ();
+
+    /** Perform essential particle house keeping
+     *
+     * Inject, communicate, scape and sort particles.
+     *
+     * @param step current step
+     * @param cur_time current time
+     * @param num_moved number of cells the moving window moved
+     */
+    void InjectRedistributeScapeParticles (int step, amrex::Real cur_time, int num_moved);
+
     void ScrapeParticles ();
+
+    /** Update the E and B fields in the explicit em PIC scheme.
+     *
+     * At the beginning, we have B^{n} and E^{n}.
+     * Particles have p^{n} and x^{n}.
+     */
+    void ExplicitEBUpdate ();
 
     void PushPSATD ();
 


### PR DESCRIPTION
Introduce new functions to simplify the number of calls in our main evolve loop.

I will probably do another follow-up PR on the sub-stepping calls, but try to avoid colliding too much with @JustinRayAngus's PRs (e.g., #4736).