### PR TITLE
[WIP] Rename current_fp/current_cp to j_fp/j_cp

### DIFF
--- a/Python/pywarpx/fields.py
+++ b/Python/pywarpx/fields.py
@@ -616,19 +616,19 @@ def BzWrapper(level=0, include_ghosts=False):
 
 def JxWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="current_fp", idir=0, level=level, include_ghosts=include_ghosts
+        mf_name="j_fp", idir=0, level=level, include_ghosts=include_ghosts
     )
 
 
 def JyWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="current_fp", idir=1, level=level, include_ghosts=include_ghosts
+        mf_name="j_fp", idir=1, level=level, include_ghosts=include_ghosts
     )
 
 
 def JzWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="current_fp", idir=2, level=level, include_ghosts=include_ghosts
+        mf_name="j_fp", idir=2, level=level, include_ghosts=include_ghosts
     )
 
 
@@ -706,19 +706,19 @@ def BzFPExternalWrapper(level=0, include_ghosts=False):
 
 def JxFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="current_fp", idir=0, level=level, include_ghosts=include_ghosts
+        mf_name="j_fp", idir=0, level=level, include_ghosts=include_ghosts
     )
 
 
 def JyFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="current_fp", idir=1, level=level, include_ghosts=include_ghosts
+        mf_name="j_fp", idir=1, level=level, include_ghosts=include_ghosts
     )
 
 
 def JzFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="current_fp", idir=2, level=level, include_ghosts=include_ghosts
+        mf_name="j_fp", idir=2, level=level, include_ghosts=include_ghosts
     )
 
 
@@ -807,19 +807,19 @@ def BzCPWrapper(level=0, include_ghosts=False):
 
 def JxCPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="current_cp", idir=0, level=level, include_ghosts=include_ghosts
+        mf_name="j_cp", idir=0, level=level, include_ghosts=include_ghosts
     )
 
 
 def JyCPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="current_cp", idir=1, level=level, include_ghosts=include_ghosts
+        mf_name="j_cp", idir=1, level=level, include_ghosts=include_ghosts
     )
 
 
 def JzCPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="current_cp", idir=2, level=level, include_ghosts=include_ghosts
+        mf_name="j_cp", idir=2, level=level, include_ghosts=include_ghosts
     )
 
 
@@ -875,7 +875,7 @@ def FaceAreaszWrapper(level=0, include_ghosts=False):
 
 def JxFPAmpereWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="hybrid_current_fp_ampere",
+        mf_name="hybrid_j_fp_ampere",
         idir=0,
         level=level,
         include_ghosts=include_ghosts,
@@ -884,7 +884,7 @@ def JxFPAmpereWrapper(level=0, include_ghosts=False):
 
 def JyFPAmpereWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="hybrid_current_fp_ampere",
+        mf_name="hybrid_j_fp_ampere",
         idir=1,
         level=level,
         include_ghosts=include_ghosts,
@@ -893,7 +893,7 @@ def JyFPAmpereWrapper(level=0, include_ghosts=False):
 
 def JzFPAmpereWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="hybrid_current_fp_ampere",
+        mf_name="hybrid_j_fp_ampere",
         idir=2,
         level=level,
         include_ghosts=include_ghosts,

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -717,9 +717,9 @@ PML::PML (const int lev, const BoxArray& grid_ba,
     warpx.m_fields.alloc_init(FieldType::pml_B_fp, Direction{1}, lev, ba_By, dm, ncompb, ngb, 0.0_rt, false, false);
     warpx.m_fields.alloc_init(FieldType::pml_B_fp, Direction{2}, lev, ba_Bz, dm, ncompb, ngb, 0.0_rt, false, false);
 
-    const amrex::BoxArray ba_jx = amrex::convert(ba, WarpX::GetInstance().m_fields.get(FieldType::current_fp, Direction{0}, 0)->ixType().toIntVect());
-    const amrex::BoxArray ba_jy = amrex::convert(ba, WarpX::GetInstance().m_fields.get(FieldType::current_fp, Direction{1}, 0)->ixType().toIntVect());
-    const amrex::BoxArray ba_jz = amrex::convert(ba, WarpX::GetInstance().m_fields.get(FieldType::current_fp, Direction{2}, 0)->ixType().toIntVect());
+    const amrex::BoxArray ba_jx = amrex::convert(ba, WarpX::GetInstance().m_fields.get(FieldType::j_fp, Direction{0}, 0)->ixType().toIntVect());
+    const amrex::BoxArray ba_jy = amrex::convert(ba, WarpX::GetInstance().m_fields.get(FieldType::j_fp, Direction{1}, 0)->ixType().toIntVect());
+    const amrex::BoxArray ba_jz = amrex::convert(ba, WarpX::GetInstance().m_fields.get(FieldType::j_fp, Direction{2}, 0)->ixType().toIntVect());
     warpx.m_fields.alloc_init(FieldType::pml_j_fp, Direction{0}, lev, ba_jx, dm, 1, ngb, 0.0_rt, false, false);
     warpx.m_fields.alloc_init(FieldType::pml_j_fp, Direction{1}, lev, ba_jy, dm, 1, ngb, 0.0_rt, false, false);
     warpx.m_fields.alloc_init(FieldType::pml_j_fp, Direction{2}, lev, ba_jz, dm, 1, ngb, 0.0_rt, false, false);
@@ -871,9 +871,9 @@ PML::PML (const int lev, const BoxArray& grid_ba,
             warpx.m_fields.alloc_init(FieldType::pml_G_cp, lev, cba_G_nodal, cdm, 3, ngf, 0.0_rt, false, false);
         }
 
-        const amrex::BoxArray cba_jx = amrex::convert(cba, WarpX::GetInstance().m_fields.get(FieldType::current_cp, Direction{0}, 1)->ixType().toIntVect());
-        const amrex::BoxArray cba_jy = amrex::convert(cba, WarpX::GetInstance().m_fields.get(FieldType::current_cp, Direction{1}, 1)->ixType().toIntVect());
-        const amrex::BoxArray cba_jz = amrex::convert(cba, WarpX::GetInstance().m_fields.get(FieldType::current_cp, Direction{2}, 1)->ixType().toIntVect());
+        const amrex::BoxArray cba_jx = amrex::convert(cba, WarpX::GetInstance().m_fields.get(FieldType::j_cp, Direction{0}, 1)->ixType().toIntVect());
+        const amrex::BoxArray cba_jy = amrex::convert(cba, WarpX::GetInstance().m_fields.get(FieldType::j_cp, Direction{1}, 1)->ixType().toIntVect());
+        const amrex::BoxArray cba_jz = amrex::convert(cba, WarpX::GetInstance().m_fields.get(FieldType::j_cp, Direction{2}, 1)->ixType().toIntVect());
         warpx.m_fields.alloc_init(FieldType::pml_j_cp, Direction{0}, lev, cba_jx, cdm, 1, ngb, 0.0_rt, false, false);
         warpx.m_fields.alloc_init(FieldType::pml_j_cp, Direction{1}, lev, cba_jy, cdm, 1, ngb, 0.0_rt, false, false);
         warpx.m_fields.alloc_init(FieldType::pml_j_cp, Direction{2}, lev, cba_jz, cdm, 1, ngb, 0.0_rt, false, false);
@@ -1060,15 +1060,15 @@ PML::CopyJtoPMLs (
 {
     using ablastr::fields::Direction;
 
-    bool const has_j_fp = fields.has_vector(FieldType::current_fp, lev);
+    bool const has_j_fp = fields.has_vector(FieldType::j_fp, lev);
     bool const has_pml_j_fp = fields.has_vector(FieldType::pml_j_fp, lev);
-    bool const has_j_cp = fields.has_vector(FieldType::current_cp, lev);
+    bool const has_j_cp = fields.has_vector(FieldType::j_cp, lev);
     bool const has_pml_j_cp = fields.has_vector(FieldType::pml_j_cp, lev);
 
     if (patch_type == PatchType::fine && has_pml_j_fp && has_j_fp)
     {
         ablastr::fields::VectorField pml_j_fp = fields.get_alldirs(FieldType::pml_j_fp, lev);
-        ablastr::fields::VectorField jp = fields.get_alldirs(FieldType::current_fp, lev);
+        ablastr::fields::VectorField jp = fields.get_alldirs(FieldType::j_fp, lev);
         CopyToPML(*pml_j_fp[0], *jp[0], *m_geom);
         CopyToPML(*pml_j_fp[1], *jp[1], *m_geom);
         CopyToPML(*pml_j_fp[2], *jp[2], *m_geom);
@@ -1076,7 +1076,7 @@ PML::CopyJtoPMLs (
     else if (patch_type == PatchType::coarse && has_j_cp && has_pml_j_cp)
     {
         ablastr::fields::VectorField pml_j_cp = fields.get_alldirs(FieldType::pml_j_cp, lev);
-        ablastr::fields::VectorField jp = fields.get_alldirs(FieldType::current_cp, lev);
+        ablastr::fields::VectorField jp = fields.get_alldirs(FieldType::j_cp, lev);
         CopyToPML(*pml_j_cp[0], *jp[0], *m_cgeom);
         CopyToPML(*pml_j_cp[1], *jp[1], *m_cgeom);
         CopyToPML(*pml_j_cp[2], *jp[2], *m_cgeom);

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -582,11 +582,11 @@ BTDiagnostics::InitializeFieldFunctors (int lev)
         } else if ( m_cellcenter_varnames[comp] == "Bz" ){
             m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Bfield_aux, Direction{2}, lev), lev, m_crse_ratio);
         } else if ( m_cellcenter_varnames[comp] == "jx" ){
-            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::current_fp,Direction{0}, lev), lev, m_crse_ratio);
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::j_fp,Direction{0}, lev), lev, m_crse_ratio);
         } else if ( m_cellcenter_varnames[comp] == "jy" ){
-            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::current_fp,Direction{1}, lev), lev, m_crse_ratio);
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::j_fp,Direction{1}, lev), lev, m_crse_ratio);
         } else if ( m_cellcenter_varnames[comp] == "jz" ){
-            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::current_fp,Direction{2}, lev), lev, m_crse_ratio);
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::j_fp,Direction{2}, lev), lev, m_crse_ratio);
         } else if ( m_cellcenter_varnames[comp] == "rho" ){
             m_cell_center_functors[lev][comp] = std::make_unique<RhoFunctor>(lev, m_crse_ratio);
         }
