### PR TITLE
PICMI (Bucket): NumPy 2.0 Compatibility

### DIFF
--- a/Python/pywarpx/Bucket.py
+++ b/Python/pywarpx/Bucket.py
@@ -59,9 +59,6 @@ class Bucket(object):
         for attr, value in self.argvattrs.items():
             if value is None:
                 continue
-            # --- str (and repr) crop some digits for floats. TODO: we should format
-            #     floating point numbers & numpy scalars to the significant digits of the
-            #     precision of amrex::Real/ParticleReal
             # --- The strip of "'" is then needed when value is a string.
             if isinstance(value, str):
                 if value.find('=') > -1:

--- a/Python/pywarpx/Bucket.py
+++ b/Python/pywarpx/Bucket.py
@@ -59,7 +59,9 @@ class Bucket(object):
         for attr, value in self.argvattrs.items():
             if value is None:
                 continue
-            # --- repr is applied to value so that for floats, all of the digits are included.
+            # --- str (and repr) crop some digits for floats. TODO: we should format
+            #     floating point numbers & numpy scalars to the significant digits of the
+            #     precision of amrex::Real/ParticleReal
             # --- The strip of "'" is then needed when value is a string.
             if isinstance(value, str):
                 if value.find('=') > -1:
@@ -73,11 +75,11 @@ class Bucket(object):
                     continue
                 # --- For lists, tuples, and arrays make a space delimited string of the values.
                 # --- The lambda is needed in case this is a list of strings.
-                rhs = ' '.join(map(lambda s : repr(s).strip("'"), value))
+                rhs = ' '.join(map(lambda s : str(s).strip("'"), value))
             elif isinstance(value, bool):
                 rhs = 1 if value else 0
             else:
                 rhs = value
-            attrstring = '{0}.{1} = {2}'.format(self.instancename, attr, repr(rhs).strip("'"))
+            attrstring = '{0}.{1} = {2}'.format(self.instancename, attr, str(rhs).strip("'"))
             result += [attrstring]
         return result

--- a/Python/pywarpx/Bucket.py
+++ b/Python/pywarpx/Bucket.py
@@ -75,11 +75,11 @@ class Bucket(object):
                     continue
                 # --- For lists, tuples, and arrays make a space delimited string of the values.
                 # --- The lambda is needed in case this is a list of strings.
-                rhs = ' '.join(map(lambda s : str(s).strip("'"), value))
+                rhs = ' '.join(map(lambda s : f'{s}', value))
             elif isinstance(value, bool):
                 rhs = 1 if value else 0
             else:
                 rhs = value
-            attrstring = '{0}.{1} = {2}'.format(self.instancename, attr, str(rhs).strip("'"))
+            attrstring = f'{self.instancename}.{attr} = {rhs}'
             result += [attrstring]
         return result

--- a/Python/pywarpx/Bucket.py
+++ b/Python/pywarpx/Bucket.py
@@ -59,7 +59,6 @@ class Bucket(object):
         for attr, value in self.argvattrs.items():
             if value is None:
                 continue
-            # --- The strip of "'" is then needed when value is a string.
             if isinstance(value, str):
                 if value.find('=') > -1:
                     # --- Expressions with temporary variables need to be inside quotes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # basic dependencies
-numpy~=1.15
+numpy>=1.15
 periodictable~=1.5
 
 # PICMI


### PR DESCRIPTION
`repr` returns `'np.float64(value)'` instead of `'value'` in NumPy 2.0.

Fix #5071