@@ -701,11 +701,11 @@ BTDiagnostics::InitializeFieldFunctorsRZopenPMD (int lev)
         } else if ( m_cellcenter_varnames_fields[comp] == "Bz" ){
             m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Bfield_aux, Direction{2}, lev), lev, m_crse_ratio, false, ncomp);
         } else if ( m_cellcenter_varnames_fields[comp] == "jr" ){
-            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::current_fp, Direction{0}, lev), lev, m_crse_ratio, false, ncomp);
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::j_fp, Direction{0}, lev), lev, m_crse_ratio, false, ncomp);
         } else if ( m_cellcenter_varnames_fields[comp] == "jt" ){
-            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::current_fp, Direction{1}, lev), lev, m_crse_ratio, false, ncomp);
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::j_fp, Direction{1}, lev), lev, m_crse_ratio, false, ncomp);
         } else if ( m_cellcenter_varnames_fields[comp] == "jz" ){
-            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::current_fp, Direction{2}, lev), lev, m_crse_ratio, false, ncomp);
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::j_fp, Direction{2}, lev), lev, m_crse_ratio, false, ncomp);
         } else if ( m_cellcenter_varnames_fields[comp] == "rho" ){
             m_cell_center_functors[lev][comp] = std::make_unique<RhoFunctor>(lev, m_crse_ratio, false, -1, false, ncomp);
         }

--- a/Source/Diagnostics/ComputeDiagFunctors/JFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/JFunctor.cpp
@@ -35,23 +35,23 @@ JFunctor::operator() (amrex::MultiFab& mf_dst, int dcomp, const int /*i_buffer*/
 
     auto& warpx = WarpX::GetInstance();
     /** pointer to source multifab (can be multi-component) */
-    amrex::MultiFab* m_mf_src = warpx.m_fields.get(FieldType::current_fp,Direction{m_dir},m_lev);
+    amrex::MultiFab* m_mf_src = warpx.m_fields.get(FieldType::j_fp,Direction{m_dir},m_lev);
 
     // Deposit current if no solver or the electrostatic solver is being used
     if (m_deposit_current)
     {
         // allocate temporary multifab to deposit current density into
-        ablastr::fields::MultiLevelVectorField current_fp_temp {
-            warpx.m_fields.get_alldirs(FieldType::current_fp, m_lev)
+        ablastr::fields::MultiLevelVectorField j_fp_temp {
+            warpx.m_fields.get_alldirs(FieldType::j_fp, m_lev)
         };
 
         auto& mypc = warpx.GetPartContainer();
-        mypc.DepositCurrent(current_fp_temp, warpx.getdt(m_lev), 0.0);
+        mypc.DepositCurrent(j_fp_temp, warpx.getdt(m_lev), 0.0);
 
         // sum values in guard cells - note that this does not filter the
         // current density.
         for (int idim = 0; idim < 3; ++idim) {
-            current_fp_temp[0][idim]->FillBoundary(warpx.Geom(m_lev).periodicity());
+            j_fp_temp[0][idim]->FillBoundary(warpx.Geom(m_lev).periodicity());
         }
     }
 

--- a/Source/Diagnostics/ComputeDiagFunctors/JdispFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/JdispFunctor.cpp
@@ -33,14 +33,14 @@ JdispFunctor::operator() (amrex::MultiFab& mf_dst, int dcomp, const int /*i_buff
     auto* hybrid_pic_model = warpx.get_pointer_HybridPICModel();
 
     /** pointer to total simulation current (J) multifab */
-    amrex::MultiFab* mf_j = warpx.m_fields.get(FieldType::current_fp, Direction{m_dir}, m_lev);
+    amrex::MultiFab* mf_j = warpx.m_fields.get(FieldType::j_fp, Direction{m_dir}, m_lev);
 
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(hybrid_pic_model,
         "Displacement current diagnostic is only implemented for the HybridPICModel.");
     AMREX_ASSUME(hybrid_pic_model != nullptr);
 
      /** pointer to current calculated from Ampere's Law (Jamp) multifab */
-    amrex::MultiFab* mf_curlB = warpx.m_fields.get(FieldType::hybrid_current_fp_ampere, Direction{m_dir}, m_lev);
+    amrex::MultiFab* mf_curlB = warpx.m_fields.get(FieldType::hybrid_j_fp_ampere, Direction{m_dir}, m_lev);
 
     //if (!hybrid_pic_model) {
         // To finish this implementation, we need to implement a method to
@@ -66,7 +66,7 @@ JdispFunctor::operator() (amrex::MultiFab& mf_dst, int dcomp, const int /*i_buff
     if (hybrid_pic_model) {
         // Subtract the interpolated j_external value from j_displacement.
         /** pointer to external currents (Jext) multifab */
-        amrex::MultiFab* mf_j_external = warpx.m_fields.get(FieldType::hybrid_current_fp_external, Direction{m_dir}, m_lev);
+        amrex::MultiFab* mf_j_external = warpx.m_fields.get(FieldType::hybrid_j_fp_external, Direction{m_dir}, m_lev);
 
         // Index type required for interpolating Jext from their respective
         // staggering (nodal) to the Jx_displacement, Jy_displacement, Jz_displacement

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -100,11 +100,11 @@ FlushFormatCheckpoint::WriteToFile (
 
         if (warpx.getis_synchronized()) {
             // Need to save j if synchronized because after restart we need j to evolve E by dt/2.
-            VisMF::Write(*warpx.m_fields.get(FieldType::current_fp, Direction{0}, lev),
+            VisMF::Write(*warpx.m_fields.get(FieldType::j_fp, Direction{0}, lev),
                          amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "jx_fp"));
-            VisMF::Write(*warpx.m_fields.get(FieldType::current_fp, Direction{1}, lev),
+            VisMF::Write(*warpx.m_fields.get(FieldType::j_fp, Direction{1}, lev),
                          amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "jy_fp"));
-            VisMF::Write(*warpx.m_fields.get(FieldType::current_fp, Direction{2}, lev),
+            VisMF::Write(*warpx.m_fields.get(FieldType::j_fp, Direction{2}, lev),
                          amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "jz_fp"));
         }
 
@@ -142,11 +142,11 @@ FlushFormatCheckpoint::WriteToFile (
 
             if (warpx.getis_synchronized()) {
                 // Need to save j if synchronized because after restart we need j to evolve E by dt/2.
-                VisMF::Write(*warpx.m_fields.get(FieldType::current_cp, Direction{0}, lev),
+                VisMF::Write(*warpx.m_fields.get(FieldType::j_cp, Direction{0}, lev),
                              amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "jx_cp"));
-                VisMF::Write(*warpx.m_fields.get(FieldType::current_cp, Direction{1}, lev),
+                VisMF::Write(*warpx.m_fields.get(FieldType::j_cp, Direction{1}, lev),
                              amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "jy_cp"));
-                VisMF::Write(*warpx.m_fields.get(FieldType::current_cp, Direction{2}, lev),
+                VisMF::Write(*warpx.m_fields.get(FieldType::j_cp, Direction{2}, lev),
                              amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "jz_cp"));
             }
         }

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -582,11 +582,11 @@ FlushFormatPlotfile::WriteAllRawFields(
                     default_level_prefix, "Ey_fp", lev, plot_raw_fields_guards );
         WriteRawMF( *warpx.m_fields.get(FieldType::Efield_fp, Direction{2}, lev), dm, raw_pltname,
                     default_level_prefix, "Ez_fp", lev, plot_raw_fields_guards );
-        WriteRawMF( *warpx.m_fields.get(FieldType::current_fp,Direction{0}, lev), dm, raw_pltname,
+        WriteRawMF( *warpx.m_fields.get(FieldType::j_fp,Direction{0}, lev), dm, raw_pltname,
                     default_level_prefix, "jx_fp", lev,plot_raw_fields_guards );
-        WriteRawMF( *warpx.m_fields.get(FieldType::current_fp,Direction{1}, lev), dm, raw_pltname,
+        WriteRawMF( *warpx.m_fields.get(FieldType::j_fp,Direction{1}, lev), dm, raw_pltname,
                     default_level_prefix, "jy_fp", lev,plot_raw_fields_guards );
-        WriteRawMF( *warpx.m_fields.get(FieldType::current_fp,Direction{2}, lev), dm, raw_pltname,
+        WriteRawMF( *warpx.m_fields.get(FieldType::j_fp,Direction{2}, lev), dm, raw_pltname,
                     default_level_prefix, "jz_fp", lev,plot_raw_fields_guards );
         WriteRawMF( *warpx.m_fields.get(FieldType::Bfield_fp, Direction{0}, lev), dm, raw_pltname,
                     default_level_prefix, "Bx_fp", lev, plot_raw_fields_guards );
@@ -653,8 +653,8 @@ FlushFormatPlotfile::WriteAllRawFields(
                                warpx.m_fields.get(FieldType::Bfield_fp, Direction{2}, lev),
                                dm, raw_pltname, default_level_prefix, lev, plot_raw_fields_guards);
             WriteCoarseVector( "j",
-                               warpx.m_fields.get(FieldType::current_cp, Direction{0}, lev), warpx.m_fields.get(FieldType::current_cp, Direction{1}, lev), warpx.m_fields.get(FieldType::current_cp, Direction{2}, lev),
-                               warpx.m_fields.get(FieldType::current_fp, Direction{0}, lev), warpx.m_fields.get(FieldType::current_fp, Direction{1}, lev), warpx.m_fields.get(FieldType::current_fp, Direction{2}, lev),
+                               warpx.m_fields.get(FieldType::j_cp, Direction{0}, lev), warpx.m_fields.get(FieldType::j_cp, Direction{1}, lev), warpx.m_fields.get(FieldType::j_cp, Direction{2}, lev),
+                               warpx.m_fields.get(FieldType::j_fp, Direction{0}, lev), warpx.m_fields.get(FieldType::j_fp, Direction{1}, lev), warpx.m_fields.get(FieldType::j_fp, Direction{2}, lev),
                                dm, raw_pltname, default_level_prefix, lev, plot_raw_fields_guards);
             if (warpx.m_fields.has(FieldType::F_fp, lev) && warpx.m_fields.has(FieldType::F_cp, lev))
             {

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -185,7 +185,7 @@ FullDiagnostics::InitializeFieldFunctorsRZopenPMD (int lev)
         AMREX_ALWAYS_ASSERT(
             warpx.m_fields.get(FieldType::Bfield_aux, Direction{dim}, lev)->nComp() == ncomp_multimodefab );
         AMREX_ALWAYS_ASSERT(
-            warpx.m_fields.get(FieldType::current_fp, Direction{dim}, lev)->nComp() == ncomp_multimodefab );
+            warpx.m_fields.get(FieldType::j_fp, Direction{dim}, lev)->nComp() == ncomp_multimodefab );
     }
 
     // Species index to loop over species that dump rho per species
@@ -409,7 +409,7 @@ FullDiagnostics::AddRZModesToDiags (int lev)
         AMREX_ALWAYS_ASSERT(
             warpx.m_fields.get(FieldType::Bfield_aux, Direction{dim}, lev)->nComp() == ncomp_multimodefab );
         AMREX_ALWAYS_ASSERT(
-            warpx.m_fields.get(FieldType::current_fp, Direction{dim}, lev)->nComp() == ncomp_multimodefab );
+            warpx.m_fields.get(FieldType::j_fp, Direction{dim}, lev)->nComp() == ncomp_multimodefab );
     }
 
     // Check if divE is requested
@@ -465,7 +465,7 @@ FullDiagnostics::AddRZModesToDiags (int lev)
             dim, lev, m_crse_ratio, false, deposit_current, ncomp_multimodefab));
         deposit_current = false;
         AddRZModesToOutputNames(std::string("J") + coord[dim],
-                warpx.m_fields.get(FieldType::current_fp,Direction{0},0)->nComp());
+                warpx.m_fields.get(FieldType::j_fp,Direction{0},0)->nComp());
     }
     // divE
     if (divE_requested) {

--- a/Source/Diagnostics/ReducedDiags/FieldReduction.H
+++ b/Source/Diagnostics/ReducedDiags/FieldReduction.H
@@ -107,9 +107,9 @@ public:
         const amrex::MultiFab & Bx = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{0}, lev);
         const amrex::MultiFab & By = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{1}, lev);
         const amrex::MultiFab & Bz = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{2}, lev);
-        const amrex::MultiFab & jx = *warpx.m_fields.get(FieldType::current_fp, Direction{0},lev);
-        const amrex::MultiFab & jy = *warpx.m_fields.get(FieldType::current_fp, Direction{1},lev);
-        const amrex::MultiFab & jz = *warpx.m_fields.get(FieldType::current_fp, Direction{2},lev);
+        const amrex::MultiFab & jx = *warpx.m_fields.get(FieldType::j_fp, Direction{0},lev);
+        const amrex::MultiFab & jy = *warpx.m_fields.get(FieldType::j_fp, Direction{1},lev);
+        const amrex::MultiFab & jz = *warpx.m_fields.get(FieldType::j_fp, Direction{2},lev);
 
 
         // General preparation of interpolation and reduction operations

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -283,7 +283,7 @@ WarpX::InitFromCheckpoint ()
     for (int lev = 0; lev < nlevs; ++lev)
     {
         for (int i = 0; i < 3; ++i) {
-            m_fields.get(FieldType::current_fp, Direction{i}, lev)->setVal(0.0);
+            m_fields.get(FieldType::j_fp, Direction{i}, lev)->setVal(0.0);
             m_fields.get(FieldType::Efield_fp, Direction{i}, lev)->setVal(0.0);
             m_fields.get(FieldType::Bfield_fp, Direction{i}, lev)->setVal(0.0);
         }
@@ -293,7 +293,7 @@ WarpX::InitFromCheckpoint ()
                 m_fields.get(FieldType::Efield_aux, Direction{i}, lev)->setVal(0.0);
                 m_fields.get(FieldType::Bfield_aux, Direction{i}, lev)->setVal(0.0);
 
-                m_fields.get(FieldType::current_cp, Direction{i}, lev)->setVal(0.0);
+                m_fields.get(FieldType::j_cp, Direction{i}, lev)->setVal(0.0);
                 m_fields.get(FieldType::Efield_cp, Direction{i}, lev)->setVal(0.0);
                 m_fields.get(FieldType::Bfield_cp, Direction{i}, lev)->setVal(0.0);
             }
@@ -331,11 +331,11 @@ WarpX::InitFromCheckpoint ()
         }
 
         if (is_synchronized) {
-            VisMF::Read(*m_fields.get(FieldType::current_fp, Direction{0}, lev),
+            VisMF::Read(*m_fields.get(FieldType::j_fp, Direction{0}, lev),
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "jx_fp"));
-            VisMF::Read(*m_fields.get(FieldType::current_fp, Direction{1}, lev),
+            VisMF::Read(*m_fields.get(FieldType::j_fp, Direction{1}, lev),
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "jy_fp"));
-            VisMF::Read(*m_fields.get(FieldType::current_fp, Direction{2}, lev),
+            VisMF::Read(*m_fields.get(FieldType::j_fp, Direction{2}, lev),
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "jz_fp"));
         }
 
@@ -373,11 +373,11 @@ WarpX::InitFromCheckpoint ()
             }
 
             if (is_synchronized) {
-                VisMF::Read(*m_fields.get(FieldType::current_cp, Direction{0}, lev),
+                VisMF::Read(*m_fields.get(FieldType::j_cp, Direction{0}, lev),
                             amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "jx_cp"));
-                VisMF::Read(*m_fields.get(FieldType::current_cp, Direction{1}, lev),
+                VisMF::Read(*m_fields.get(FieldType::j_cp, Direction{1}, lev),
                             amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "jy_cp"));
-                VisMF::Read(*m_fields.get(FieldType::current_cp, Direction{2}, lev),
+                VisMF::Read(*m_fields.get(FieldType::j_cp, Direction{2}, lev),
                             amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "jz_cp"));
             }
         }

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
@@ -64,7 +64,7 @@ void FiniteDifferenceSolver::EvolveE (
     const ablastr::fields::VectorField Bfield = patch_type == PatchType::fine ?
         fields.get_alldirs(FieldType::Bfield_fp, lev) : fields.get_alldirs(FieldType::Bfield_cp, lev);
     const ablastr::fields::VectorField Jfield = patch_type == PatchType::fine ?
-        fields.get_alldirs(FieldType::current_fp, lev) : fields.get_alldirs(FieldType::current_cp, lev);
+        fields.get_alldirs(FieldType::j_fp, lev) : fields.get_alldirs(FieldType::j_cp, lev);
 
     amrex::MultiFab* Ffield = nullptr;
     if (fields.has(FieldType::F_fp, lev)) {

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -69,9 +69,9 @@ void HybridPICModel::AllocateLevelMFs (ablastr::fields::MultiFabRegister & field
     // from the specified equation of state.
     // The "hybrid_rho_fp_temp" multifab is used to store the ion charge density
     // interpolated or extrapolated to appropriate timesteps.
-    // The "hybrid_current_fp_temp" multifab is used to store the ion current density
+    // The "hybrid_j_fp_temp" multifab is used to store the ion current density
     // interpolated or extrapolated to appropriate timesteps.
-    // The "hybrid_current_fp_ampere" multifab stores the total current calculated as
+    // The "hybrid_j_fp_ampere" multifab stores the total current calculated as
     // the curl of B.
     fields.alloc_init(FieldType::hybrid_electron_pressure_fp,
         lev, amrex::convert(ba, rho_nodal_flag),
@@ -79,36 +79,36 @@ void HybridPICModel::AllocateLevelMFs (ablastr::fields::MultiFabRegister & field
     fields.alloc_init(FieldType::hybrid_rho_fp_temp,
         lev, amrex::convert(ba, rho_nodal_flag),
         dm, ncomps, ngRho, 0.0_rt);
-    fields.alloc_init(FieldType::hybrid_current_fp_temp, Direction{0},
+    fields.alloc_init(FieldType::hybrid_j_fp_temp, Direction{0},
         lev, amrex::convert(ba, jx_nodal_flag),
         dm, ncomps, ngJ, 0.0_rt);
-    fields.alloc_init(FieldType::hybrid_current_fp_temp, Direction{1},
+    fields.alloc_init(FieldType::hybrid_j_fp_temp, Direction{1},
         lev, amrex::convert(ba, jy_nodal_flag),
         dm, ncomps, ngJ, 0.0_rt);
-    fields.alloc_init(FieldType::hybrid_current_fp_temp, Direction{2},
+    fields.alloc_init(FieldType::hybrid_j_fp_temp, Direction{2},
         lev, amrex::convert(ba, jz_nodal_flag),
         dm, ncomps, ngJ, 0.0_rt);
 
-    fields.alloc_init(FieldType::hybrid_current_fp_ampere, Direction{0},
+    fields.alloc_init(FieldType::hybrid_j_fp_ampere, Direction{0},
         lev, amrex::convert(ba, jx_nodal_flag),
         dm, ncomps, ngJ, 0.0_rt);
-    fields.alloc_init(FieldType::hybrid_current_fp_ampere, Direction{1},
+    fields.alloc_init(FieldType::hybrid_j_fp_ampere, Direction{1},
         lev, amrex::convert(ba, jy_nodal_flag),
         dm, ncomps, ngJ, 0.0_rt);
-    fields.alloc_init(FieldType::hybrid_current_fp_ampere, Direction{2},
+    fields.alloc_init(FieldType::hybrid_j_fp_ampere, Direction{2},
         lev, amrex::convert(ba, jz_nodal_flag),
         dm, ncomps, ngJ, 0.0_rt);
 
     // the external current density multifab is made nodal to avoid needing to interpolate
     // to a nodal grid as has to be done for the ion and total current density multifabs
     // this also allows the external current multifab to not have any ghost cells
-    fields.alloc_init(FieldType::hybrid_current_fp_external, Direction{0},
+    fields.alloc_init(FieldType::hybrid_j_fp_external, Direction{0},
         lev, amrex::convert(ba, IntVect(AMREX_D_DECL(1,1,1))),
         dm, ncomps, IntVect(AMREX_D_DECL(0,0,0)), 0.0_rt);
-    fields.alloc_init(FieldType::hybrid_current_fp_external, Direction{1},
+    fields.alloc_init(FieldType::hybrid_j_fp_external, Direction{1},
         lev, amrex::convert(ba, IntVect(AMREX_D_DECL(1,1,1))),
         dm, ncomps, IntVect(AMREX_D_DECL(0,0,0)), 0.0_rt);
-    fields.alloc_init(FieldType::hybrid_current_fp_external, Direction{2},
+    fields.alloc_init(FieldType::hybrid_j_fp_external, Direction{2},
         lev, amrex::convert(ba, IntVect(AMREX_D_DECL(1,1,1))),
         dm, ncomps, IntVect(AMREX_D_DECL(0,0,0)), 0.0_rt);
 
@@ -147,9 +147,9 @@ void HybridPICModel::InitData ()
     using ablastr::fields::Direction;
 
     // Get the grid staggering of the fields involved in calculating E
-    amrex::IntVect Jx_stag = warpx.m_fields.get(FieldType::current_fp, Direction{0}, 0)->ixType().toIntVect();
-    amrex::IntVect Jy_stag = warpx.m_fields.get(FieldType::current_fp, Direction{1}, 0)->ixType().toIntVect();
-    amrex::IntVect Jz_stag = warpx.m_fields.get(FieldType::current_fp, Direction{2}, 0)->ixType().toIntVect();
+    amrex::IntVect Jx_stag = warpx.m_fields.get(FieldType::j_fp, Direction{0}, 0)->ixType().toIntVect();
+    amrex::IntVect Jy_stag = warpx.m_fields.get(FieldType::j_fp, Direction{1}, 0)->ixType().toIntVect();
+    amrex::IntVect Jz_stag = warpx.m_fields.get(FieldType::j_fp, Direction{2}, 0)->ixType().toIntVect();
     amrex::IntVect Bx_stag = warpx.m_fields.get(FieldType::Bfield_fp, Direction{0}, 0)->ixType().toIntVect();
     amrex::IntVect By_stag = warpx.m_fields.get(FieldType::Bfield_fp, Direction{1}, 0)->ixType().toIntVect();
     amrex::IntVect Bz_stag = warpx.m_fields.get(FieldType::Bfield_fp, Direction{2}, 0)->ixType().toIntVect();
@@ -269,9 +269,9 @@ void HybridPICModel::GetCurrentExternal (
     const RealBox& real_box = warpx.Geom(lev).ProbDomain();
 
     using ablastr::fields::Direction;
-    amrex::MultiFab * mfx = warpx.m_fields.get(FieldType::hybrid_current_fp_external, Direction{0}, lev);
-    amrex::MultiFab * mfy = warpx.m_fields.get(FieldType::hybrid_current_fp_external, Direction{1}, lev);
-    amrex::MultiFab * mfz = warpx.m_fields.get(FieldType::hybrid_current_fp_external, Direction{2}, lev);
+    amrex::MultiFab * mfx = warpx.m_fields.get(FieldType::hybrid_j_fp_external, Direction{0}, lev);
+    amrex::MultiFab * mfy = warpx.m_fields.get(FieldType::hybrid_j_fp_external, Direction{1}, lev);
+    amrex::MultiFab * mfz = warpx.m_fields.get(FieldType::hybrid_j_fp_external, Direction{2}, lev);
 
     const amrex::IntVect x_nodal_flag = mfx->ixType().toIntVect();
     const amrex::IntVect y_nodal_flag = mfy->ixType().toIntVect();
@@ -403,16 +403,16 @@ void HybridPICModel::CalculateCurrentAmpere (
     WARPX_PROFILE("WarpX::CalculateCurrentAmpere()");
 
     auto& warpx = WarpX::GetInstance();
-    ablastr::fields::VectorField current_fp_ampere = warpx.m_fields.get_alldirs(FieldType::hybrid_current_fp_ampere, lev);
+    ablastr::fields::VectorField j_fp_ampere = warpx.m_fields.get_alldirs(FieldType::hybrid_j_fp_ampere, lev);
     warpx.get_pointer_fdtd_solver_fp(lev)->CalculateCurrentAmpere(
-        current_fp_ampere, Bfield, edge_lengths, lev
+        j_fp_ampere, Bfield, edge_lengths, lev
     );
 
     // we shouldn't apply the boundary condition to J since J = J_i - J_e but
     // the boundary correction was already applied to J_i and the B-field
     // boundary ensures that J itself complies with the boundary conditions, right?
     // ApplyJfieldBoundary(lev, Jfield[0].get(), Jfield[1].get(), Jfield[2].get());
-    for (int i=0; i<3; i++) { current_fp_ampere[i]->FillBoundary(warpx.Geom(lev).periodicity()); }
+    for (int i=0; i<3; i++) { j_fp_ampere[i]->FillBoundary(warpx.Geom(lev).periodicity()); }
 }
 
 void HybridPICModel::HybridPICSolveE (
@@ -466,13 +466,13 @@ void HybridPICModel::HybridPICSolveE (
 
     auto& warpx = WarpX::GetInstance();
 
-    ablastr::fields::VectorField current_fp_ampere = warpx.m_fields.get_alldirs(FieldType::hybrid_current_fp_ampere, lev);
-    const ablastr::fields::VectorField current_fp_external = warpx.m_fields.get_alldirs(FieldType::hybrid_current_fp_external, lev);
+    ablastr::fields::VectorField j_fp_ampere = warpx.m_fields.get_alldirs(FieldType::hybrid_j_fp_ampere, lev);
+    const ablastr::fields::VectorField j_fp_external = warpx.m_fields.get_alldirs(FieldType::hybrid_j_fp_external, lev);
     const ablastr::fields::ScalarField electron_pressure_fp = warpx.m_fields.get(FieldType::hybrid_electron_pressure_fp, lev);
 
     // Solve E field in regular cells
     warpx.get_pointer_fdtd_solver_fp(lev)->HybridPICSolveE(
-        Efield, current_fp_ampere, Jfield, current_fp_external,
+        Efield, j_fp_ampere, Jfield, j_fp_external,
         Bfield, rhofield,
         *electron_pressure_fp,
         edge_lengths, lev, this, solve_for_Faraday

--- a/Source/FieldSolver/MagnetostaticSolver/MagnetostaticSolver.cpp
+++ b/Source/FieldSolver/MagnetostaticSolver/MagnetostaticSolver.cpp
@@ -89,10 +89,10 @@ WarpX::AddMagnetostaticFieldLabFrame()
                                      "Error: RZ magnetostatic only implemented for a single mode");
 #endif
 
-    // reset current_fp before depositing current density for this step
+    // reset j_fp before depositing current density for this step
     for (int lev = 0; lev <= max_level; lev++) {
         for (int dim=0; dim < 3; dim++) {
-            m_fields.get(FieldType::current_fp, Direction{dim}, lev)->setVal(0.);
+            m_fields.get(FieldType::j_fp, Direction{dim}, lev)->setVal(0.);
         }
     }
 
@@ -101,7 +101,7 @@ WarpX::AddMagnetostaticFieldLabFrame()
         WarpXParticleContainer& species = mypc->GetParticleContainer(ispecies);
         if (!species.do_not_deposit) {
             species.DepositCurrent(
-                m_fields.get_mr_levels_alldirs(FieldType::current_fp, finest_level),
+                m_fields.get_mr_levels_alldirs(FieldType::j_fp, finest_level),
                 dt[0], 0.);
         }
     }
@@ -109,14 +109,14 @@ WarpX::AddMagnetostaticFieldLabFrame()
 #ifdef WARPX_DIM_RZ
     for (int lev = 0; lev <= max_level; lev++) {
         ApplyInverseVolumeScalingToCurrentDensity(
-            m_fields.get(FieldType::current_fp, Direction{0}, lev),
-            m_fields.get(FieldType::current_fp, Direction{1}, lev),
-            m_fields.get(FieldType::current_fp, Direction{2}, lev),
+            m_fields.get(FieldType::j_fp, Direction{0}, lev),
+            m_fields.get(FieldType::j_fp, Direction{1}, lev),
+            m_fields.get(FieldType::j_fp, Direction{2}, lev),
             lev );
     }
 #endif
 
-    SyncCurrent("current_fp");
+    SyncCurrent("j_fp");
 
     // set the boundary and current density potentials
     setVectorPotentialBC(m_fields.get_mr_levels_alldirs(FieldType::vector_potential_fp_nodal, finest_level));
@@ -133,7 +133,7 @@ WarpX::AddMagnetostaticFieldLabFrame()
     const int self_fields_verbosity = 2;
 
     computeVectorPotential(
-        m_fields.get_mr_levels_alldirs(FieldType::current_fp, finest_level),
+        m_fields.get_mr_levels_alldirs(FieldType::j_fp, finest_level),
         m_fields.get_mr_levels_alldirs(FieldType::vector_potential_fp_nodal, finest_level),
         self_fields_required_precision, magnetostatic_absolute_tolerance, self_fields_max_iters,
         self_fields_verbosity);

--- a/Source/FieldSolver/WarpX_QED_Field_Pushers.cpp
+++ b/Source/FieldSolver/WarpX_QED_Field_Pushers.cpp
@@ -90,9 +90,9 @@ WarpX::Hybrid_QED_Push (int lev, PatchType patch_type, amrex::Real a_dt)
         Bx = m_fields.get(FieldType::Bfield_fp, Direction{0}, lev);
         By = m_fields.get(FieldType::Bfield_fp, Direction{1}, lev);
         Bz = m_fields.get(FieldType::Bfield_fp, Direction{2}, lev);
-        Jx = m_fields.get(FieldType::current_fp, Direction{0}, lev);
-        Jy = m_fields.get(FieldType::current_fp, Direction{1}, lev);
-        Jz = m_fields.get(FieldType::current_fp, Direction{2}, lev);
+        Jx = m_fields.get(FieldType::j_fp, Direction{0}, lev);
+        Jy = m_fields.get(FieldType::j_fp, Direction{1}, lev);
+        Jz = m_fields.get(FieldType::j_fp, Direction{2}, lev);
     }
     else
     {
@@ -102,9 +102,9 @@ WarpX::Hybrid_QED_Push (int lev, PatchType patch_type, amrex::Real a_dt)
         Bx = m_fields.get(FieldType::Bfield_cp, Direction{0}, lev);
         By = m_fields.get(FieldType::Bfield_cp, Direction{1}, lev);
         Bz = m_fields.get(FieldType::Bfield_cp, Direction{2}, lev);
-        Jx = m_fields.get(FieldType::current_cp, Direction{0}, lev);
-        Jy = m_fields.get(FieldType::current_cp, Direction{1}, lev);
-        Jz = m_fields.get(FieldType::current_cp, Direction{2}, lev);
+        Jx = m_fields.get(FieldType::j_cp, Direction{0}, lev);
+        Jy = m_fields.get(FieldType::j_cp, Direction{1}, lev);
+        Jz = m_fields.get(FieldType::j_cp, Direction{2}, lev);
     }
 
     amrex::LayoutData<amrex::Real>* cost = WarpX::getCosts(lev);

--- a/Source/Fields.H
+++ b/Source/Fields.H
@@ -26,9 +26,9 @@ namespace warpx::fields
         Bfield_fp,  //!< The field that is updated by the field solver at each timestep
         Efield_fp_external, //!< Stores grid particle fields provided by the user as  through an openPMD file
         Bfield_fp_external, //!< Stores grid particle fields provided by the user as  through an openPMD file
-        current_fp, //!< The current that is used as a source for the field solver
-        current_fp_nodal, //!< Only used when using nodal current deposition
-        current_fp_vay,   //!< Only used when using Vay current deposition
+        j_fp, //!< The current that is used as a source for the field solver
+        j_fp_nodal, //!< Only used when using nodal current deposition
+        j_fp_vay,   //!< Only used when using Vay current deposition
         current_buf, //!< Particles that are close to the edge of the MR patch (i.e. in the deposition buffer) deposit to this field.
         current_store, //!< Only used when doing subcycling with mesh refinement, for book-keeping of currents
         rho_buf, //!< Particles that are close to the edge of the MR patch (i.e. in the deposition buffer) deposit to this field.
@@ -42,12 +42,12 @@ namespace warpx::fields
         vector_potential_grad_buf_b_stag,
         hybrid_electron_pressure_fp,
         hybrid_rho_fp_temp,
-        hybrid_current_fp_temp,
-        hybrid_current_fp_ampere,
-        hybrid_current_fp_external,
+        hybrid_j_fp_temp,
+        hybrid_j_fp_ampere,
+        hybrid_j_fp_external,
         Efield_cp,  //!< Only used with MR. The field that is updated by the field solver at each timestep, on the coarse patch of each level
         Bfield_cp,  //!< Only used with MR. The field that is updated by the field solver at each timestep, on the coarse patch of each level
-        current_cp, //!< Only used with MR. The current that is used as a source for the field solver, on the coarse patch of each level
+        j_cp, //!< Only used with MR. The current that is used as a source for the field solver, on the coarse patch of each level
         rho_cp, //!< Only used with MR. The charge density that is used as a source for the field solver, on the coarse patch of each level
         F_cp,   //!< Only used with MR. Used for divE cleaning, on the coarse patch of each level
         G_cp,   //!< Only used with MR. Used for divB cleaning, on the coarse patch of each level
@@ -85,21 +85,21 @@ namespace warpx::fields
         FieldType::Bfield_aux,
         FieldType::Efield_fp,
         FieldType::Bfield_fp,
-        FieldType::current_fp,
-        FieldType::current_fp_nodal,
-        FieldType::current_fp_vay,
+        FieldType::j_fp,
+        FieldType::j_fp_nodal,
+        FieldType::j_fp_vay,
         FieldType::current_buf,
         FieldType::current_store,
         FieldType::vector_potential_fp,
         FieldType::vector_potential_fp_nodal,
         FieldType::vector_potential_grad_buf_e_stag,
         FieldType::vector_potential_grad_buf_b_stag,
-        FieldType::hybrid_current_fp_temp,
-        FieldType::hybrid_current_fp_ampere,
-        FieldType::hybrid_current_fp_external,
+        FieldType::hybrid_j_fp_temp,
+        FieldType::hybrid_j_fp_ampere,
+        FieldType::hybrid_j_fp_external,
         FieldType::Efield_cp,
         FieldType::Bfield_cp,
-        FieldType::current_cp,
+        FieldType::j_cp,
         FieldType::Efield_cax,
         FieldType::Bfield_cax,
         FieldType::E_external_particle_field,

--- a/Source/Fluids/MultiFluidContainer.H
+++ b/Source/Fluids/MultiFluidContainer.H
@@ -64,7 +64,7 @@ public:
     ///
     void Evolve (ablastr::fields::MultiFabRegister& fields,
                  int lev,
-                 std::string const& current_fp_string,
+                 std::string const& j_fp_string,
                  amrex::Real cur_time,
                  bool skip_deposition=false);
 

--- a/Source/Fluids/MultiFluidContainer.cpp
+++ b/Source/Fluids/MultiFluidContainer.cpp
@@ -63,11 +63,11 @@ MultiFluidContainer::DepositCurrent (ablastr::fields::MultiFabRegister& m_fields
 void
 MultiFluidContainer::Evolve (ablastr::fields::MultiFabRegister& fields,
                             int lev,
-                            std::string const& current_fp_string,
+                            std::string const& j_fp_string,
                             amrex::Real cur_time,
                             bool skip_deposition)
 {
     for (auto& fl : allcontainers) {
-        fl->Evolve(fields, lev, current_fp_string, cur_time, skip_deposition);
+        fl->Evolve(fields, lev, j_fp_string, cur_time, skip_deposition);
     }
 }

--- a/Source/Fluids/WarpXFluidContainer.H
+++ b/Source/Fluids/WarpXFluidContainer.H
@@ -49,7 +49,7 @@ public:
      */
     void Evolve (ablastr::fields::MultiFabRegister& fields,
                  int lev,
-                 const std::string& current_fp_string,
+                 const std::string& j_fp_string,
                  amrex::Real cur_time,
                  bool skip_deposition=false);
 

--- a/Source/Fluids/WarpXFluidContainer.cpp
+++ b/Source/Fluids/WarpXFluidContainer.cpp
@@ -257,7 +257,7 @@ void WarpXFluidContainer::InitData(ablastr::fields::MultiFabRegister& fields, am
 void WarpXFluidContainer::Evolve(
     ablastr::fields::MultiFabRegister& fields,
     int lev,
-    const std::string& current_fp_string,
+    const std::string& j_fp_string,
     amrex::Real cur_time,
     bool skip_deposition)
 {
@@ -306,9 +306,9 @@ void WarpXFluidContainer::Evolve(
     // Deposit J to the simulation mesh
     if (!skip_deposition && ! do_not_deposit) {
         DepositCurrent(fields,
-                        *fields.get(current_fp_string, Direction{0}, lev),
-                        *fields.get(current_fp_string, Direction{1}, lev),
-                        *fields.get(current_fp_string, Direction{2}, lev),
+                        *fields.get(j_fp_string, Direction{0}, lev),
+                        *fields.get(j_fp_string, Direction{1}, lev),
+                        *fields.get(j_fp_string, Direction{2}, lev),
                         lev);
     }
 }

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -1241,7 +1241,7 @@ void WarpX::CheckGuardCells()
         {
             ::CheckGuardCells(m_fields, "Efield_fp[" + std::to_string(dim) + "]", lev);
             ::CheckGuardCells(m_fields, "Bfield_fp[" + std::to_string(dim) + "]", lev);
-            ::CheckGuardCells(m_fields, "current_fp[" + std::to_string(dim) + "]", lev);
+            ::CheckGuardCells(m_fields, "j_fp[" + std::to_string(dim) + "]", lev);
 
             if (WarpX::fft_do_time_averaging)
             {
@@ -1261,7 +1261,7 @@ void WarpX::CheckGuardCells()
             {
                 ::CheckGuardCells(m_fields, "Efield_cp[" + std::to_string(dim) + "]", lev);
                 ::CheckGuardCells(m_fields, "Bfield_cp[" + std::to_string(dim) + "]", lev);
-                ::CheckGuardCells(m_fields, "current_cp[" + std::to_string(dim) + "]", lev);
+                ::CheckGuardCells(m_fields, "j_cp[" + std::to_string(dim) + "]", lev);
 
                 if (WarpX::fft_do_time_averaging)
                 {

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -1071,18 +1071,18 @@ WarpX::FillBoundaryAux (int lev, IntVect ng)
 }
 
 void
-WarpX::SyncCurrent (const std::string& current_fp_string)
+WarpX::SyncCurrent (const std::string& j_fp_string)
 {
     using ablastr::fields::Direction;
 
     WARPX_PROFILE("WarpX::SyncCurrent()");
 
-    ablastr::fields::MultiLevelVectorField const& J_fp = m_fields.get_mr_levels_alldirs(current_fp_string, finest_level);
+    ablastr::fields::MultiLevelVectorField const& J_fp = m_fields.get_mr_levels_alldirs(j_fp_string, finest_level);
 
     // If warpx.do_current_centering = 1, center currents from nodal grid to staggered grid
     if (do_current_centering)
     {
-        ablastr::fields::MultiLevelVectorField const& J_fp_nodal = m_fields.get_mr_levels_alldirs(FieldType::current_fp_nodal, finest_level+1);
+        ablastr::fields::MultiLevelVectorField const& J_fp_nodal = m_fields.get_mr_levels_alldirs(FieldType::j_fp_nodal, finest_level+1);
 
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(finest_level <= 1,
                                          "warpx.do_current_centering=1 not supported with more than one fine levels");
@@ -1192,7 +1192,7 @@ WarpX::SyncCurrent (const std::string& current_fp_string)
                     }
                 });
                 // Now it's safe to apply filter and sumboundary on J_cp
-                ablastr::fields::MultiLevelVectorField const& J_cp = m_fields.get_mr_levels_alldirs(FieldType::current_cp, finest_level);
+                ablastr::fields::MultiLevelVectorField const& J_cp = m_fields.get_mr_levels_alldirs(FieldType::j_cp, finest_level);
                 if (use_filter)
                 {
                     ApplyFilterJ(J_cp, lev+1, idim);
@@ -1207,7 +1207,7 @@ WarpX::SyncCurrent (const std::string& current_fp_string)
                 // filtering depends on the level. This is also done before any
                 // same-level communication because it's easier this way to
                 // avoid double counting.
-                ablastr::fields::MultiLevelVectorField const& J_cp = m_fields.get_mr_levels_alldirs(FieldType::current_cp, finest_level);
+                ablastr::fields::MultiLevelVectorField const& J_cp = m_fields.get_mr_levels_alldirs(FieldType::j_cp, finest_level);
                 J_cp[lev][Direction{idim}]->setVal(0.0);
                 ablastr::coarsen::average::Coarsen(*J_cp[lev][Direction{idim}],
                                                    *J_fp[lev][Direction{idim}],

--- a/Source/Particles/LaserParticleContainer.H
+++ b/Source/Particles/LaserParticleContainer.H
@@ -66,7 +66,7 @@ public:
 
     void Evolve (ablastr::fields::MultiFabRegister& fields,
                  int lev,
-                 const std::string& current_fp_string,
+                 const std::string& j_fp_string,
                  amrex::Real t, amrex::Real dt, DtType a_dt_type=DtType::Full,
                  bool skip_deposition=false, PushType push_type=PushType::Explicit) final;
 

--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -559,7 +559,7 @@ LaserParticleContainer::InitData (int lev)
 void
 LaserParticleContainer::Evolve (ablastr::fields::MultiFabRegister& fields,
                                 int lev,
-                                const std::string& current_fp_string,
+                                const std::string& j_fp_string,
                                 Real t, Real dt, DtType /*a_dt_type*/, bool skip_deposition, PushType push_type)
 {
     using ablastr::fields::Direction;
@@ -581,7 +581,7 @@ LaserParticleContainer::Evolve (ablastr::fields::MultiFabRegister& fields,
     // Update laser profile
     m_up_laser_profile->update(t_lab);
 
-    BL_ASSERT(OnSameGrids(lev, *fields.get(FieldType::current_fp, Direction{0}, lev)));
+    BL_ASSERT(OnSameGrids(lev, *fields.get(FieldType::j_fp, Direction{0}, lev)));
 
     amrex::LayoutData<amrex::Real>* cost = WarpX::getCosts(lev);
 
@@ -668,9 +668,9 @@ LaserParticleContainer::Evolve (ablastr::fields::MultiFabRegister& fields,
 
                 int* ion_lev = nullptr;
                 // Deposit inside domains
-                amrex::MultiFab * jx = fields.get(current_fp_string, Direction{0}, lev);
-                amrex::MultiFab * jy = fields.get(current_fp_string, Direction{1}, lev);
-                amrex::MultiFab * jz = fields.get(current_fp_string, Direction{2}, lev);
+                amrex::MultiFab * jx = fields.get(j_fp_string, Direction{0}, lev);
+                amrex::MultiFab * jy = fields.get(j_fp_string, Direction{1}, lev);
+                amrex::MultiFab * jz = fields.get(j_fp_string, Direction{2}, lev);
                 DepositCurrent(pti, wp, uxp, uyp, uzp, ion_lev, jx, jy, jz,
                                0, np_current, thread_num,
                                lev, lev, dt, relative_time, push_type);

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -107,7 +107,7 @@ public:
     void Evolve (
         ablastr::fields::MultiFabRegister& fields,
         int lev,
-        std::string const& current_fp_string,
+        std::string const& j_fp_string,
         amrex::Real t,
         amrex::Real dt,
         DtType a_dt_type=DtType::Full,

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -460,16 +460,16 @@ MultiParticleContainer::InitMultiPhysicsModules ()
 void
 MultiParticleContainer::Evolve (ablastr::fields::MultiFabRegister& fields,
                                 int lev,
-                                std::string const& current_fp_string,
+                                std::string const& j_fp_string,
                                 Real t, Real dt, DtType a_dt_type, bool skip_deposition,
                                 PushType push_type)
 {
     if (! skip_deposition) {
         using ablastr::fields::Direction;
 
-        fields.get(current_fp_string, Direction{0}, lev)->setVal(0.0);
-        fields.get(current_fp_string, Direction{1}, lev)->setVal(0.0);
-        fields.get(current_fp_string, Direction{2}, lev)->setVal(0.0);
+        fields.get(j_fp_string, Direction{0}, lev)->setVal(0.0);
+        fields.get(j_fp_string, Direction{1}, lev)->setVal(0.0);
+        fields.get(j_fp_string, Direction{2}, lev)->setVal(0.0);
         if (fields.has(FieldType::current_buf, Direction{0}, lev)) { fields.get(FieldType::current_buf, Direction{0}, lev)->setVal(0.0); }
         if (fields.has(FieldType::current_buf, Direction{1}, lev)) { fields.get(FieldType::current_buf, Direction{1}, lev)->setVal(0.0); }
         if (fields.has(FieldType::current_buf, Direction{2}, lev)) { fields.get(FieldType::current_buf, Direction{2}, lev)->setVal(0.0); }
@@ -477,7 +477,7 @@ MultiParticleContainer::Evolve (ablastr::fields::MultiFabRegister& fields,
         if (fields.has(FieldType::rho_buf, lev)) { fields.get(FieldType::rho_buf, lev)->setVal(0.0); }
     }
     for (auto& pc : allcontainers) {
-        pc->Evolve(fields, lev, current_fp_string, t, dt, a_dt_type, skip_deposition, push_type);
+        pc->Evolve(fields, lev, j_fp_string, t, dt, a_dt_type, skip_deposition, push_type);
     }
 }
 

--- a/Source/Particles/PhotonParticleContainer.H
+++ b/Source/Particles/PhotonParticleContainer.H
@@ -48,7 +48,7 @@ public:
 
     void Evolve (ablastr::fields::MultiFabRegister& fields,
                  int lev,
-                 const std::string& current_fp_string,
+                 const std::string& j_fp_string,
                  amrex::Real t,
                  amrex::Real dt,
                  DtType a_dt_type=DtType::Full,

--- a/Source/Particles/PhotonParticleContainer.cpp
+++ b/Source/Particles/PhotonParticleContainer.cpp
@@ -231,7 +231,7 @@ PhotonParticleContainer::PushPX (WarpXParIter& pti,
 void
 PhotonParticleContainer::Evolve (ablastr::fields::MultiFabRegister& fields,
                                  int lev,
-                                 const std::string& current_fp_string,
+                                 const std::string& j_fp_string,
                                  Real t, Real dt, DtType a_dt_type, bool skip_deposition,
                                  PushType push_type)
 {
@@ -239,7 +239,7 @@ PhotonParticleContainer::Evolve (ablastr::fields::MultiFabRegister& fields,
     // Push and deposit have been re-written for photons
     PhysicalParticleContainer::Evolve (fields,
                                        lev,
-                                       current_fp_string,
+                                       j_fp_string,
                                        t, dt, a_dt_type, skip_deposition, push_type);
 
 }

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -83,7 +83,7 @@ public:
      *
      * \param fields the WarpX field register
      * \param lev level on which particles are living
-     * \param current_fp_string current coarse or fine patch identifier in fields
+     * \param j_fp_string current coarse or fine patch identifier in fields
      * \param t current physical time
      * \param dt time step by which particles are advanced
      * \param a_dt_type type of time step (used for sub-cycling)
@@ -96,7 +96,7 @@ public:
      */
     void Evolve (ablastr::fields::MultiFabRegister& fields,
                  int lev,
-                 const std::string& current_fp_string,
+                 const std::string& j_fp_string,
                  amrex::Real t,
                  amrex::Real dt,
                  DtType a_dt_type=DtType::Full,

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1735,7 +1735,7 @@ PhysicalParticleContainer::AddPlasmaFlux (PlasmaInjector const& plasma_injector,
 void
 PhysicalParticleContainer::Evolve (ablastr::fields::MultiFabRegister& fields,
                                    int lev,
-                                   const std::string& current_fp_string,
+                                   const std::string& j_fp_string,
                                    Real /*t*/, Real dt, DtType a_dt_type, bool skip_deposition,
                                    PushType push_type)
 {
@@ -1745,7 +1745,7 @@ PhysicalParticleContainer::Evolve (ablastr::fields::MultiFabRegister& fields,
     WARPX_PROFILE("PhysicalParticleContainer::Evolve()");
     WARPX_PROFILE_VAR_NS("PhysicalParticleContainer::Evolve::GatherAndPush", blp_fg);
 
-    BL_ASSERT(OnSameGrids(lev, *fields.get(FieldType::current_fp, Direction{0}, lev)));
+    BL_ASSERT(OnSameGrids(lev, *fields.get(FieldType::j_fp, Direction{0}, lev)));
 
     amrex::LayoutData<amrex::Real>* cost = WarpX::getCosts(lev);
 
@@ -1955,9 +1955,9 @@ PhysicalParticleContainer::Evolve (ablastr::fields::MultiFabRegister& fields,
                         pti.GetiAttribs(particle_icomps["ionizationLevel"]).dataPtr():nullptr;
 
                     // Deposit inside domains
-                    amrex::MultiFab * jx = fields.get(current_fp_string, Direction{0}, lev);
-                    amrex::MultiFab * jy = fields.get(current_fp_string, Direction{1}, lev);
-                    amrex::MultiFab * jz = fields.get(current_fp_string, Direction{2}, lev);
+                    amrex::MultiFab * jx = fields.get(j_fp_string, Direction{0}, lev);
+                    amrex::MultiFab * jy = fields.get(j_fp_string, Direction{1}, lev);
+                    amrex::MultiFab * jz = fields.get(j_fp_string, Direction{2}, lev);
                     DepositCurrent(pti, wp, uxp, uyp, uzp, ion_lev, jx, jy, jz,
                                    0, np_current, thread_num,
                                    lev, lev, dt, relative_time, push_type);

--- a/Source/Particles/RigidInjectedParticleContainer.H
+++ b/Source/Particles/RigidInjectedParticleContainer.H
@@ -63,7 +63,7 @@ public:
 
     void Evolve (ablastr::fields::MultiFabRegister& fields,
                  int lev,
-                 const std::string& current_fp_string,
+                 const std::string& j_fp_string,
                  amrex::Real t,
                  amrex::Real dt,
                  DtType a_dt_type=DtType::Full,

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -293,7 +293,7 @@ RigidInjectedParticleContainer::PushPX (WarpXParIter& pti,
 void
 RigidInjectedParticleContainer::Evolve (ablastr::fields::MultiFabRegister& fields,
                                         int lev,
-                                        const std::string& current_fp_string,
+                                        const std::string& j_fp_string,
                                         Real t, Real dt, DtType a_dt_type, bool skip_deposition,
                                         PushType push_type)
 {
@@ -314,7 +314,7 @@ RigidInjectedParticleContainer::Evolve (ablastr::fields::MultiFabRegister& field
 
     PhysicalParticleContainer::Evolve (fields,
                                        lev,
-                                       current_fp_string,
+                                       j_fp_string,
                                        t, dt, a_dt_type, skip_deposition, push_type);
 }
 

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -149,7 +149,7 @@ public:
      */
     virtual void Evolve (ablastr::fields::MultiFabRegister& fields,
                          int lev,
-                         const std::string& current_fp_string,
+                         const std::string& j_fp_string,
                          amrex::Real t, amrex::Real dt, DtType a_dt_type=DtType::Full, bool skip_deposition=false,
                          PushType push_type=PushType::Explicit) = 0;
 

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -251,7 +251,7 @@ WarpX::MoveWindow (const int step, bool move_j)
                    m_p_ext_field_params-> E_external_grid[dim], use_Eparser, Efield_parser);
             }
             if (move_j) {
-                shiftMF(*m_fields.get(FieldType::current_fp, Direction{dim}, lev), geom[lev], num_shift, dir, lev, do_update_cost);
+                shiftMF(*m_fields.get(FieldType::j_fp, Direction{dim}, lev), geom[lev], num_shift, dir, lev, do_update_cost);
             }
             if (pml[lev] && pml[lev]->ok()) {
                 amrex::MultiFab* pml_B = m_fields.get(FieldType::pml_B_fp, Direction{dim}, lev);
@@ -284,7 +284,7 @@ WarpX::MoveWindow (const int step, bool move_j)
                         m_p_ext_field_params->E_external_grid[dim], use_Eparser, Efield_parser);
                 }
                 if (move_j) {
-                    shiftMF(*m_fields.get(FieldType::current_cp, Direction{dim}, lev), geom[lev-1], num_shift_crse, dir, lev, do_update_cost);
+                    shiftMF(*m_fields.get(FieldType::j_cp, Direction{dim}, lev), geom[lev-1], num_shift_crse, dir, lev, do_update_cost);
                 }
                 if (do_pml && pml[lev]->ok()) {
                     amrex::MultiFab* pml_B_cp = m_fields.get(FieldType::pml_B_cp, Direction{dim}, lev);

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -815,9 +815,9 @@ public:
      * Then, for each MR level, including level 0, apply filter and sum guard
      * cells across levels.
      *
-     * \param[in] current_fp_string the coarse of fine patch to use for current
+     * \param[in] j_fp_string the coarse of fine patch to use for current
      */
-    void SyncCurrent (const std::string& current_fp_string);
+    void SyncCurrent (const std::string& j_fp_string);
 
     void SyncRho ();
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -2202,23 +2202,23 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     m_fields.alloc_init(FieldType::Efield_fp, Direction{1}, lev, amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
     m_fields.alloc_init(FieldType::Efield_fp, Direction{2}, lev, amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
 
-    m_fields.alloc_init(FieldType::current_fp, Direction{0}, lev, amrex::convert(ba, jx_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
-    m_fields.alloc_init(FieldType::current_fp, Direction{1}, lev, amrex::convert(ba, jy_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
-    m_fields.alloc_init(FieldType::current_fp, Direction{2}, lev, amrex::convert(ba, jz_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
+    m_fields.alloc_init(FieldType::j_fp, Direction{0}, lev, amrex::convert(ba, jx_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
+    m_fields.alloc_init(FieldType::j_fp, Direction{1}, lev, amrex::convert(ba, jy_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
+    m_fields.alloc_init(FieldType::j_fp, Direction{2}, lev, amrex::convert(ba, jz_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
 
     if (do_current_centering)
     {
         amrex::BoxArray const& nodal_ba = amrex::convert(ba, amrex::IntVect::TheNodeVector());
-        m_fields.alloc_init(FieldType::current_fp_nodal, Direction{0}, lev, nodal_ba, dm, ncomps, ngJ, 0.0_rt);
-        m_fields.alloc_init(FieldType::current_fp_nodal, Direction{1}, lev, nodal_ba, dm, ncomps, ngJ, 0.0_rt);
-        m_fields.alloc_init(FieldType::current_fp_nodal, Direction{2}, lev, nodal_ba, dm, ncomps, ngJ, 0.0_rt);
+        m_fields.alloc_init(FieldType::j_fp_nodal, Direction{0}, lev, nodal_ba, dm, ncomps, ngJ, 0.0_rt);
+        m_fields.alloc_init(FieldType::j_fp_nodal, Direction{1}, lev, nodal_ba, dm, ncomps, ngJ, 0.0_rt);
+        m_fields.alloc_init(FieldType::j_fp_nodal, Direction{2}, lev, nodal_ba, dm, ncomps, ngJ, 0.0_rt);
     }
 
     if (WarpX::current_deposition_algo == CurrentDepositionAlgo::Vay)
     {
-        m_fields.alloc_init(FieldType::current_fp_vay, Direction{0}, lev, amrex::convert(ba, rho_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
-        m_fields.alloc_init(FieldType::current_fp_vay, Direction{1}, lev, amrex::convert(ba, rho_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
-        m_fields.alloc_init(FieldType::current_fp_vay, Direction{2}, lev, amrex::convert(ba, rho_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
+        m_fields.alloc_init(FieldType::j_fp_vay, Direction{0}, lev, amrex::convert(ba, rho_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
+        m_fields.alloc_init(FieldType::j_fp_vay, Direction{1}, lev, amrex::convert(ba, rho_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
+        m_fields.alloc_init(FieldType::j_fp_vay, Direction{2}, lev, amrex::convert(ba, rho_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
     }
 
     if (electrostatic_solver_id == ElectrostaticSolverAlgo::LabFrameElectroMagnetostatic)
@@ -2604,9 +2604,9 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         }
 
         // Create the MultiFabs for the current
-        m_fields.alloc_init(FieldType::current_cp, Direction{0}, lev, amrex::convert(cba, jx_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
-        m_fields.alloc_init(FieldType::current_cp, Direction{1}, lev, amrex::convert(cba, jy_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
-        m_fields.alloc_init(FieldType::current_cp, Direction{2}, lev, amrex::convert(cba, jz_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
+        m_fields.alloc_init(FieldType::j_cp, Direction{0}, lev, amrex::convert(cba, jx_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
+        m_fields.alloc_init(FieldType::j_cp, Direction{1}, lev, amrex::convert(cba, jy_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
+        m_fields.alloc_init(FieldType::j_cp, Direction{2}, lev, amrex::convert(cba, jz_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
 
         if (rho_ncomps > 0) {
             m_fields.alloc_init(FieldType::rho_cp,
@@ -3260,7 +3260,7 @@ WarpX::StoreCurrent (int lev)
     for (int idim = 0; idim < 3; ++idim) {
         if (m_fields.has(FieldType::current_store, Direction{idim},lev)) {
             MultiFab::Copy(*m_fields.get(FieldType::current_store, Direction{idim}, lev),
-                           *m_fields.get(FieldType::current_fp, Direction{idim}, lev),
+                           *m_fields.get(FieldType::j_fp, Direction{idim}, lev),
                            0, 0, 1, m_fields.get(FieldType::current_store, Direction{idim}, lev)->nGrowVect());
         }
     }
@@ -3275,7 +3275,7 @@ WarpX::RestoreCurrent (int lev)
     for (int idim = 0; idim < 3; ++idim) {
         if (m_fields.has(FieldType::current_store, Direction{idim}, lev)) {
             std::swap(
-                *m_fields.get(FieldType::current_fp, Direction{idim}, lev),
+                *m_fields.get(FieldType::j_fp, Direction{idim}, lev),
                 *m_fields.get(FieldType::current_store, Direction{idim}, lev)
             );
         }


### PR DESCRIPTION
This makes the name shorter and more consistent with the rest of the code.

Note that this will break the Python access API.