### PR TITLE
[WIP] Rename Efield/Bfield to E/B

### DIFF
--- a/Docs/source/developers/fields.rst
+++ b/Docs/source/developers/fields.rst
@@ -19,14 +19,14 @@ Due the AMR strategy used in WarpX (see section :ref:`Theory: AMR <theory-amr>` 
 
 * In some conditions, i.e., when buffers are used for the field gather (for numerical reasons), a **copy of E and B on the auxiliary grid** ``_aux`` **of the  level below** ``lev-1`` is stored in fields with suffix ``_cax`` (for `coarse aux`).
 
-As an example, the structures for the electric field are ``Efield_fp``, ``Efield_cp``, ``Efield_aux`` (and optionally ``Efield_cax``).
+As an example, the structures for the electric field are ``E_fp``, ``E_cp``, ``E_aux`` (and optionally ``E_cax``).
 
 Declaration
 -----------
 
 All the fields described above are public members of class ``WarpX``, defined in ``WarpX.H``. They are defined as an ``amrex::Vector`` (over MR levels) of ``std::array`` (for the 3 spatial components :math:`E_x`, :math:`E_y`, :math:`E_z`) of ``std::unique_ptr`` of ``amrex::MultiFab``, i.e.:
 
-  amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > Efield_fp;
+  amrex::Vector<std::array< std::unique_ptr<amrex::MultiFab>, 3 > > E_fp;
 
 Hence, ``Ex`` on MR level ``lev`` is a pointer to an ``amrex::MultiFab``. The other fields are organized in the same way.
 
@@ -50,7 +50,7 @@ As all cell-wise operation, the field push is done as follows (this is split in 
    // Loop over MR levels
    for (int lev = 0; lev <= finest_level; ++lev) {
       // Get pointer to MultiFab Ex on level lev
-      MultiFab* Ex = Efield_fp[lev][0].get();
+      MultiFab* Ex = E_fp[lev][0].get();
       // Loop over boxes (or tiles if not on GPU)
       for ( MFIter mfi(*Ex, TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
           // Apply field solver on the FAB

--- a/Docs/source/developers/particles.rst
+++ b/Docs/source/developers/particles.rst
@@ -72,7 +72,7 @@ On a loop over particles it can be useful to access the fields on the box we are
 
 .. code-block:: cpp
 
-  // E is a reference to, say, WarpX::Efield_aux
+  // E is a reference to, say, WarpX::E_aux
   // Get the Ex field on the grid
   const FArrayBox& exfab = (*E[lev][0])[pti];
   // Let's be generous and also get the underlying box (i.e., index info)
@@ -91,7 +91,7 @@ Main functions
 Buffers
 -------
 
-To reduce numerical artifacts at the boundary of a mesh-refinement patch, WarpX has an option to use buffers: When particles evolve on the fine level, they gather from the coarse level (e.g., ``Efield_cax``, a copy of the ``aux`` data from the level below) if they are located on the fine level but fewer than ``WarpX::n_field_gather_buffer`` cells away from the coarse-patch boundary. Similarly, when particles evolve on the fine level, they deposit on the coarse level (e.g., ``Efield_cp``) if they are located on the fine level but fewer than ``WarpX::n_current_deposition_buffer`` cells away from the coarse-patch boundary.
+To reduce numerical artifacts at the boundary of a mesh-refinement patch, WarpX has an option to use buffers: When particles evolve on the fine level, they gather from the coarse level (e.g., ``E_cax``, a copy of the ``aux`` data from the level below) if they are located on the fine level but fewer than ``WarpX::n_field_gather_buffer`` cells away from the coarse-patch boundary. Similarly, when particles evolve on the fine level, they deposit on the coarse level (e.g., ``E_cp``) if they are located on the fine level but fewer than ``WarpX::n_current_deposition_buffer`` cells away from the coarse-patch boundary.
 
 ``WarpX::gather_buffer_masks`` and ``WarpX::current_buffer_masks`` contain masks indicating if a cell is in the interior of the fine-resolution patch or in the buffers. Then, particles depending on this mask in
 

--- a/Docs/source/developers/python.rst
+++ b/Docs/source/developers/python.rst
@@ -101,7 +101,7 @@ Fields
 The ``fields`` module provides wrapper around most of the MultiFabs that are defined in the WarpX class.
 For a list of all of the available wrappers, see the file ``Python/pywarpx/fields.py``.
 For each MultiFab, there is a function that will return a wrapper around the data.
-For instance, the function ``ExWrapper`` returns a wrapper around the ``x`` component of the MultiFab vector ``Efield_aux``.
+For instance, the function ``ExWrapper`` returns a wrapper around the ``x`` component of the MultiFab vector ``E_aux``.
 
 .. code-block:: python
 

--- a/Docs/source/usage/workflows/python_extend.rst
+++ b/Docs/source/usage/workflows/python_extend.rst
@@ -76,7 +76,7 @@ This object is the Python equivalent to the C++ ``WarpX`` simulation class.
 
    .. py:method:: multifab(multifab_name: str)
 
-      Return MultiFabs by name, e.g., ``"Efield_aux[x][level=0]"``, ``"Efield_cp[x][level=0]"``, ...
+      Return MultiFabs by name, e.g., ``"E_aux[x][level=0]"``, ``"E_cp[x][level=0]"``, ...
 
       The physical fields in WarpX have the following naming:
 
@@ -134,7 +134,7 @@ This example accesses the :math:`E_x(x,y,z)` field at level 0 after every time s
        warpx = sim.extension.warpx
 
        # data access
-       E_x_mf = warpx.multifab(f"Efield_fp[x][level=0]")
+       E_x_mf = warpx.multifab(f"E_fp[x][level=0]")
 
        # compute
        # iterate over mesh-refinement levels

--- a/Python/pywarpx/callbacks.py
+++ b/Python/pywarpx/callbacks.py
@@ -25,7 +25,7 @@ extra reference to the method's object is saved.
 
 Functions can be called at the following times:
 
-* ``loadExternalFields``: during ``WarpX::LoadExternalFields`` to write ``B/Efield_fp_external`` values
+* ``loadExternalFields``: during ``WarpX::LoadExternalFields`` to write ``B/E_fp_external`` values
 * ``beforeInitEsolve``: before the initial solve for the E fields (i.e. before the PIC loop starts)
 * ``afterinit``: immediately after the init is complete
 * ``beforeEsolve``: before the solve for E fields

--- a/Python/pywarpx/fields.py
+++ b/Python/pywarpx/fields.py
@@ -580,37 +580,37 @@ class _MultiFABWrapper(object):
 
 def ExWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Efield_aux", idir=0, level=level, include_ghosts=include_ghosts
+        mf_name="E_aux", idir=0, level=level, include_ghosts=include_ghosts
     )
 
 
 def EyWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Efield_aux", idir=1, level=level, include_ghosts=include_ghosts
+        mf_name="E_aux", idir=1, level=level, include_ghosts=include_ghosts
     )
 
 
 def EzWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Efield_aux", idir=2, level=level, include_ghosts=include_ghosts
+        mf_name="E_aux", idir=2, level=level, include_ghosts=include_ghosts
     )
 
 
 def BxWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Bfield_aux", idir=0, level=level, include_ghosts=include_ghosts
+        mf_name="B_aux", idir=0, level=level, include_ghosts=include_ghosts
     )
 
 
 def ByWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Bfield_aux", idir=1, level=level, include_ghosts=include_ghosts
+        mf_name="B_aux", idir=1, level=level, include_ghosts=include_ghosts
     )
 
 
 def BzWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Bfield_aux", idir=2, level=level, include_ghosts=include_ghosts
+        mf_name="B_aux", idir=2, level=level, include_ghosts=include_ghosts
     )
 
 
@@ -634,73 +634,73 @@ def JzWrapper(level=0, include_ghosts=False):
 
 def ExFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Efield_fp", idir=0, level=level, include_ghosts=include_ghosts
+        mf_name="E_fp", idir=0, level=level, include_ghosts=include_ghosts
     )
 
 
 def EyFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Efield_fp", idir=1, level=level, include_ghosts=include_ghosts
+        mf_name="E_fp", idir=1, level=level, include_ghosts=include_ghosts
     )
 
 
 def EzFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Efield_fp", idir=2, level=level, include_ghosts=include_ghosts
+        mf_name="E_fp", idir=2, level=level, include_ghosts=include_ghosts
     )
 
 
 def BxFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Bfield_fp", idir=0, level=level, include_ghosts=include_ghosts
+        mf_name="B_fp", idir=0, level=level, include_ghosts=include_ghosts
     )
 
 
 def ByFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Bfield_fp", idir=1, level=level, include_ghosts=include_ghosts
+        mf_name="B_fp", idir=1, level=level, include_ghosts=include_ghosts
     )
 
 
 def BzFPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Bfield_fp", idir=2, level=level, include_ghosts=include_ghosts
+        mf_name="B_fp", idir=2, level=level, include_ghosts=include_ghosts
     )
 
 
 def ExFPExternalWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Efield_fp_external", idir=0, level=level, include_ghosts=include_ghosts
+        mf_name="E_fp_external", idir=0, level=level, include_ghosts=include_ghosts
     )
 
 
 def EyFPExternalWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Efield_fp_external", idir=1, level=level, include_ghosts=include_ghosts
+        mf_name="E_fp_external", idir=1, level=level, include_ghosts=include_ghosts
     )
 
 
 def EzFPExternalWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Efield_fp_external", idir=2, level=level, include_ghosts=include_ghosts
+        mf_name="E_fp_external", idir=2, level=level, include_ghosts=include_ghosts
     )
 
 
 def BxFPExternalWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Bfield_fp_external", idir=0, level=level, include_ghosts=include_ghosts
+        mf_name="B_fp_external", idir=0, level=level, include_ghosts=include_ghosts
     )
 
 
 def ByFPExternalWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Bfield_fp_external", idir=1, level=level, include_ghosts=include_ghosts
+        mf_name="B_fp_external", idir=1, level=level, include_ghosts=include_ghosts
     )
 
 
 def BzFPExternalWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Bfield_fp_external", idir=2, level=level, include_ghosts=include_ghosts
+        mf_name="B_fp_external", idir=2, level=level, include_ghosts=include_ghosts
     )
 
 
@@ -771,37 +771,37 @@ def AzFPWrapper(level=0, include_ghosts=False):
 
 def ExCPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Efield_cp", idir=0, level=level, include_ghosts=include_ghosts
+        mf_name="E_cp", idir=0, level=level, include_ghosts=include_ghosts
     )
 
 
 def EyCPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Efield_cp", idir=1, level=level, include_ghosts=include_ghosts
+        mf_name="E_cp", idir=1, level=level, include_ghosts=include_ghosts
     )
 
 
 def EzCPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Efield_cp", idir=2, level=level, include_ghosts=include_ghosts
+        mf_name="E_cp", idir=2, level=level, include_ghosts=include_ghosts
     )
 
 
 def BxCPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Bfield_cp", idir=0, level=level, include_ghosts=include_ghosts
+        mf_name="B_cp", idir=0, level=level, include_ghosts=include_ghosts
     )
 
 
 def ByCPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Bfield_cp", idir=1, level=level, include_ghosts=include_ghosts
+        mf_name="B_cp", idir=1, level=level, include_ghosts=include_ghosts
     )
 
 
 def BzCPWrapper(level=0, include_ghosts=False):
     return _MultiFABWrapper(
-        mf_name="Bfield_cp", idir=2, level=level, include_ghosts=include_ghosts
+        mf_name="B_cp", idir=2, level=level, include_ghosts=include_ghosts
     )
 
 

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -703,16 +703,16 @@ PML::PML (const int lev, const BoxArray& grid_ba,
     auto& warpx = WarpX::GetInstance();
     using ablastr::fields::Direction;
 
-    const amrex::BoxArray ba_Ex = amrex::convert(ba, warpx.m_fields.get(FieldType::Efield_fp, Direction{0}, 0)->ixType().toIntVect());
-    const amrex::BoxArray ba_Ey = amrex::convert(ba, warpx.m_fields.get(FieldType::Efield_fp, Direction{1}, 0)->ixType().toIntVect());
-    const amrex::BoxArray ba_Ez = amrex::convert(ba, warpx.m_fields.get(FieldType::Efield_fp, Direction{2}, 0)->ixType().toIntVect());
+    const amrex::BoxArray ba_Ex = amrex::convert(ba, warpx.m_fields.get(FieldType::E_fp, Direction{0}, 0)->ixType().toIntVect());
+    const amrex::BoxArray ba_Ey = amrex::convert(ba, warpx.m_fields.get(FieldType::E_fp, Direction{1}, 0)->ixType().toIntVect());
+    const amrex::BoxArray ba_Ez = amrex::convert(ba, warpx.m_fields.get(FieldType::E_fp, Direction{2}, 0)->ixType().toIntVect());
     warpx.m_fields.alloc_init(FieldType::pml_E_fp, Direction{0}, lev, ba_Ex, dm, ncompe, nge, 0.0_rt, false, false);
     warpx.m_fields.alloc_init(FieldType::pml_E_fp, Direction{1}, lev, ba_Ey, dm, ncompe, nge, 0.0_rt, false, false);
     warpx.m_fields.alloc_init(FieldType::pml_E_fp, Direction{2}, lev, ba_Ez, dm, ncompe, nge, 0.0_rt, false, false);
 
-    const amrex::BoxArray ba_Bx = amrex::convert(ba, warpx.m_fields.get(FieldType::Bfield_fp, Direction{0}, 0)->ixType().toIntVect());
-    const amrex::BoxArray ba_By = amrex::convert(ba, warpx.m_fields.get(FieldType::Bfield_fp, Direction{1}, 0)->ixType().toIntVect());
-    const amrex::BoxArray ba_Bz = amrex::convert(ba, warpx.m_fields.get(FieldType::Bfield_fp, Direction{2}, 0)->ixType().toIntVect());
+    const amrex::BoxArray ba_Bx = amrex::convert(ba, warpx.m_fields.get(FieldType::B_fp, Direction{0}, 0)->ixType().toIntVect());
+    const amrex::BoxArray ba_By = amrex::convert(ba, warpx.m_fields.get(FieldType::B_fp, Direction{1}, 0)->ixType().toIntVect());
+    const amrex::BoxArray ba_Bz = amrex::convert(ba, warpx.m_fields.get(FieldType::B_fp, Direction{2}, 0)->ixType().toIntVect());
     warpx.m_fields.alloc_init(FieldType::pml_B_fp, Direction{0}, lev, ba_Bx, dm, ncompb, ngb, 0.0_rt, false, false);
     warpx.m_fields.alloc_init(FieldType::pml_B_fp, Direction{1}, lev, ba_By, dm, ncompb, ngb, 0.0_rt, false, false);
     warpx.m_fields.alloc_init(FieldType::pml_B_fp, Direction{2}, lev, ba_Bz, dm, ncompb, ngb, 0.0_rt, false, false);
@@ -841,16 +841,16 @@ PML::PML (const int lev, const BoxArray& grid_ba,
             cdm.define(cba);
         }
 
-        const amrex::BoxArray cba_Ex = amrex::convert(cba, WarpX::GetInstance().m_fields.get(FieldType::Efield_cp, Direction{0}, 1)->ixType().toIntVect());
-        const amrex::BoxArray cba_Ey = amrex::convert(cba, WarpX::GetInstance().m_fields.get(FieldType::Efield_cp, Direction{1}, 1)->ixType().toIntVect());
-        const amrex::BoxArray cba_Ez = amrex::convert(cba, WarpX::GetInstance().m_fields.get(FieldType::Efield_cp, Direction{2}, 1)->ixType().toIntVect());
+        const amrex::BoxArray cba_Ex = amrex::convert(cba, WarpX::GetInstance().m_fields.get(FieldType::E_cp, Direction{0}, 1)->ixType().toIntVect());
+        const amrex::BoxArray cba_Ey = amrex::convert(cba, WarpX::GetInstance().m_fields.get(FieldType::E_cp, Direction{1}, 1)->ixType().toIntVect());
+        const amrex::BoxArray cba_Ez = amrex::convert(cba, WarpX::GetInstance().m_fields.get(FieldType::E_cp, Direction{2}, 1)->ixType().toIntVect());
         warpx.m_fields.alloc_init(FieldType::pml_E_cp, Direction{0}, lev, cba_Ex, cdm, ncompe, nge, 0.0_rt, false, false);
         warpx.m_fields.alloc_init(FieldType::pml_E_cp, Direction{1}, lev, cba_Ey, cdm, ncompe, nge, 0.0_rt, false, false);
         warpx.m_fields.alloc_init(FieldType::pml_E_cp, Direction{2}, lev, cba_Ez, cdm, ncompe, nge, 0.0_rt, false, false);
 
-        const amrex::BoxArray cba_Bx = amrex::convert(cba, WarpX::GetInstance().m_fields.get(FieldType::Bfield_cp, Direction{0}, 1)->ixType().toIntVect());
-        const amrex::BoxArray cba_By = amrex::convert(cba, WarpX::GetInstance().m_fields.get(FieldType::Bfield_cp, Direction{1}, 1)->ixType().toIntVect());
-        const amrex::BoxArray cba_Bz = amrex::convert(cba, WarpX::GetInstance().m_fields.get(FieldType::Bfield_cp, Direction{2}, 1)->ixType().toIntVect());
+        const amrex::BoxArray cba_Bx = amrex::convert(cba, WarpX::GetInstance().m_fields.get(FieldType::B_cp, Direction{0}, 1)->ixType().toIntVect());
+        const amrex::BoxArray cba_By = amrex::convert(cba, WarpX::GetInstance().m_fields.get(FieldType::B_cp, Direction{1}, 1)->ixType().toIntVect());
+        const amrex::BoxArray cba_Bz = amrex::convert(cba, WarpX::GetInstance().m_fields.get(FieldType::B_cp, Direction{2}, 1)->ixType().toIntVect());
         warpx.m_fields.alloc_init(FieldType::pml_B_cp, Direction{0}, lev, cba_Bx, cdm, ncompb, ngb, 0.0_rt, false, false);
         warpx.m_fields.alloc_init(FieldType::pml_B_cp, Direction{1}, lev, cba_By, cdm, ncompb, ngb, 0.0_rt, false, false);
         warpx.m_fields.alloc_init(FieldType::pml_B_cp, Direction{2}, lev, cba_Bz, cdm, ncompb, ngb, 0.0_rt, false, false);

--- a/Source/BoundaryConditions/PML_RZ.cpp
+++ b/Source/BoundaryConditions/PML_RZ.cpp
@@ -48,8 +48,8 @@ PML_RZ::PML_RZ (int lev, amrex::BoxArray const& grid_ba, amrex::DistributionMapp
     bool const remake = false;
     bool const redistribute_on_remake = false;
 
-    amrex::MultiFab const& Er_fp = *warpx.m_fields.get(FieldType::Efield_fp, Direction{0}, lev);
-    amrex::MultiFab const& Et_fp = *warpx.m_fields.get(FieldType::Efield_fp, Direction{1}, lev);
+    amrex::MultiFab const& Er_fp = *warpx.m_fields.get(FieldType::E_fp, Direction{0}, lev);
+    amrex::MultiFab const& Et_fp = *warpx.m_fields.get(FieldType::E_fp, Direction{1}, lev);
     amrex::BoxArray const ba_Er = amrex::convert(grid_ba, Er_fp.ixType().toIntVect());
     amrex::BoxArray const ba_Et = amrex::convert(grid_ba, Et_fp.ixType().toIntVect());
     warpx.m_fields.alloc_init(FieldType::pml_E_fp, Direction{0}, lev, ba_Er, grid_dm, Er_fp.nComp(), Er_fp.nGrowVect(), 0.0_rt,
@@ -57,8 +57,8 @@ PML_RZ::PML_RZ (int lev, amrex::BoxArray const& grid_ba, amrex::DistributionMapp
     warpx.m_fields.alloc_init(FieldType::pml_E_fp, Direction{1}, lev, ba_Et, grid_dm, Et_fp.nComp(), Et_fp.nGrowVect(), 0.0_rt,
                               remake, redistribute_on_remake);
 
-    amrex::MultiFab const& Br_fp = *warpx.m_fields.get(FieldType::Bfield_fp,Direction{0},lev);
-    amrex::MultiFab const& Bt_fp = *warpx.m_fields.get(FieldType::Bfield_fp,Direction{1},lev);
+    amrex::MultiFab const& Br_fp = *warpx.m_fields.get(FieldType::B_fp,Direction{0},lev);
+    amrex::MultiFab const& Bt_fp = *warpx.m_fields.get(FieldType::B_fp,Direction{1},lev);
     amrex::BoxArray const ba_Br = amrex::convert(grid_ba, Br_fp.ixType().toIntVect());
     amrex::BoxArray const ba_Bt = amrex::convert(grid_ba, Bt_fp.ixType().toIntVect());
     warpx.m_fields.alloc_init(FieldType::pml_B_fp, Direction{0}, lev, ba_Br, grid_dm, Br_fp.nComp(), Br_fp.nGrowVect(), 0.0_rt,

--- a/Source/BoundaryConditions/WarpXEvolvePML.cpp
+++ b/Source/BoundaryConditions/WarpXEvolvePML.cpp
@@ -68,10 +68,10 @@ WarpX::DampPML (const int lev, PatchType patch_type)
     if (pml_rz[lev]) {
         using ablastr::fields::Direction;
         using warpx::fields::FieldType;
-        pml_rz[lev]->ApplyDamping( m_fields.get(FieldType::Efield_fp, Direction{1}, lev),
-                                   m_fields.get(FieldType::Efield_fp, Direction{2}, lev),
-                                   m_fields.get(FieldType::Bfield_fp, Direction{1}, lev),
-                                   m_fields.get(FieldType::Bfield_fp, Direction{2}, lev),
+        pml_rz[lev]->ApplyDamping( m_fields.get(FieldType::E_fp, Direction{1}, lev),
+                                   m_fields.get(FieldType::E_fp, Direction{2}, lev),
+                                   m_fields.get(FieldType::B_fp, Direction{1}, lev),
+                                   m_fields.get(FieldType::B_fp, Direction{2}, lev),
                                    dt[lev], m_fields);
     }
 #endif

--- a/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
+++ b/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
@@ -55,9 +55,9 @@ void WarpX::ApplyEfieldBoundary(const int lev, PatchType patch_type)
     if (::isAnyBoundary<FieldBoundaryType::PEC>(field_boundary_lo, field_boundary_hi)) {
         if (patch_type == PatchType::fine) {
             PEC::ApplyPECtoEfield(
-                    {m_fields.get(FieldType::Efield_fp, Direction{0}, lev),
-                     m_fields.get(FieldType::Efield_fp, Direction{1}, lev),
-                     m_fields.get(FieldType::Efield_fp, Direction{2}, lev)},
+                    {m_fields.get(FieldType::E_fp, Direction{0}, lev),
+                     m_fields.get(FieldType::E_fp, Direction{1}, lev),
+                     m_fields.get(FieldType::E_fp, Direction{2}, lev)},
                     field_boundary_lo, field_boundary_hi,
                     get_ng_fieldgather(), Geom(lev),
                     lev, patch_type, ref_ratio);
@@ -73,9 +73,9 @@ void WarpX::ApplyEfieldBoundary(const int lev, PatchType patch_type)
             }
         } else {
             PEC::ApplyPECtoEfield(
-                {m_fields.get(FieldType::Efield_cp,Direction{0},lev),
-                 m_fields.get(FieldType::Efield_cp,Direction{1},lev),
-                 m_fields.get(FieldType::Efield_cp,Direction{2},lev)},
+                {m_fields.get(FieldType::E_cp,Direction{0},lev),
+                 m_fields.get(FieldType::E_cp,Direction{1},lev),
+                 m_fields.get(FieldType::E_cp,Direction{2},lev)},
                 field_boundary_lo, field_boundary_hi,
                 get_ng_fieldgather(), Geom(lev),
                 lev, patch_type, ref_ratio);
@@ -94,13 +94,13 @@ void WarpX::ApplyEfieldBoundary(const int lev, PatchType patch_type)
 
 #ifdef WARPX_DIM_RZ
     if (patch_type == PatchType::fine) {
-        ApplyFieldBoundaryOnAxis(m_fields.get(FieldType::Efield_fp, Direction{0}, lev),
-                                 m_fields.get(FieldType::Efield_fp, Direction{1}, lev),
-                                 m_fields.get(FieldType::Efield_fp, Direction{2}, lev), lev);
+        ApplyFieldBoundaryOnAxis(m_fields.get(FieldType::E_fp, Direction{0}, lev),
+                                 m_fields.get(FieldType::E_fp, Direction{1}, lev),
+                                 m_fields.get(FieldType::E_fp, Direction{2}, lev), lev);
     } else {
-        ApplyFieldBoundaryOnAxis(m_fields.get(FieldType::Efield_cp, Direction{0}, lev),
-                                 m_fields.get(FieldType::Efield_cp, Direction{1}, lev),
-                                 m_fields.get(FieldType::Efield_cp, Direction{2}, lev), lev);
+        ApplyFieldBoundaryOnAxis(m_fields.get(FieldType::E_cp, Direction{0}, lev),
+                                 m_fields.get(FieldType::E_cp, Direction{1}, lev),
+                                 m_fields.get(FieldType::E_cp, Direction{2}, lev), lev);
     }
 #endif
 }
@@ -112,17 +112,17 @@ void WarpX::ApplyBfieldBoundary (const int lev, PatchType patch_type, DtType a_d
     if (::isAnyBoundary<FieldBoundaryType::PEC>(field_boundary_lo, field_boundary_hi)) {
         if (patch_type == PatchType::fine) {
             PEC::ApplyPECtoBfield( {
-                m_fields.get(FieldType::Bfield_fp,Direction{0},lev),
-                m_fields.get(FieldType::Bfield_fp,Direction{1},lev),
-                m_fields.get(FieldType::Bfield_fp,Direction{2},lev) },
+                m_fields.get(FieldType::B_fp,Direction{0},lev),
+                m_fields.get(FieldType::B_fp,Direction{1},lev),
+                m_fields.get(FieldType::B_fp,Direction{2},lev) },
                 field_boundary_lo, field_boundary_hi,
                 get_ng_fieldgather(), Geom(lev),
                 lev, patch_type, ref_ratio);
         } else {
             PEC::ApplyPECtoBfield( {
-                m_fields.get(FieldType::Bfield_cp,Direction{0},lev),
-                m_fields.get(FieldType::Bfield_cp,Direction{1},lev),
-                m_fields.get(FieldType::Bfield_cp,Direction{2},lev) },
+                m_fields.get(FieldType::B_cp,Direction{0},lev),
+                m_fields.get(FieldType::B_cp,Direction{1},lev),
+                m_fields.get(FieldType::B_cp,Direction{2},lev) },
                 field_boundary_lo, field_boundary_hi,
                 get_ng_fieldgather(), Geom(lev),
                 lev, patch_type, ref_ratio);
@@ -135,10 +135,10 @@ void WarpX::ApplyBfieldBoundary (const int lev, PatchType patch_type, DtType a_d
     if (lev == 0) {
         if (a_dt_type == DtType::FirstHalf) {
             if(::isAnyBoundary<FieldBoundaryType::Absorbing_SilverMueller>(field_boundary_lo, field_boundary_hi)){
-                auto Efield_fp = m_fields.get_mr_levels_alldirs(FieldType::Efield_fp, max_level);
-                auto Bfield_fp = m_fields.get_mr_levels_alldirs(FieldType::Bfield_fp, max_level);
+                auto E_fp = m_fields.get_mr_levels_alldirs(FieldType::E_fp, max_level);
+                auto B_fp = m_fields.get_mr_levels_alldirs(FieldType::B_fp, max_level);
                 m_fdtd_solver_fp[0]->ApplySilverMuellerBoundary(
-                Efield_fp[lev], Bfield_fp[lev],
+                E_fp[lev], B_fp[lev],
                 Geom(lev).Domain(), dt[lev],
                 field_boundary_lo, field_boundary_hi);
             }
@@ -147,13 +147,13 @@ void WarpX::ApplyBfieldBoundary (const int lev, PatchType patch_type, DtType a_d
 
 #ifdef WARPX_DIM_RZ
     if (patch_type == PatchType::fine) {
-        ApplyFieldBoundaryOnAxis(m_fields.get(FieldType::Bfield_fp,Direction{0},lev),
-                                 m_fields.get(FieldType::Bfield_fp,Direction{1},lev),
-                                 m_fields.get(FieldType::Bfield_fp,Direction{2},lev), lev);
+        ApplyFieldBoundaryOnAxis(m_fields.get(FieldType::B_fp,Direction{0},lev),
+                                 m_fields.get(FieldType::B_fp,Direction{1},lev),
+                                 m_fields.get(FieldType::B_fp,Direction{2},lev), lev);
     } else {
-        ApplyFieldBoundaryOnAxis(m_fields.get(FieldType::Bfield_cp,Direction{0},lev),
-                                 m_fields.get(FieldType::Bfield_cp,Direction{1},lev),
-                                 m_fields.get(FieldType::Bfield_cp,Direction{2},lev), lev);
+        ApplyFieldBoundaryOnAxis(m_fields.get(FieldType::B_cp,Direction{0},lev),
+                                 m_fields.get(FieldType::B_cp,Direction{1},lev),
+                                 m_fields.get(FieldType::B_cp,Direction{2},lev), lev);
     }
 #endif
 }

--- a/Source/Diagnostics/BTDiagnostics.cpp
+++ b/Source/Diagnostics/BTDiagnostics.cpp
@@ -570,17 +570,17 @@ BTDiagnostics::InitializeFieldFunctors (int lev)
         m_cell_center_functors.at(lev).size());
     for (int comp=0; comp<m_cell_center_functors_at_lev_size; comp++){
         if        ( m_cellcenter_varnames[comp] == "Ex" ){
-            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Efield_aux, Direction{0}, lev), lev, m_crse_ratio);
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::E_aux, Direction{0}, lev), lev, m_crse_ratio);
         } else if ( m_cellcenter_varnames[comp] == "Ey" ){
-            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Efield_aux, Direction{1}, lev), lev, m_crse_ratio);
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::E_aux, Direction{1}, lev), lev, m_crse_ratio);
         } else if ( m_cellcenter_varnames[comp] == "Ez" ){
-            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Efield_aux, Direction{2}, lev), lev, m_crse_ratio);
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::E_aux, Direction{2}, lev), lev, m_crse_ratio);
         } else if ( m_cellcenter_varnames[comp] == "Bx" ){
-            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Bfield_aux, Direction{0}, lev), lev, m_crse_ratio);
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::B_aux, Direction{0}, lev), lev, m_crse_ratio);
         } else if ( m_cellcenter_varnames[comp] == "By" ){
-            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Bfield_aux, Direction{1}, lev), lev, m_crse_ratio);
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::B_aux, Direction{1}, lev), lev, m_crse_ratio);
         } else if ( m_cellcenter_varnames[comp] == "Bz" ){
-            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Bfield_aux, Direction{2}, lev), lev, m_crse_ratio);
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::B_aux, Direction{2}, lev), lev, m_crse_ratio);
         } else if ( m_cellcenter_varnames[comp] == "jx" ){
             m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::current_fp,Direction{0}, lev), lev, m_crse_ratio);
         } else if ( m_cellcenter_varnames[comp] == "jy" ){
@@ -602,7 +602,7 @@ BTDiagnostics::UpdateVarnamesForRZopenPMD ()
 #ifdef WARPX_DIM_RZ
     auto & warpx = WarpX::GetInstance();
     using ablastr::fields::Direction;
-    const int ncomp_multimodefab = warpx.m_fields.get(FieldType::Efield_aux, Direction{0}, 0)->nComp();
+    const int ncomp_multimodefab = warpx.m_fields.get(FieldType::E_aux, Direction{0}, 0)->nComp();
     const int ncomp = ncomp_multimodefab;
 
 
@@ -663,7 +663,7 @@ BTDiagnostics::InitializeFieldFunctorsRZopenPMD (int lev)
     using ablastr::fields::Direction;
 
     auto & warpx = WarpX::GetInstance();
-    const int ncomp_multimodefab = warpx.m_fields.get(FieldType::Efield_aux, Direction{0}, 0)->nComp();
+    const int ncomp_multimodefab = warpx.m_fields.get(FieldType::E_aux, Direction{0}, 0)->nComp();
     const int ncomp = ncomp_multimodefab;
     // Clear any pre-existing vector to release stored data
     // This ensures that when domain is load-balanced, the functors point
@@ -689,17 +689,17 @@ BTDiagnostics::InitializeFieldFunctorsRZopenPMD (int lev)
     const auto m_cell_center_functors_at_lev_size = static_cast<int>(m_cell_center_functors.at(lev).size());
     for (int comp=0; comp<m_cell_center_functors_at_lev_size; comp++){
         if        ( m_cellcenter_varnames_fields[comp] == "Er" ){
-            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Efield_aux, Direction{0}, lev), lev, m_crse_ratio, false, ncomp);
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::E_aux, Direction{0}, lev), lev, m_crse_ratio, false, ncomp);
         } else if ( m_cellcenter_varnames_fields[comp] == "Et" ){
-            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Efield_aux, Direction{1}, lev), lev, m_crse_ratio, false, ncomp);
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::E_aux, Direction{1}, lev), lev, m_crse_ratio, false, ncomp);
         } else if ( m_cellcenter_varnames_fields[comp] == "Ez" ){
-            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Efield_aux, Direction{2}, lev), lev, m_crse_ratio, false, ncomp);
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::E_aux, Direction{2}, lev), lev, m_crse_ratio, false, ncomp);
         } else if ( m_cellcenter_varnames_fields[comp] == "Br" ){
-            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Bfield_aux, Direction{0}, lev), lev, m_crse_ratio, false, ncomp);
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::B_aux, Direction{0}, lev), lev, m_crse_ratio, false, ncomp);
         } else if ( m_cellcenter_varnames_fields[comp] == "Bt" ){
-            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Bfield_aux, Direction{1}, lev), lev, m_crse_ratio, false, ncomp);
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::B_aux, Direction{1}, lev), lev, m_crse_ratio, false, ncomp);
         } else if ( m_cellcenter_varnames_fields[comp] == "Bz" ){
-            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Bfield_aux, Direction{2}, lev), lev, m_crse_ratio, false, ncomp);
+            m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::B_aux, Direction{2}, lev), lev, m_crse_ratio, false, ncomp);
         } else if ( m_cellcenter_varnames_fields[comp] == "jr" ){
             m_cell_center_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::current_fp, Direction{0}, lev), lev, m_crse_ratio, false, ncomp);
         } else if ( m_cellcenter_varnames_fields[comp] == "jt" ){

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -68,33 +68,33 @@ FlushFormatCheckpoint::WriteToFile (
 
     for (int lev = 0; lev < nlev; ++lev)
     {
-        VisMF::Write(*warpx.m_fields.get(FieldType::Efield_fp, Direction{0}, lev),
+        VisMF::Write(*warpx.m_fields.get(FieldType::E_fp, Direction{0}, lev),
                      amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ex_fp"));
-        VisMF::Write(*warpx.m_fields.get(FieldType::Efield_fp, Direction{1}, lev),
+        VisMF::Write(*warpx.m_fields.get(FieldType::E_fp, Direction{1}, lev),
                      amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ey_fp"));
-        VisMF::Write(*warpx.m_fields.get(FieldType::Efield_fp, Direction{2}, lev),
+        VisMF::Write(*warpx.m_fields.get(FieldType::E_fp, Direction{2}, lev),
                      amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ez_fp"));
-        VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_fp, Direction{0}, lev),
+        VisMF::Write(*warpx.m_fields.get(FieldType::B_fp, Direction{0}, lev),
                      amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Bx_fp"));
-        VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_fp, Direction{1}, lev),
+        VisMF::Write(*warpx.m_fields.get(FieldType::B_fp, Direction{1}, lev),
                      amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "By_fp"));
-        VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_fp, Direction{2}, lev),
+        VisMF::Write(*warpx.m_fields.get(FieldType::B_fp, Direction{2}, lev),
                      amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Bz_fp"));
 
         if (WarpX::fft_do_time_averaging)
         {
-            VisMF::Write(*warpx.m_fields.get(FieldType::Efield_avg_fp, Direction{0}, lev),
+            VisMF::Write(*warpx.m_fields.get(FieldType::E_avg_fp, Direction{0}, lev),
                          amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ex_avg_fp"));
-            VisMF::Write(*warpx.m_fields.get(FieldType::Efield_avg_fp, Direction{1}, lev),
+            VisMF::Write(*warpx.m_fields.get(FieldType::E_avg_fp, Direction{1}, lev),
                          amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ey_avg_fp"));
-            VisMF::Write(*warpx.m_fields.get(FieldType::Efield_avg_fp, Direction{2}, lev),
+            VisMF::Write(*warpx.m_fields.get(FieldType::E_avg_fp, Direction{2}, lev),
                          amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ez_avg_fp"));
 
-            VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_avg_fp, Direction{0}, lev),
+            VisMF::Write(*warpx.m_fields.get(FieldType::B_avg_fp, Direction{0}, lev),
                          amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Bx_avg_fp"));
-            VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_avg_fp, Direction{1}, lev),
+            VisMF::Write(*warpx.m_fields.get(FieldType::B_avg_fp, Direction{1}, lev),
                          amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "By_avg_fp"));
-            VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_avg_fp, Direction{2}, lev),
+            VisMF::Write(*warpx.m_fields.get(FieldType::B_avg_fp, Direction{2}, lev),
                          amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Bz_avg_fp"));
         }
 
@@ -110,33 +110,33 @@ FlushFormatCheckpoint::WriteToFile (
 
         if (lev > 0)
         {
-            VisMF::Write(*warpx.m_fields.get(FieldType::Efield_cp, Direction{0}, lev),
+            VisMF::Write(*warpx.m_fields.get(FieldType::E_cp, Direction{0}, lev),
                          amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ex_cp"));
-            VisMF::Write(*warpx.m_fields.get(FieldType::Efield_cp, Direction{1}, lev),
+            VisMF::Write(*warpx.m_fields.get(FieldType::E_cp, Direction{1}, lev),
                          amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ey_cp"));
-            VisMF::Write(*warpx.m_fields.get(FieldType::Efield_cp, Direction{2}, lev),
+            VisMF::Write(*warpx.m_fields.get(FieldType::E_cp, Direction{2}, lev),
                          amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ez_cp"));
-            VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_cp, Direction{0}, lev),
+            VisMF::Write(*warpx.m_fields.get(FieldType::B_cp, Direction{0}, lev),
                          amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Bx_cp"));
-            VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_cp, Direction{1}, lev),
+            VisMF::Write(*warpx.m_fields.get(FieldType::B_cp, Direction{1}, lev),
                          amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "By_cp"));
-            VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_cp, Direction{2}, lev),
+            VisMF::Write(*warpx.m_fields.get(FieldType::B_cp, Direction{2}, lev),
                          amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Bz_cp"));
 
             if (WarpX::fft_do_time_averaging)
             {
-                VisMF::Write(*warpx.m_fields.get(FieldType::Efield_avg_cp, Direction{0}, lev),
+                VisMF::Write(*warpx.m_fields.get(FieldType::E_avg_cp, Direction{0}, lev),
                              amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ex_avg_cp"));
-                VisMF::Write(*warpx.m_fields.get(FieldType::Efield_avg_cp, Direction{1}, lev),
+                VisMF::Write(*warpx.m_fields.get(FieldType::E_avg_cp, Direction{1}, lev),
                              amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ey_avg_cp"));
-                VisMF::Write(*warpx.m_fields.get(FieldType::Efield_avg_cp, Direction{2}, lev),
+                VisMF::Write(*warpx.m_fields.get(FieldType::E_avg_cp, Direction{2}, lev),
                              amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ez_avg_cp"));
 
-                VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_avg_cp, Direction{0}, lev),
+                VisMF::Write(*warpx.m_fields.get(FieldType::B_avg_cp, Direction{0}, lev),
                              amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Bx_avg_cp"));
-                VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_avg_cp, Direction{1}, lev),
+                VisMF::Write(*warpx.m_fields.get(FieldType::B_avg_cp, Direction{1}, lev),
                              amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "By_avg_cp"));
-                VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_avg_cp, Direction{2}, lev),
+                VisMF::Write(*warpx.m_fields.get(FieldType::B_avg_cp, Direction{2}, lev),
                              amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Bz_avg_cp"));
             }
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -568,19 +568,19 @@ FlushFormatPlotfile::WriteAllRawFields(
 
         // Auxiliary patch
 
-        WriteRawMF( *warpx.m_fields.get(FieldType::Efield_aux, Direction{0}, lev), dm, raw_pltname, default_level_prefix, "Ex_aux", lev, plot_raw_fields_guards);
-        WriteRawMF( *warpx.m_fields.get(FieldType::Efield_aux, Direction{1}, lev), dm, raw_pltname, default_level_prefix, "Ey_aux", lev, plot_raw_fields_guards);
-        WriteRawMF( *warpx.m_fields.get(FieldType::Efield_aux, Direction{2}, lev), dm, raw_pltname, default_level_prefix, "Ez_aux", lev, plot_raw_fields_guards);
-        WriteRawMF( *warpx.m_fields.get(FieldType::Bfield_aux, Direction{0}, lev), dm, raw_pltname, default_level_prefix, "Bx_aux", lev, plot_raw_fields_guards);
-        WriteRawMF( *warpx.m_fields.get(FieldType::Bfield_aux, Direction{1}, lev), dm, raw_pltname, default_level_prefix, "By_aux", lev, plot_raw_fields_guards);
-        WriteRawMF( *warpx.m_fields.get(FieldType::Bfield_aux, Direction{2}, lev), dm, raw_pltname, default_level_prefix, "Bz_aux", lev, plot_raw_fields_guards);
+        WriteRawMF( *warpx.m_fields.get(FieldType::E_aux, Direction{0}, lev), dm, raw_pltname, default_level_prefix, "Ex_aux", lev, plot_raw_fields_guards);
+        WriteRawMF( *warpx.m_fields.get(FieldType::E_aux, Direction{1}, lev), dm, raw_pltname, default_level_prefix, "Ey_aux", lev, plot_raw_fields_guards);
+        WriteRawMF( *warpx.m_fields.get(FieldType::E_aux, Direction{2}, lev), dm, raw_pltname, default_level_prefix, "Ez_aux", lev, plot_raw_fields_guards);
+        WriteRawMF( *warpx.m_fields.get(FieldType::B_aux, Direction{0}, lev), dm, raw_pltname, default_level_prefix, "Bx_aux", lev, plot_raw_fields_guards);
+        WriteRawMF( *warpx.m_fields.get(FieldType::B_aux, Direction{1}, lev), dm, raw_pltname, default_level_prefix, "By_aux", lev, plot_raw_fields_guards);
+        WriteRawMF( *warpx.m_fields.get(FieldType::B_aux, Direction{2}, lev), dm, raw_pltname, default_level_prefix, "Bz_aux", lev, plot_raw_fields_guards);
 
         // fine patch
-        WriteRawMF( *warpx.m_fields.get(FieldType::Efield_fp, Direction{0}, lev), dm, raw_pltname,
+        WriteRawMF( *warpx.m_fields.get(FieldType::E_fp, Direction{0}, lev), dm, raw_pltname,
                     default_level_prefix, "Ex_fp", lev, plot_raw_fields_guards );
-        WriteRawMF( *warpx.m_fields.get(FieldType::Efield_fp, Direction{1}, lev), dm, raw_pltname,
+        WriteRawMF( *warpx.m_fields.get(FieldType::E_fp, Direction{1}, lev), dm, raw_pltname,
                     default_level_prefix, "Ey_fp", lev, plot_raw_fields_guards );
-        WriteRawMF( *warpx.m_fields.get(FieldType::Efield_fp, Direction{2}, lev), dm, raw_pltname,
+        WriteRawMF( *warpx.m_fields.get(FieldType::E_fp, Direction{2}, lev), dm, raw_pltname,
                     default_level_prefix, "Ez_fp", lev, plot_raw_fields_guards );
         WriteRawMF( *warpx.m_fields.get(FieldType::current_fp,Direction{0}, lev), dm, raw_pltname,
                     default_level_prefix, "jx_fp", lev,plot_raw_fields_guards );
@@ -588,11 +588,11 @@ FlushFormatPlotfile::WriteAllRawFields(
                     default_level_prefix, "jy_fp", lev,plot_raw_fields_guards );
         WriteRawMF( *warpx.m_fields.get(FieldType::current_fp,Direction{2}, lev), dm, raw_pltname,
                     default_level_prefix, "jz_fp", lev,plot_raw_fields_guards );
-        WriteRawMF( *warpx.m_fields.get(FieldType::Bfield_fp, Direction{0}, lev), dm, raw_pltname,
+        WriteRawMF( *warpx.m_fields.get(FieldType::B_fp, Direction{0}, lev), dm, raw_pltname,
                     default_level_prefix, "Bx_fp", lev, plot_raw_fields_guards );
-        WriteRawMF( *warpx.m_fields.get(FieldType::Bfield_fp, Direction{1}, lev), dm, raw_pltname,
+        WriteRawMF( *warpx.m_fields.get(FieldType::B_fp, Direction{1}, lev), dm, raw_pltname,
                     default_level_prefix, "By_fp", lev, plot_raw_fields_guards );
-        WriteRawMF( *warpx.m_fields.get(FieldType::Bfield_fp, Direction{2}, lev), dm, raw_pltname,
+        WriteRawMF( *warpx.m_fields.get(FieldType::B_fp, Direction{2}, lev), dm, raw_pltname,
                     default_level_prefix, "Bz_fp", lev, plot_raw_fields_guards );
         if (warpx.m_fields.has(FieldType::F_fp, lev))
         {
@@ -615,42 +615,42 @@ FlushFormatPlotfile::WriteAllRawFields(
         // Averaged fields on fine patch
         if (WarpX::fft_do_time_averaging)
         {
-            WriteRawMF(*warpx.m_fields.get(FieldType::Efield_avg_fp, Direction{0}, lev) , dm, raw_pltname, default_level_prefix,
+            WriteRawMF(*warpx.m_fields.get(FieldType::E_avg_fp, Direction{0}, lev) , dm, raw_pltname, default_level_prefix,
                        "Ex_avg_fp", lev, plot_raw_fields_guards);
 
-            WriteRawMF(*warpx.m_fields.get(FieldType::Efield_avg_fp, Direction{1}, lev) , dm, raw_pltname, default_level_prefix,
+            WriteRawMF(*warpx.m_fields.get(FieldType::E_avg_fp, Direction{1}, lev) , dm, raw_pltname, default_level_prefix,
                        "Ey_avg_fp", lev, plot_raw_fields_guards);
 
-            WriteRawMF(*warpx.m_fields.get(FieldType::Efield_avg_fp, Direction{2}, lev) , dm, raw_pltname, default_level_prefix,
+            WriteRawMF(*warpx.m_fields.get(FieldType::E_avg_fp, Direction{2}, lev) , dm, raw_pltname, default_level_prefix,
                        "Ez_avg_fp", lev, plot_raw_fields_guards);
 
-            WriteRawMF(*warpx.m_fields.get(FieldType::Bfield_avg_fp, Direction{0}, lev) , dm, raw_pltname, default_level_prefix,
+            WriteRawMF(*warpx.m_fields.get(FieldType::B_avg_fp, Direction{0}, lev) , dm, raw_pltname, default_level_prefix,
                        "Bx_avg_fp", lev, plot_raw_fields_guards);
 
-            WriteRawMF(*warpx.m_fields.get(FieldType::Bfield_avg_fp, Direction{1}, lev) , dm, raw_pltname, default_level_prefix,
+            WriteRawMF(*warpx.m_fields.get(FieldType::B_avg_fp, Direction{1}, lev) , dm, raw_pltname, default_level_prefix,
                        "By_avg_fp", lev, plot_raw_fields_guards);
 
-            WriteRawMF(*warpx.m_fields.get(FieldType::Bfield_avg_fp, Direction{2}, lev) , dm, raw_pltname, default_level_prefix,
+            WriteRawMF(*warpx.m_fields.get(FieldType::B_avg_fp, Direction{2}, lev) , dm, raw_pltname, default_level_prefix,
                        "Bz_avg_fp", lev, plot_raw_fields_guards);
         }
 
         // Coarse path
         if (lev > 0) {
             WriteCoarseVector( "E",
-                               warpx.m_fields.get(FieldType::Efield_cp, Direction{0}, lev),
-                               warpx.m_fields.get(FieldType::Efield_cp, Direction{1}, lev),
-                               warpx.m_fields.get(FieldType::Efield_cp, Direction{2}, lev),
-                               warpx.m_fields.get(FieldType::Efield_fp, Direction{0}, lev),
-                               warpx.m_fields.get(FieldType::Efield_fp, Direction{1}, lev),
-                               warpx.m_fields.get(FieldType::Efield_fp, Direction{2}, lev),
+                               warpx.m_fields.get(FieldType::E_cp, Direction{0}, lev),
+                               warpx.m_fields.get(FieldType::E_cp, Direction{1}, lev),
+                               warpx.m_fields.get(FieldType::E_cp, Direction{2}, lev),
+                               warpx.m_fields.get(FieldType::E_fp, Direction{0}, lev),
+                               warpx.m_fields.get(FieldType::E_fp, Direction{1}, lev),
+                               warpx.m_fields.get(FieldType::E_fp, Direction{2}, lev),
                                dm, raw_pltname, default_level_prefix, lev, plot_raw_fields_guards);
             WriteCoarseVector( "B",
-                               warpx.m_fields.get(FieldType::Bfield_cp, Direction{0}, lev),
-                               warpx.m_fields.get(FieldType::Bfield_cp, Direction{1}, lev),
-                               warpx.m_fields.get(FieldType::Bfield_cp, Direction{2}, lev),
-                               warpx.m_fields.get(FieldType::Bfield_fp, Direction{0}, lev),
-                               warpx.m_fields.get(FieldType::Bfield_fp, Direction{1}, lev),
-                               warpx.m_fields.get(FieldType::Bfield_fp, Direction{2}, lev),
+                               warpx.m_fields.get(FieldType::B_cp, Direction{0}, lev),
+                               warpx.m_fields.get(FieldType::B_cp, Direction{1}, lev),
+                               warpx.m_fields.get(FieldType::B_cp, Direction{2}, lev),
+                               warpx.m_fields.get(FieldType::B_fp, Direction{0}, lev),
+                               warpx.m_fields.get(FieldType::B_fp, Direction{1}, lev),
+                               warpx.m_fields.get(FieldType::B_fp, Direction{2}, lev),
                                dm, raw_pltname, default_level_prefix, lev, plot_raw_fields_guards);
             WriteCoarseVector( "j",
                                warpx.m_fields.get(FieldType::current_cp, Direction{0}, lev), warpx.m_fields.get(FieldType::current_cp, Direction{1}, lev), warpx.m_fields.get(FieldType::current_cp, Direction{2}, lev),

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -177,13 +177,13 @@ FullDiagnostics::InitializeFieldFunctorsRZopenPMD (int lev)
     using ablastr::fields::Direction;
 
     auto & warpx = WarpX::GetInstance();
-    const int ncomp_multimodefab = warpx.m_fields.get(FieldType::Efield_aux, Direction{0}, 0)->nComp();
+    const int ncomp_multimodefab = warpx.m_fields.get(FieldType::E_aux, Direction{0}, 0)->nComp();
     // Make sure all multifabs have the same number of components
     for (int dim=0; dim<3; dim++){
         AMREX_ALWAYS_ASSERT(
-            warpx.m_fields.get(FieldType::Efield_aux, Direction{dim}, lev)->nComp() == ncomp_multimodefab );
+            warpx.m_fields.get(FieldType::E_aux, Direction{dim}, lev)->nComp() == ncomp_multimodefab );
         AMREX_ALWAYS_ASSERT(
-            warpx.m_fields.get(FieldType::Bfield_aux, Direction{dim}, lev)->nComp() == ncomp_multimodefab );
+            warpx.m_fields.get(FieldType::B_aux, Direction{dim}, lev)->nComp() == ncomp_multimodefab );
         AMREX_ALWAYS_ASSERT(
             warpx.m_fields.get(FieldType::current_fp, Direction{dim}, lev)->nComp() == ncomp_multimodefab );
     }
@@ -220,37 +220,37 @@ FullDiagnostics::InitializeFieldFunctorsRZopenPMD (int lev)
     const auto m_varname_fields_size = static_cast<int>(m_varnames_fields.size());
     for (int comp=0; comp<m_varname_fields_size; comp++){
         if        ( m_varnames_fields[comp] == "Er" ){
-            m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Efield_aux, Direction{0}, lev), lev, m_crse_ratio,
+            m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::E_aux, Direction{0}, lev), lev, m_crse_ratio,
                                                         false, ncomp);
             if (update_varnames) {
                 AddRZModesToOutputNames(std::string("Er"), ncomp);
             }
         } else if ( m_varnames_fields[comp] == "Et" ){
-            m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Efield_aux, Direction{1}, lev), lev, m_crse_ratio,
+            m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::E_aux, Direction{1}, lev), lev, m_crse_ratio,
                                                         false, ncomp);
             if (update_varnames) {
                 AddRZModesToOutputNames(std::string("Et"), ncomp);
             }
         } else if ( m_varnames_fields[comp] == "Ez" ){
-            m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Efield_aux, Direction{2}, lev), lev, m_crse_ratio,
+            m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::E_aux, Direction{2}, lev), lev, m_crse_ratio,
                                                         false, ncomp);
             if (update_varnames) {
                 AddRZModesToOutputNames(std::string("Ez"), ncomp);
             }
         } else if ( m_varnames_fields[comp] == "Br" ){
-            m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Bfield_aux, Direction{0}, lev), lev, m_crse_ratio,
+            m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::B_aux, Direction{0}, lev), lev, m_crse_ratio,
                                                         false, ncomp);
             if (update_varnames) {
                 AddRZModesToOutputNames(std::string("Br"), ncomp);
             }
         } else if ( m_varnames_fields[comp] == "Bt" ){
-            m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Bfield_aux, Direction{1}, lev), lev, m_crse_ratio,
+            m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::B_aux, Direction{1}, lev), lev, m_crse_ratio,
                                                         false, ncomp);
             if (update_varnames) {
                 AddRZModesToOutputNames(std::string("Bt"), ncomp);
             }
         } else if ( m_varnames_fields[comp] == "Bz" ){
-            m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Bfield_aux, Direction{2}, lev), lev, m_crse_ratio,
+            m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::B_aux, Direction{2}, lev), lev, m_crse_ratio,
                                                         false, ncomp);
             if (update_varnames) {
                 AddRZModesToOutputNames(std::string("Bz"), ncomp);
@@ -346,14 +346,14 @@ FullDiagnostics::InitializeFieldFunctorsRZopenPMD (int lev)
             }
         } else if ( m_varnames_fields[comp] == "divB" ){
             m_all_field_functors[lev][comp] = std::make_unique<DivBFunctor>(
-                warpx.m_fields.get_alldirs(FieldType::Bfield_aux, lev),
+                warpx.m_fields.get_alldirs(FieldType::B_aux, lev),
                 lev, m_crse_ratio, false, ncomp);
             if (update_varnames) {
                 AddRZModesToOutputNames(std::string("divB"), ncomp);
             }
         } else if ( m_varnames_fields[comp] == "divE" ){
             m_all_field_functors[lev][comp] = std::make_unique<DivEFunctor>(
-                warpx.m_fields.get_alldirs(FieldType::Efield_aux, lev),
+                warpx.m_fields.get_alldirs(FieldType::E_aux, lev),
                 lev, m_crse_ratio, false, ncomp);
             if (update_varnames) {
                 AddRZModesToOutputNames(std::string("divE"), ncomp);
@@ -401,13 +401,13 @@ FullDiagnostics::AddRZModesToDiags (int lev)
     if (!m_dump_rz_modes) { return; }
 
     auto & warpx = WarpX::GetInstance();
-    const int ncomp_multimodefab = warpx.m_fields.get(FieldType::Efield_aux, Direction{0}, 0)->nComp();
+    const int ncomp_multimodefab = warpx.m_fields.get(FieldType::E_aux, Direction{0}, 0)->nComp();
     // Make sure all multifabs have the same number of components
     for (int dim=0; dim<3; dim++){
         AMREX_ALWAYS_ASSERT(
-            warpx.m_fields.get(FieldType::Efield_aux, Direction{dim}, lev)->nComp() == ncomp_multimodefab );
+            warpx.m_fields.get(FieldType::E_aux, Direction{dim}, lev)->nComp() == ncomp_multimodefab );
         AMREX_ALWAYS_ASSERT(
-            warpx.m_fields.get(FieldType::Bfield_aux, Direction{dim}, lev)->nComp() == ncomp_multimodefab );
+            warpx.m_fields.get(FieldType::B_aux, Direction{dim}, lev)->nComp() == ncomp_multimodefab );
         AMREX_ALWAYS_ASSERT(
             warpx.m_fields.get(FieldType::current_fp, Direction{dim}, lev)->nComp() == ncomp_multimodefab );
     }
@@ -444,19 +444,19 @@ FullDiagnostics::AddRZModesToDiags (int lev)
     for (int dim=0; dim<3; dim++){
         // 3 components, r theta z
         m_all_field_functors[lev].push_back(std::make_unique<CellCenterFunctor>(
-                warpx.m_fields.get(FieldType::Efield_aux, Direction{dim}, lev), lev,
+                warpx.m_fields.get(FieldType::E_aux, Direction{dim}, lev), lev,
                     m_crse_ratio, false, ncomp_multimodefab));
         AddRZModesToOutputNames(std::string("E") + coord[dim],
-                warpx.m_fields.get(FieldType::Efield_aux, Direction{0}, 0)->nComp());
+                warpx.m_fields.get(FieldType::E_aux, Direction{0}, 0)->nComp());
     }
     // B
     for (int dim=0; dim<3; dim++){
         // 3 components, r theta z
         m_all_field_functors[lev].push_back(std::make_unique<CellCenterFunctor>(
-                warpx.m_fields.get(FieldType::Bfield_aux, Direction{dim}, lev), lev,
+                warpx.m_fields.get(FieldType::B_aux, Direction{dim}, lev), lev,
                     m_crse_ratio, false, ncomp_multimodefab));
         AddRZModesToOutputNames(std::string("B") + coord[dim],
-                warpx.m_fields.get(FieldType::Bfield_aux, Direction{0}, 0)->nComp());
+                warpx.m_fields.get(FieldType::B_aux, Direction{0}, 0)->nComp());
     }
     // j
     for (int dim=0; dim<3; dim++){
@@ -470,7 +470,7 @@ FullDiagnostics::AddRZModesToDiags (int lev)
     // divE
     if (divE_requested) {
         m_all_field_functors[lev].push_back(std::make_unique<DivEFunctor>(
-            warpx.m_fields.get_alldirs(FieldType::Efield_aux, lev),
+            warpx.m_fields.get_alldirs(FieldType::E_aux, lev),
             lev, m_crse_ratio, false, ncomp_multimodefab));
         AddRZModesToOutputNames(std::string("divE"), ncomp_multimodefab);
     }
@@ -668,9 +668,9 @@ FullDiagnostics::InitializeFieldFunctors (int lev)
     // Fill vector of functors for all components except individual cylindrical modes.
     for (int comp=0; comp<nvar; comp++){
         if        ( m_varnames[comp] == "Ez" ){
-            m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Efield_aux, Direction{2}, lev), lev, m_crse_ratio);
+            m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::E_aux, Direction{2}, lev), lev, m_crse_ratio);
         } else if ( m_varnames[comp] == "Bz" ){
-            m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Bfield_aux, Direction{2}, lev), lev, m_crse_ratio);
+            m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::B_aux, Direction{2}, lev), lev, m_crse_ratio);
         } else if ( m_varnames[comp] == "jz" ){
             m_all_field_functors[lev][comp] = std::make_unique<JFunctor>(2, lev, m_crse_ratio, true, deposit_current);
             deposit_current = false;
@@ -700,21 +700,21 @@ FullDiagnostics::InitializeFieldFunctors (int lev)
         } else if ( m_varnames[comp] == "part_per_grid" ){
             m_all_field_functors[lev][comp] = std::make_unique<PartPerGridFunctor>(nullptr, lev, m_crse_ratio);
         } else if ( m_varnames[comp] == "divB" ){
-            m_all_field_functors[lev][comp] = std::make_unique<DivBFunctor>(warpx.m_fields.get_alldirs(FieldType::Bfield_aux, lev), lev, m_crse_ratio);
+            m_all_field_functors[lev][comp] = std::make_unique<DivBFunctor>(warpx.m_fields.get_alldirs(FieldType::B_aux, lev), lev, m_crse_ratio);
         } else if ( m_varnames[comp] == "divE" ){
-            m_all_field_functors[lev][comp] = std::make_unique<DivEFunctor>(warpx.m_fields.get_alldirs(FieldType::Efield_aux, lev), lev, m_crse_ratio);
+            m_all_field_functors[lev][comp] = std::make_unique<DivEFunctor>(warpx.m_fields.get_alldirs(FieldType::E_aux, lev), lev, m_crse_ratio);
         }
         else {
 
 #ifdef WARPX_DIM_RZ
             if        ( m_varnames[comp] == "Er" ){
-                m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Efield_aux, Direction{0}, lev), lev, m_crse_ratio);
+                m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::E_aux, Direction{0}, lev), lev, m_crse_ratio);
             } else if ( m_varnames[comp] == "Et" ){
-                m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Efield_aux, Direction{1}, lev), lev, m_crse_ratio);
+                m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::E_aux, Direction{1}, lev), lev, m_crse_ratio);
             } else if ( m_varnames[comp] == "Br" ){
-                m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Bfield_aux, Direction{0}, lev), lev, m_crse_ratio);
+                m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::B_aux, Direction{0}, lev), lev, m_crse_ratio);
             } else if ( m_varnames[comp] == "Bt" ){
-                m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Bfield_aux, Direction{1}, lev), lev, m_crse_ratio);
+                m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::B_aux, Direction{1}, lev), lev, m_crse_ratio);
             } else if ( m_varnames[comp] == "jr" ){
                 m_all_field_functors[lev][comp] = std::make_unique<JFunctor>(0, lev, m_crse_ratio, true, deposit_current);
                 deposit_current = false;
@@ -735,13 +735,13 @@ FullDiagnostics::InitializeFieldFunctors (int lev)
 #else
         // Valid transverse fields in Cartesian coordinates
             if        ( m_varnames[comp] == "Ex" ){
-                m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Efield_aux, Direction{0}, lev), lev, m_crse_ratio);
+                m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::E_aux, Direction{0}, lev), lev, m_crse_ratio);
             } else if ( m_varnames[comp] == "Ey" ){
-                m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Efield_aux, Direction{1}, lev), lev, m_crse_ratio);
+                m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::E_aux, Direction{1}, lev), lev, m_crse_ratio);
             } else if ( m_varnames[comp] == "Bx" ){
-                m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Bfield_aux, Direction{0}, lev), lev, m_crse_ratio);
+                m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::B_aux, Direction{0}, lev), lev, m_crse_ratio);
             } else if ( m_varnames[comp] == "By" ){
-                m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::Bfield_aux, Direction{1}, lev), lev, m_crse_ratio);
+                m_all_field_functors[lev][comp] = std::make_unique<CellCenterFunctor>(warpx.m_fields.get(FieldType::B_aux, Direction{1}, lev), lev, m_crse_ratio);
             } else if ( m_varnames[comp] == "jx" ){
                 m_all_field_functors[lev][comp] = std::make_unique<JFunctor>(0, lev, m_crse_ratio, true, deposit_current);
                 deposit_current = false;

--- a/Source/Diagnostics/ReducedDiags/ChargeOnEB.cpp
+++ b/Source/Diagnostics/ReducedDiags/ChargeOnEB.cpp
@@ -106,9 +106,9 @@ void ChargeOnEB::ComputeDiags (const int step)
 
     // get MultiFab data at lev
     using warpx::fields::FieldType;
-    const amrex::MultiFab & Ex = *warpx.m_fields.get(FieldType::Efield_fp, Direction{0}, lev);
-    const amrex::MultiFab & Ey = *warpx.m_fields.get(FieldType::Efield_fp, Direction{1}, lev);
-    const amrex::MultiFab & Ez = *warpx.m_fields.get(FieldType::Efield_fp, Direction{2}, lev);
+    const amrex::MultiFab & Ex = *warpx.m_fields.get(FieldType::E_fp, Direction{0}, lev);
+    const amrex::MultiFab & Ey = *warpx.m_fields.get(FieldType::E_fp, Direction{1}, lev);
+    const amrex::MultiFab & Ez = *warpx.m_fields.get(FieldType::E_fp, Direction{2}, lev);
 
     // get EB structures
     amrex::EBFArrayBoxFactory const& eb_box_factory = warpx.fieldEBFactory(lev);

--- a/Source/Diagnostics/ReducedDiags/ColliderRelevant.cpp
+++ b/Source/Diagnostics/ReducedDiags/ColliderRelevant.cpp
@@ -445,12 +445,12 @@ void ColliderRelevant::ComputeDiags (int step)
             // define variables in preparation for field gathering
             using warpx::fields::FieldType;
             const amrex::XDim3 dinv = WarpX::InvCellSize(std::max(lev, 0));
-            const amrex::MultiFab & Ex = *warpx.m_fields.get(FieldType::Efield_aux, Direction{0}, lev);
-            const amrex::MultiFab & Ey = *warpx.m_fields.get(FieldType::Efield_aux, Direction{1}, lev);
-            const amrex::MultiFab & Ez = *warpx.m_fields.get(FieldType::Efield_aux, Direction{2}, lev);
-            const amrex::MultiFab & Bx = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{0}, lev);
-            const amrex::MultiFab & By = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{1}, lev);
-            const amrex::MultiFab & Bz = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{2}, lev);
+            const amrex::MultiFab & Ex = *warpx.m_fields.get(FieldType::E_aux, Direction{0}, lev);
+            const amrex::MultiFab & Ey = *warpx.m_fields.get(FieldType::E_aux, Direction{1}, lev);
+            const amrex::MultiFab & Ez = *warpx.m_fields.get(FieldType::E_aux, Direction{2}, lev);
+            const amrex::MultiFab & Bx = *warpx.m_fields.get(FieldType::B_aux, Direction{0}, lev);
+            const amrex::MultiFab & By = *warpx.m_fields.get(FieldType::B_aux, Direction{1}, lev);
+            const amrex::MultiFab & Bz = *warpx.m_fields.get(FieldType::B_aux, Direction{2}, lev);
 
             // declare reduce_op
             ReduceOps<ReduceOpMin, ReduceOpMax, ReduceOpSum> reduce_op;

--- a/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldEnergy.cpp
@@ -95,12 +95,12 @@ void FieldEnergy::ComputeDiags (int step)
     for (int lev = 0; lev < nLevel; ++lev)
     {
         // get MultiFab data at lev
-        const MultiFab & Ex = *warpx.m_fields.get(FieldType::Efield_aux, Direction{0}, lev);
-        const MultiFab & Ey = *warpx.m_fields.get(FieldType::Efield_aux, Direction{1}, lev);
-        const MultiFab & Ez = *warpx.m_fields.get(FieldType::Efield_aux, Direction{2}, lev);
-        const MultiFab & Bx = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{0}, lev);
-        const MultiFab & By = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{1}, lev);
-        const MultiFab & Bz = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{2}, lev);
+        const MultiFab & Ex = *warpx.m_fields.get(FieldType::E_aux, Direction{0}, lev);
+        const MultiFab & Ey = *warpx.m_fields.get(FieldType::E_aux, Direction{1}, lev);
+        const MultiFab & Ez = *warpx.m_fields.get(FieldType::E_aux, Direction{2}, lev);
+        const MultiFab & Bx = *warpx.m_fields.get(FieldType::B_aux, Direction{0}, lev);
+        const MultiFab & By = *warpx.m_fields.get(FieldType::B_aux, Direction{1}, lev);
+        const MultiFab & Bz = *warpx.m_fields.get(FieldType::B_aux, Direction{2}, lev);
 
         // get cell volume
         const std::array<Real, 3> &dx = WarpX::CellSize(lev);

--- a/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
@@ -119,12 +119,12 @@ void FieldMaximum::ComputeDiags (int step)
     for (int lev = 0; lev < nLevel; ++lev)
     {
         // get MultiFab data at lev
-        const MultiFab & Ex = *warpx.m_fields.get(FieldType::Efield_aux, Direction{0}, lev);
-        const MultiFab & Ey = *warpx.m_fields.get(FieldType::Efield_aux, Direction{1}, lev);
-        const MultiFab & Ez = *warpx.m_fields.get(FieldType::Efield_aux, Direction{2}, lev);
-        const MultiFab & Bx = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{0}, lev);
-        const MultiFab & By = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{1}, lev);
-        const MultiFab & Bz = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{2}, lev);
+        const MultiFab & Ex = *warpx.m_fields.get(FieldType::E_aux, Direction{0}, lev);
+        const MultiFab & Ey = *warpx.m_fields.get(FieldType::E_aux, Direction{1}, lev);
+        const MultiFab & Ez = *warpx.m_fields.get(FieldType::E_aux, Direction{2}, lev);
+        const MultiFab & Bx = *warpx.m_fields.get(FieldType::B_aux, Direction{0}, lev);
+        const MultiFab & By = *warpx.m_fields.get(FieldType::B_aux, Direction{1}, lev);
+        const MultiFab & Bz = *warpx.m_fields.get(FieldType::B_aux, Direction{2}, lev);
 
         constexpr int noutputs = 8; // max of Ex,Ey,Ez,|E|,Bx,By,Bz and |B|
         constexpr int index_Ex = 0;

--- a/Source/Diagnostics/ReducedDiags/FieldMomentum.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldMomentum.cpp
@@ -111,12 +111,12 @@ void FieldMomentum::ComputeDiags (int step)
     for (int lev = 0; lev < nLevel; ++lev)
     {
         // Get MultiFab data at given refinement level
-        const amrex::MultiFab & Ex = *warpx.m_fields.get(FieldType::Efield_aux, Direction{0}, lev);
-        const amrex::MultiFab & Ey = *warpx.m_fields.get(FieldType::Efield_aux, Direction{1}, lev);
-        const amrex::MultiFab & Ez = *warpx.m_fields.get(FieldType::Efield_aux, Direction{2}, lev);
-        const amrex::MultiFab & Bx = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{0}, lev);
-        const amrex::MultiFab & By = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{1}, lev);
-        const amrex::MultiFab & Bz = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{2}, lev);
+        const amrex::MultiFab & Ex = *warpx.m_fields.get(FieldType::E_aux, Direction{0}, lev);
+        const amrex::MultiFab & Ey = *warpx.m_fields.get(FieldType::E_aux, Direction{1}, lev);
+        const amrex::MultiFab & Ez = *warpx.m_fields.get(FieldType::E_aux, Direction{2}, lev);
+        const amrex::MultiFab & Bx = *warpx.m_fields.get(FieldType::B_aux, Direction{0}, lev);
+        const amrex::MultiFab & By = *warpx.m_fields.get(FieldType::B_aux, Direction{1}, lev);
+        const amrex::MultiFab & Bz = *warpx.m_fields.get(FieldType::B_aux, Direction{2}, lev);
 
         // Cell-centered index type
         const amrex::GpuArray<int,3> cc{0,0,0};

--- a/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldProbe.cpp
@@ -401,12 +401,12 @@ void FieldProbe::ComputeDiags (int step)
         }
 
         // get MultiFab data at lev
-        const amrex::MultiFab &Ex = *warpx.m_fields.get(FieldType::Efield_aux, Direction{0}, lev);
-        const amrex::MultiFab &Ey = *warpx.m_fields.get(FieldType::Efield_aux, Direction{1}, lev);
-        const amrex::MultiFab &Ez = *warpx.m_fields.get(FieldType::Efield_aux, Direction{2}, lev);
-        const amrex::MultiFab &Bx = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{0}, lev);
-        const amrex::MultiFab &By = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{1}, lev);
-        const amrex::MultiFab &Bz = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{2}, lev);
+        const amrex::MultiFab &Ex = *warpx.m_fields.get(FieldType::E_aux, Direction{0}, lev);
+        const amrex::MultiFab &Ey = *warpx.m_fields.get(FieldType::E_aux, Direction{1}, lev);
+        const amrex::MultiFab &Ez = *warpx.m_fields.get(FieldType::E_aux, Direction{2}, lev);
+        const amrex::MultiFab &Bx = *warpx.m_fields.get(FieldType::B_aux, Direction{0}, lev);
+        const amrex::MultiFab &By = *warpx.m_fields.get(FieldType::B_aux, Direction{1}, lev);
+        const amrex::MultiFab &Bz = *warpx.m_fields.get(FieldType::B_aux, Direction{2}, lev);
 
         /*
          * Prepare interpolation of field components to probe_position

--- a/Source/Diagnostics/ReducedDiags/FieldReduction.H
+++ b/Source/Diagnostics/ReducedDiags/FieldReduction.H
@@ -101,12 +101,12 @@ public:
         const auto dx = geom.CellSizeArray();
 
         // get MultiFab data
-        const amrex::MultiFab & Ex = *warpx.m_fields.get(FieldType::Efield_aux, Direction{0}, lev);
-        const amrex::MultiFab & Ey = *warpx.m_fields.get(FieldType::Efield_aux, Direction{1}, lev);
-        const amrex::MultiFab & Ez = *warpx.m_fields.get(FieldType::Efield_aux, Direction{2}, lev);
-        const amrex::MultiFab & Bx = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{0}, lev);
-        const amrex::MultiFab & By = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{1}, lev);
-        const amrex::MultiFab & Bz = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{2}, lev);
+        const amrex::MultiFab & Ex = *warpx.m_fields.get(FieldType::E_aux, Direction{0}, lev);
+        const amrex::MultiFab & Ey = *warpx.m_fields.get(FieldType::E_aux, Direction{1}, lev);
+        const amrex::MultiFab & Ez = *warpx.m_fields.get(FieldType::E_aux, Direction{2}, lev);
+        const amrex::MultiFab & Bx = *warpx.m_fields.get(FieldType::B_aux, Direction{0}, lev);
+        const amrex::MultiFab & By = *warpx.m_fields.get(FieldType::B_aux, Direction{1}, lev);
+        const amrex::MultiFab & Bz = *warpx.m_fields.get(FieldType::B_aux, Direction{2}, lev);
         const amrex::MultiFab & jx = *warpx.m_fields.get(FieldType::current_fp, Direction{0},lev);
         const amrex::MultiFab & jy = *warpx.m_fields.get(FieldType::current_fp, Direction{1},lev);
         const amrex::MultiFab & jz = *warpx.m_fields.get(FieldType::current_fp, Direction{2},lev);

--- a/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
+++ b/Source/Diagnostics/ReducedDiags/LoadBalanceCosts.cpp
@@ -131,7 +131,7 @@ void LoadBalanceCosts::ComputeDiags (int step)
     for (int lev = 0; lev < nLevels; ++lev)
     {
         const amrex::DistributionMapping& dm = warpx.DistributionMap(lev);
-        const MultiFab & Ex = *warpx.m_fields.get(FieldType::Efield_aux, Direction{0}, lev);
+        const MultiFab & Ex = *warpx.m_fields.get(FieldType::E_aux, Direction{0}, lev);
         for (MFIter mfi(Ex, false); mfi.isValid(); ++mfi)
         {
             const Box& tbx = mfi.tilebox();

--- a/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
@@ -270,12 +270,12 @@ void ParticleExtrema::ComputeDiags (int step)
                 // define variables in preparation for field gathering
                 const amrex::XDim3 dinv = WarpX::InvCellSize(std::max(lev, 0));
 
-                const amrex::MultiFab & Ex = *warpx.m_fields.get(FieldType::Efield_aux, Direction{0}, lev);
-                const amrex::MultiFab & Ey = *warpx.m_fields.get(FieldType::Efield_aux, Direction{1}, lev);
-                const amrex::MultiFab & Ez = *warpx.m_fields.get(FieldType::Efield_aux, Direction{2}, lev);
-                const amrex::MultiFab & Bx = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{0}, lev);
-                const amrex::MultiFab & By = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{1}, lev);
-                const amrex::MultiFab & Bz = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{2}, lev);
+                const amrex::MultiFab & Ex = *warpx.m_fields.get(FieldType::E_aux, Direction{0}, lev);
+                const amrex::MultiFab & Ey = *warpx.m_fields.get(FieldType::E_aux, Direction{1}, lev);
+                const amrex::MultiFab & Ez = *warpx.m_fields.get(FieldType::E_aux, Direction{2}, lev);
+                const amrex::MultiFab & Bx = *warpx.m_fields.get(FieldType::B_aux, Direction{0}, lev);
+                const amrex::MultiFab & By = *warpx.m_fields.get(FieldType::B_aux, Direction{1}, lev);
+                const amrex::MultiFab & Bz = *warpx.m_fields.get(FieldType::B_aux, Direction{2}, lev);
 
                 // declare reduce_op
                 amrex::ReduceOps<amrex::ReduceOpMin, amrex::ReduceOpMax> reduce_op;

--- a/Source/Diagnostics/SliceDiagnostic.cpp
+++ b/Source/Diagnostics/SliceDiagnostic.cpp
@@ -201,27 +201,27 @@ CreateSlice( const MultiFab& mf, const Vector<Geometry> &dom_geom,
                 amrex::amrex_avgdown_nodes(Dst_bx, Dst_fabox, Src_fabox, dcomp,
                                            scomp, ncomp, slice_cr_ratio);
             }
-            if( SliceType == warpx.m_fields.get(FieldType::Efield_aux, Direction{0}, 0)->ixType().toIntVect() ) {
+            if( SliceType == warpx.m_fields.get(FieldType::E_aux, Direction{0}, 0)->ixType().toIntVect() ) {
                 amrex::amrex_avgdown_edges(Dst_bx, Dst_fabox, Src_fabox, dcomp,
                                            scomp, ncomp, slice_cr_ratio, 0);
             }
-            if( SliceType == warpx.m_fields.get(FieldType::Efield_aux, Direction{1}, 0)->ixType().toIntVect() ) {
+            if( SliceType == warpx.m_fields.get(FieldType::E_aux, Direction{1}, 0)->ixType().toIntVect() ) {
                 amrex::amrex_avgdown_edges(Dst_bx, Dst_fabox, Src_fabox, dcomp,
                                            scomp, ncomp, slice_cr_ratio, 1);
             }
-            if( SliceType == warpx.m_fields.get(FieldType::Efield_aux, Direction{2}, 0)->ixType().toIntVect() ) {
+            if( SliceType == warpx.m_fields.get(FieldType::E_aux, Direction{2}, 0)->ixType().toIntVect() ) {
                 amrex::amrex_avgdown_edges(Dst_bx, Dst_fabox, Src_fabox, dcomp,
                                            scomp, ncomp, slice_cr_ratio, 2);
             }
-            if( SliceType == warpx.m_fields.get(FieldType::Bfield_aux, Direction{0}, 0)->ixType().toIntVect() ) {
+            if( SliceType == warpx.m_fields.get(FieldType::B_aux, Direction{0}, 0)->ixType().toIntVect() ) {
                 amrex::amrex_avgdown_faces(Dst_bx, Dst_fabox, Src_fabox, dcomp,
                                            scomp, ncomp, slice_cr_ratio, 0);
             }
-            if( SliceType == warpx.m_fields.get(FieldType::Bfield_aux, Direction{1}, 0)->ixType().toIntVect() ) {
+            if( SliceType == warpx.m_fields.get(FieldType::B_aux, Direction{1}, 0)->ixType().toIntVect() ) {
                 amrex::amrex_avgdown_faces(Dst_bx, Dst_fabox, Src_fabox, dcomp,
                                            scomp, ncomp, slice_cr_ratio, 1);
             }
-            if( SliceType == warpx.m_fields.get(FieldType::Bfield_aux, Direction{2}, 0)->ixType().toIntVect() ) {
+            if( SliceType == warpx.m_fields.get(FieldType::B_aux, Direction{2}, 0)->ixType().toIntVect() ) {
                 amrex::amrex_avgdown_faces(Dst_bx, Dst_fabox, Src_fabox, dcomp,
                                            scomp, ncomp, slice_cr_ratio, 2);
             }

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -284,49 +284,49 @@ WarpX::InitFromCheckpoint ()
     {
         for (int i = 0; i < 3; ++i) {
             m_fields.get(FieldType::current_fp, Direction{i}, lev)->setVal(0.0);
-            m_fields.get(FieldType::Efield_fp, Direction{i}, lev)->setVal(0.0);
-            m_fields.get(FieldType::Bfield_fp, Direction{i}, lev)->setVal(0.0);
+            m_fields.get(FieldType::E_fp, Direction{i}, lev)->setVal(0.0);
+            m_fields.get(FieldType::B_fp, Direction{i}, lev)->setVal(0.0);
         }
 
         if (lev > 0) {
             for (int i = 0; i < 3; ++i) {
-                m_fields.get(FieldType::Efield_aux, Direction{i}, lev)->setVal(0.0);
-                m_fields.get(FieldType::Bfield_aux, Direction{i}, lev)->setVal(0.0);
+                m_fields.get(FieldType::E_aux, Direction{i}, lev)->setVal(0.0);
+                m_fields.get(FieldType::B_aux, Direction{i}, lev)->setVal(0.0);
 
                 m_fields.get(FieldType::current_cp, Direction{i}, lev)->setVal(0.0);
-                m_fields.get(FieldType::Efield_cp, Direction{i}, lev)->setVal(0.0);
-                m_fields.get(FieldType::Bfield_cp, Direction{i}, lev)->setVal(0.0);
+                m_fields.get(FieldType::E_cp, Direction{i}, lev)->setVal(0.0);
+                m_fields.get(FieldType::B_cp, Direction{i}, lev)->setVal(0.0);
             }
         }
 
-        VisMF::Read(*m_fields.get(FieldType::Efield_fp, Direction{0}, lev),
+        VisMF::Read(*m_fields.get(FieldType::E_fp, Direction{0}, lev),
                     amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ex_fp"));
-        VisMF::Read(*m_fields.get(FieldType::Efield_fp, Direction{1}, lev),
+        VisMF::Read(*m_fields.get(FieldType::E_fp, Direction{1}, lev),
                     amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ey_fp"));
-        VisMF::Read(*m_fields.get(FieldType::Efield_fp, Direction{2}, lev),
+        VisMF::Read(*m_fields.get(FieldType::E_fp, Direction{2}, lev),
                     amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ez_fp"));
 
-        VisMF::Read(*m_fields.get(FieldType::Bfield_fp, Direction{0}, lev),
+        VisMF::Read(*m_fields.get(FieldType::B_fp, Direction{0}, lev),
                     amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bx_fp"));
-        VisMF::Read(*m_fields.get(FieldType::Bfield_fp, Direction{1}, lev),
+        VisMF::Read(*m_fields.get(FieldType::B_fp, Direction{1}, lev),
                     amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "By_fp"));
-        VisMF::Read(*m_fields.get(FieldType::Bfield_fp, Direction{2}, lev),
+        VisMF::Read(*m_fields.get(FieldType::B_fp, Direction{2}, lev),
                     amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bz_fp"));
 
         if (WarpX::fft_do_time_averaging)
         {
-            VisMF::Read(*m_fields.get(FieldType::Efield_avg_fp, Direction{0}, lev),
+            VisMF::Read(*m_fields.get(FieldType::E_avg_fp, Direction{0}, lev),
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ex_avg_fp"));
-            VisMF::Read(*m_fields.get(FieldType::Efield_avg_fp, Direction{1}, lev),
+            VisMF::Read(*m_fields.get(FieldType::E_avg_fp, Direction{1}, lev),
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ey_avg_fp"));
-            VisMF::Read(*m_fields.get(FieldType::Efield_avg_fp, Direction{2}, lev),
+            VisMF::Read(*m_fields.get(FieldType::E_avg_fp, Direction{2}, lev),
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ez_avg_fp"));
 
-            VisMF::Read(*m_fields.get(FieldType::Bfield_avg_fp, Direction{0}, lev),
+            VisMF::Read(*m_fields.get(FieldType::B_avg_fp, Direction{0}, lev),
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bx_avg_fp"));
-            VisMF::Read(*m_fields.get(FieldType::Bfield_avg_fp, Direction{1}, lev),
+            VisMF::Read(*m_fields.get(FieldType::B_avg_fp, Direction{1}, lev),
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "By_avg_fp"));
-            VisMF::Read(*m_fields.get(FieldType::Bfield_avg_fp, Direction{2}, lev),
+            VisMF::Read(*m_fields.get(FieldType::B_avg_fp, Direction{2}, lev),
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bz_avg_fp"));
         }
 
@@ -341,34 +341,34 @@ WarpX::InitFromCheckpoint ()
 
         if (lev > 0)
         {
-            VisMF::Read(*m_fields.get(FieldType::Efield_cp, Direction{0}, lev),
+            VisMF::Read(*m_fields.get(FieldType::E_cp, Direction{0}, lev),
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ex_cp"));
-            VisMF::Read(*m_fields.get(FieldType::Efield_cp, Direction{1}, lev),
+            VisMF::Read(*m_fields.get(FieldType::E_cp, Direction{1}, lev),
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ey_cp"));
-            VisMF::Read(*m_fields.get(FieldType::Efield_cp, Direction{2}, lev),
+            VisMF::Read(*m_fields.get(FieldType::E_cp, Direction{2}, lev),
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ez_cp"));
 
-            VisMF::Read(*m_fields.get(FieldType::Bfield_cp, Direction{0}, lev),
+            VisMF::Read(*m_fields.get(FieldType::B_cp, Direction{0}, lev),
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bx_cp"));
-            VisMF::Read(*m_fields.get(FieldType::Bfield_cp, Direction{1}, lev),
+            VisMF::Read(*m_fields.get(FieldType::B_cp, Direction{1}, lev),
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "By_cp"));
-            VisMF::Read(*m_fields.get(FieldType::Bfield_cp, Direction{2}, lev),
+            VisMF::Read(*m_fields.get(FieldType::B_cp, Direction{2}, lev),
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bz_cp"));
 
             if (WarpX::fft_do_time_averaging)
             {
-                VisMF::Read(*m_fields.get(FieldType::Efield_avg_cp, Direction{0}, lev),
+                VisMF::Read(*m_fields.get(FieldType::E_avg_cp, Direction{0}, lev),
                             amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ex_avg_cp"));
-                VisMF::Read(*m_fields.get(FieldType::Efield_avg_cp, Direction{1}, lev),
+                VisMF::Read(*m_fields.get(FieldType::E_avg_cp, Direction{1}, lev),
                             amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ey_avg_cp"));
-                VisMF::Read(*m_fields.get(FieldType::Efield_avg_cp, Direction{2}, lev),
+                VisMF::Read(*m_fields.get(FieldType::E_avg_cp, Direction{2}, lev),
                             amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ez_avg_cp"));
 
-                VisMF::Read(*m_fields.get(FieldType::Bfield_avg_cp, Direction{0}, lev),
+                VisMF::Read(*m_fields.get(FieldType::B_avg_cp, Direction{0}, lev),
                             amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bx_avg_cp"));
-                VisMF::Read(*m_fields.get(FieldType::Bfield_avg_cp, Direction{1}, lev),
+                VisMF::Read(*m_fields.get(FieldType::B_avg_cp, Direction{1}, lev),
                             amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "By_avg_cp"));
-                VisMF::Read(*m_fields.get(FieldType::Bfield_avg_cp, Direction{2}, lev),
+                VisMF::Read(*m_fields.get(FieldType::B_avg_cp, Direction{2}, lev),
                             amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bz_avg_cp"));
             }
 

--- a/Source/EmbeddedBoundary/WarpXFaceExtensions.cpp
+++ b/Source/EmbeddedBoundary/WarpXFaceExtensions.cpp
@@ -288,7 +288,7 @@ WarpX::ComputeFaceExtensions ()
 void
 WarpX::InitBorrowing() {
     int idim = 0;
-    for (amrex::MFIter mfi(*m_fields.get(FieldType::Bfield_fp, Direction{idim}, maxLevel())); mfi.isValid(); ++mfi) {
+    for (amrex::MFIter mfi(*m_fields.get(FieldType::B_fp, Direction{idim}, maxLevel())); mfi.isValid(); ++mfi) {
         amrex::Box const &box = mfi.validbox();
         auto &borrowing_x = (*m_borrowing[maxLevel()][idim])[mfi];
         borrowing_x.inds_pointer.resize(box);
@@ -304,7 +304,7 @@ WarpX::InitBorrowing() {
     }
 
     idim = 1;
-    for (amrex::MFIter mfi(*m_fields.get(FieldType::Bfield_fp, Direction{idim}, maxLevel())); mfi.isValid(); ++mfi) {
+    for (amrex::MFIter mfi(*m_fields.get(FieldType::B_fp, Direction{idim}, maxLevel())); mfi.isValid(); ++mfi) {
         amrex::Box const &box = mfi.validbox();
         auto &borrowing_y = (*m_borrowing[maxLevel()][idim])[mfi];
         borrowing_y.inds_pointer.resize(box);
@@ -317,7 +317,7 @@ WarpX::InitBorrowing() {
     }
 
     idim = 2;
-    for (amrex::MFIter mfi(*m_fields.get(FieldType::Bfield_fp, Direction{idim}, maxLevel())); mfi.isValid(); ++mfi) {
+    for (amrex::MFIter mfi(*m_fields.get(FieldType::B_fp, Direction{idim}, maxLevel())); mfi.isValid(); ++mfi) {
         amrex::Box const &box = mfi.validbox();
         auto &borrowing_z = (*m_borrowing[maxLevel()][idim])[mfi];
         borrowing_z.inds_pointer.resize(box);
@@ -458,7 +458,7 @@ WarpX::ComputeOneWayExtensions ()
         WARPX_ABORT_WITH_MESSAGE(
             "ComputeOneWayExtensions: Only implemented in 2D3V and 3D3V");
 #endif
-        for (amrex::MFIter mfi(*m_fields.get(FieldType::Bfield_fp, Direction{idim}, maxLevel())); mfi.isValid(); ++mfi) {
+        for (amrex::MFIter mfi(*m_fields.get(FieldType::B_fp, Direction{idim}, maxLevel())); mfi.isValid(); ++mfi) {
 
             amrex::Box const &box = mfi.validbox();
             auto const &S = m_fields.get(FieldType::face_areas, Direction{idim}, maxLevel())->array(mfi);
@@ -585,7 +585,7 @@ WarpX::ComputeEightWaysExtensions ()
         WARPX_ABORT_WITH_MESSAGE(
             "ComputeEightWaysExtensions: Only implemented in 2D3V and 3D3V");
 #endif
-        for (amrex::MFIter mfi(*m_fields.get(FieldType::Bfield_fp, Direction{idim}, maxLevel())); mfi.isValid(); ++mfi) {
+        for (amrex::MFIter mfi(*m_fields.get(FieldType::B_fp, Direction{idim}, maxLevel())); mfi.isValid(); ++mfi) {
 
             amrex::Box const &box = mfi.validbox();
 
@@ -737,7 +737,7 @@ WarpX::ApplyBCKCorrection (const int idim)
     const amrex::Real dy = cell_size[1];
     const amrex::Real dz = cell_size[2];
 
-    for (amrex::MFIter mfi(*m_fields.get(FieldType::Bfield_fp, Direction{idim}, maxLevel()), amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+    for (amrex::MFIter mfi(*m_fields.get(FieldType::B_fp, Direction{idim}, maxLevel()), amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
 
         const amrex::Box &box = mfi.tilebox();
         const amrex::Array4<int> &flag_ext_face = m_flag_ext_face[maxLevel()][idim]->array(mfi);
@@ -765,7 +765,7 @@ void
 WarpX::ShrinkBorrowing ()
 {
     for(int idim = 0; idim < AMREX_SPACEDIM; idim++) {
-        for (amrex::MFIter mfi(*m_fields.get(FieldType::Bfield_fp, Direction{idim}, maxLevel())); mfi.isValid(); ++mfi) {
+        for (amrex::MFIter mfi(*m_fields.get(FieldType::B_fp, Direction{idim}, maxLevel())); mfi.isValid(); ++mfi) {
             auto &borrowing = (*m_borrowing[maxLevel()][idim])[mfi];
             borrowing.inds.resize(borrowing.vecs_size);
             borrowing.neigh_faces.resize(borrowing.vecs_size);

--- a/Source/EmbeddedBoundary/WarpXInitEB.cpp
+++ b/Source/EmbeddedBoundary/WarpXInitEB.cpp
@@ -313,7 +313,7 @@ WarpX::MarkCells ()
             continue;
         }
 #endif
-        for (amrex::MFIter mfi(*m_fields.get(FieldType::Bfield_fp, Direction{idim}, maxLevel())); mfi.isValid(); ++mfi) {
+        for (amrex::MFIter mfi(*m_fields.get(FieldType::B_fp, Direction{idim}, maxLevel())); mfi.isValid(); ++mfi) {
             auto* face_areas_idim_max_lev =
                 m_fields.get(FieldType::face_areas, Direction{idim}, maxLevel());
 

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -79,12 +79,12 @@ WarpX::Synchronize () {
         mypc->PushP(
             lev,
             0.5_rt*dt[lev],
-            *m_fields.get(FieldType::Efield_aux, Direction{0}, lev),
-            *m_fields.get(FieldType::Efield_aux, Direction{1}, lev),
-            *m_fields.get(FieldType::Efield_aux, Direction{2}, lev),
-            *m_fields.get(FieldType::Bfield_aux, Direction{0}, lev),
-            *m_fields.get(FieldType::Bfield_aux, Direction{1}, lev),
-            *m_fields.get(FieldType::Bfield_aux, Direction{2}, lev)
+            *m_fields.get(FieldType::E_aux, Direction{0}, lev),
+            *m_fields.get(FieldType::E_aux, Direction{1}, lev),
+            *m_fields.get(FieldType::E_aux, Direction{2}, lev),
+            *m_fields.get(FieldType::B_aux, Direction{0}, lev),
+            *m_fields.get(FieldType::B_aux, Direction{1}, lev),
+            *m_fields.get(FieldType::B_aux, Direction{2}, lev)
         );
     }
     is_synchronized = true;
@@ -495,12 +495,12 @@ void WarpX::ExplicitFillBoundaryEBUpdateAux ()
             mypc->PushP(
                 lev,
                 -0.5_rt*dt[lev],
-                *m_fields.get(FieldType::Efield_aux, Direction{0}, lev),
-                *m_fields.get(FieldType::Efield_aux, Direction{1}, lev),
-                *m_fields.get(FieldType::Efield_aux, Direction{2}, lev),
-                *m_fields.get(FieldType::Bfield_aux, Direction{0}, lev),
-                *m_fields.get(FieldType::Bfield_aux, Direction{1}, lev),
-                *m_fields.get(FieldType::Bfield_aux, Direction{2}, lev)
+                *m_fields.get(FieldType::E_aux, Direction{0}, lev),
+                *m_fields.get(FieldType::E_aux, Direction{1}, lev),
+                *m_fields.get(FieldType::E_aux, Direction{2}, lev),
+                *m_fields.get(FieldType::B_aux, Direction{0}, lev),
+                *m_fields.get(FieldType::B_aux, Direction{1}, lev),
+                *m_fields.get(FieldType::B_aux, Direction{2}, lev)
             );
         }
         is_synchronized = false;
@@ -794,10 +794,10 @@ WarpX::OneStep_multiJ (const amrex::Real cur_time)
         // We summed the integral of the field over 2*dt
         PSATDScaleAverageFields(1._rt / (2._rt*dt[0]));
         PSATDBackwardTransformEBavg(
-            m_fields.get_mr_levels_alldirs(FieldType::Efield_avg_fp, finest_level),
-            m_fields.get_mr_levels_alldirs(FieldType::Bfield_avg_fp, finest_level),
-            m_fields.get_mr_levels_alldirs(FieldType::Efield_avg_cp, finest_level),
-            m_fields.get_mr_levels_alldirs(FieldType::Bfield_avg_cp, finest_level)
+            m_fields.get_mr_levels_alldirs(FieldType::E_avg_fp, finest_level),
+            m_fields.get_mr_levels_alldirs(FieldType::B_avg_fp, finest_level),
+            m_fields.get_mr_levels_alldirs(FieldType::E_avg_cp, finest_level),
+            m_fields.get_mr_levels_alldirs(FieldType::B_avg_cp, finest_level)
         );
     }
 
@@ -1061,12 +1061,12 @@ WarpX::doFieldIonization (int lev)
 
     mypc->doFieldIonization(
         lev,
-        *m_fields.get(FieldType::Efield_aux, Direction{0}, lev),
-        *m_fields.get(FieldType::Efield_aux, Direction{1}, lev),
-        *m_fields.get(FieldType::Efield_aux, Direction{2}, lev),
-        *m_fields.get(FieldType::Bfield_aux, Direction{0}, lev),
-        *m_fields.get(FieldType::Bfield_aux, Direction{1}, lev),
-        *m_fields.get(FieldType::Bfield_aux, Direction{2}, lev)
+        *m_fields.get(FieldType::E_aux, Direction{0}, lev),
+        *m_fields.get(FieldType::E_aux, Direction{1}, lev),
+        *m_fields.get(FieldType::E_aux, Direction{2}, lev),
+        *m_fields.get(FieldType::B_aux, Direction{0}, lev),
+        *m_fields.get(FieldType::B_aux, Direction{1}, lev),
+        *m_fields.get(FieldType::B_aux, Direction{2}, lev)
     );
 }
 
@@ -1087,12 +1087,12 @@ WarpX::doQEDEvents (int lev)
 
     mypc->doQedEvents(
         lev,
-        *m_fields.get(FieldType::Efield_aux, Direction{0}, lev),
-        *m_fields.get(FieldType::Efield_aux, Direction{1}, lev),
-        *m_fields.get(FieldType::Efield_aux, Direction{2}, lev),
-        *m_fields.get(FieldType::Bfield_aux, Direction{0}, lev),
-        *m_fields.get(FieldType::Bfield_aux, Direction{1}, lev),
-        *m_fields.get(FieldType::Bfield_aux, Direction{2}, lev)
+        *m_fields.get(FieldType::E_aux, Direction{0}, lev),
+        *m_fields.get(FieldType::E_aux, Direction{1}, lev),
+        *m_fields.get(FieldType::E_aux, Direction{2}, lev),
+        *m_fields.get(FieldType::B_aux, Direction{0}, lev),
+        *m_fields.get(FieldType::B_aux, Direction{1}, lev),
+        *m_fields.get(FieldType::B_aux, Direction{2}, lev)
     );
 }
 #endif
@@ -1216,12 +1216,12 @@ WarpX::applyMirrors (Real time)
             const amrex::Real z_max = std::max(z_max_tmp, z_min+mirror_z_npoints[i_mirror]*dz);
 
             // Set each field on the fine patch to zero between z_min and z_max
-            NullifyMF(m_fields, "Efield_fp", Direction{0}, lev, z_min, z_max);
-            NullifyMF(m_fields, "Efield_fp", Direction{1}, lev, z_min, z_max);
-            NullifyMF(m_fields, "Efield_fp", Direction{2}, lev, z_min, z_max);
-            NullifyMF(m_fields, "Bfield_fp", Direction{0}, lev, z_min, z_max);
-            NullifyMF(m_fields, "Bfield_fp", Direction{1}, lev, z_min, z_max);
-            NullifyMF(m_fields, "Bfield_fp", Direction{2}, lev, z_min, z_max);
+            NullifyMF(m_fields, "E_fp", Direction{0}, lev, z_min, z_max);
+            NullifyMF(m_fields, "E_fp", Direction{1}, lev, z_min, z_max);
+            NullifyMF(m_fields, "E_fp", Direction{2}, lev, z_min, z_max);
+            NullifyMF(m_fields, "B_fp", Direction{0}, lev, z_min, z_max);
+            NullifyMF(m_fields, "B_fp", Direction{1}, lev, z_min, z_max);
+            NullifyMF(m_fields, "B_fp", Direction{2}, lev, z_min, z_max);
 
             // If div(E)/div(B) cleaning are used, set F/G field to zero
             NullifyMF(m_fields, "F_fp", lev, z_min, z_max);
@@ -1230,12 +1230,12 @@ WarpX::applyMirrors (Real time)
             if (lev>0)
             {
                 // Set each field on the coarse patch to zero between z_min and z_max
-                NullifyMF(m_fields, "Efield_cp", Direction{0}, lev, z_min, z_max);
-                NullifyMF(m_fields, "Efield_cp", Direction{1}, lev, z_min, z_max);
-                NullifyMF(m_fields, "Efield_cp", Direction{2}, lev, z_min, z_max);
-                NullifyMF(m_fields, "Bfield_cp", Direction{0}, lev, z_min, z_max);
-                NullifyMF(m_fields, "Bfield_cp", Direction{1}, lev, z_min, z_max);
-                NullifyMF(m_fields, "Bfield_cp", Direction{2}, lev, z_min, z_max);
+                NullifyMF(m_fields, "E_cp", Direction{0}, lev, z_min, z_max);
+                NullifyMF(m_fields, "E_cp", Direction{1}, lev, z_min, z_max);
+                NullifyMF(m_fields, "E_cp", Direction{2}, lev, z_min, z_max);
+                NullifyMF(m_fields, "B_cp", Direction{0}, lev, z_min, z_max);
+                NullifyMF(m_fields, "B_cp", Direction{1}, lev, z_min, z_max);
+                NullifyMF(m_fields, "B_cp", Direction{2}, lev, z_min, z_max);
 
                 // If div(E)/div(B) cleaning are used, set F/G field to zero
                 NullifyMF(m_fields, "F_cp", lev, z_min, z_max);

--- a/Source/FieldSolver/ElectrostaticSolvers/ElectrostaticSolver.cpp
+++ b/Source/FieldSolver/ElectrostaticSolvers/ElectrostaticSolver.cpp
@@ -149,7 +149,7 @@ ElectrostaticSolver::computePhi (
             // EB: use AMReX to directly calculate the electric field since with EB's the
             // simple finite difference scheme in WarpX::computeE sometimes fails
 
-            // TODO: maybe make this a helper function or pass Efield_fp directly
+            // TODO: maybe make this a helper function or pass E_fp directly
             amrex::Vector<
                 amrex::Array<amrex::MultiFab *, AMREX_SPACEDIM>
             > e_field;
@@ -157,18 +157,18 @@ ElectrostaticSolver::computePhi (
                 e_field.push_back(
 #if defined(WARPX_DIM_1D_Z)
                     amrex::Array<amrex::MultiFab*, 1>{
-                        warpx.m_fields.get(FieldType::Efield_fp, Direction{2}, lev)
+                        warpx.m_fields.get(FieldType::E_fp, Direction{2}, lev)
                     }
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
                     amrex::Array<amrex::MultiFab*, 2>{
-                        warpx.m_fields.get(FieldType::Efield_fp, Direction{0}, lev),
-                        warpx.m_fields.get(FieldType::Efield_fp, Direction{2}, lev)
+                        warpx.m_fields.get(FieldType::E_fp, Direction{0}, lev),
+                        warpx.m_fields.get(FieldType::E_fp, Direction{2}, lev)
                     }
 #elif defined(WARPX_DIM_3D)
                     amrex::Array<amrex::MultiFab *, 3>{
-                        warpx.m_fields.get(FieldType::Efield_fp, Direction{0}, lev),
-                        warpx.m_fields.get(FieldType::Efield_fp, Direction{1}, lev),
-                        warpx.m_fields.get(FieldType::Efield_fp, Direction{2}, lev)
+                        warpx.m_fields.get(FieldType::E_fp, Direction{0}, lev),
+                        warpx.m_fields.get(FieldType::E_fp, Direction{1}, lev),
+                        warpx.m_fields.get(FieldType::E_fp, Direction{2}, lev)
                     }
 #endif
                 );

--- a/Source/FieldSolver/ElectrostaticSolvers/LabFrameExplicitES.cpp
+++ b/Source/FieldSolver/ElectrostaticSolvers/LabFrameExplicitES.cpp
@@ -34,7 +34,7 @@ void LabFrameExplicitES::ComputeSpaceChargeField (
     const MultiLevelScalarField rho_fp = fields.get_mr_levels(FieldType::rho_fp, max_level);
     const MultiLevelScalarField rho_cp = fields.get_mr_levels(FieldType::rho_cp, max_level);
     const MultiLevelScalarField phi_fp = fields.get_mr_levels(FieldType::phi_fp, max_level);
-    const MultiLevelVectorField Efield_fp = fields.get_mr_levels_alldirs(FieldType::Efield_fp, max_level);
+    const MultiLevelVectorField E_fp = fields.get_mr_levels_alldirs(FieldType::E_fp, max_level);
 
     mpc.DepositCharge(rho_fp, 0.0_rt);
     if (mfl) {
@@ -82,9 +82,9 @@ void LabFrameExplicitES::ComputeSpaceChargeField (
 
     // Compute the electric field. Note that if an EB is used the electric
     // field will be calculated in the computePhi call.
-    if (!EB::enabled()) { computeE( Efield_fp, phi_fp, beta ); }
+    if (!EB::enabled()) { computeE( E_fp, phi_fp, beta ); }
     else {
-        if (IsPythonCallbackInstalled("poissonsolver")) { computeE(Efield_fp, phi_fp, beta); }
+        if (IsPythonCallbackInstalled("poissonsolver")) { computeE(E_fp, phi_fp, beta); }
     }
 }
 

--- a/Source/FieldSolver/ElectrostaticSolvers/RelativisticExplicitES.H
+++ b/Source/FieldSolver/ElectrostaticSolvers/RelativisticExplicitES.H
@@ -68,10 +68,10 @@ public:
     /** Compute the potential `phi` by solving the Poisson equation with the
        simulation specific boundary conditions and boundary values, then add the
        E field due to that `phi` to `E_fp`.
-    * \param[in] Efield Efield updated to include potential gradient from boundary condition
+    * \param[in] E_fp Efield updated to include potential gradient from boundary condition
     */
     void AddBoundaryField (
-        ablastr::fields::MultiLevelVectorField& Efield
+        ablastr::fields::MultiLevelVectorField& E_fp
     );
 };
 

--- a/Source/FieldSolver/ElectrostaticSolvers/RelativisticExplicitES.H
+++ b/Source/FieldSolver/ElectrostaticSolvers/RelativisticExplicitES.H
@@ -40,7 +40,7 @@ public:
      * \param[in] charge_buf Buffer region to synchronize charge density from fine and coarse patch
      * \param[in,unused] phi_fp A temporary multifab is used to compute electrostatic potentail for each species
      * \param[in] mpc Pointer to multi particle container to access species data
-     * \param[in,out] Efield_fp Field contribution from phi computed from each species' charge density is added
+     * \param[in,out] E_fp Field contribution from phi computed from each species' charge density is added
      * \param[in,out] Bfield Field contribution from phi computed from each species' charge density is added
      */
     void ComputeSpaceChargeField (
@@ -61,13 +61,13 @@ public:
      */
     void AddSpaceChargeField (
         WarpXParticleContainer& pc,
-        ablastr::fields::MultiLevelVectorField& Efield_fp,
-        ablastr::fields::MultiLevelVectorField& Bfield_fp
+        ablastr::fields::MultiLevelVectorField& E_fp,
+        ablastr::fields::MultiLevelVectorField& B_fp
     );
 
     /** Compute the potential `phi` by solving the Poisson equation with the
        simulation specific boundary conditions and boundary values, then add the
-       E field due to that `phi` to `Efield_fp`.
+       E field due to that `phi` to `E_fp`.
     * \param[in] Efield Efield updated to include potential gradient from boundary condition
     */
     void AddBoundaryField (

--- a/Source/FieldSolver/ElectrostaticSolvers/RelativisticExplicitES.cpp
+++ b/Source/FieldSolver/ElectrostaticSolvers/RelativisticExplicitES.cpp
@@ -43,29 +43,29 @@ void RelativisticExplicitES::ComputeSpaceChargeField (
 
     const bool always_run_solve = (WarpX::electrostatic_solver_id == ElectrostaticSolverAlgo::Relativistic);
 
-    MultiLevelVectorField Efield_fp = fields.get_mr_levels_alldirs(FieldType::Efield_fp, max_level);
-    MultiLevelVectorField Bfield_fp = fields.get_mr_levels_alldirs(FieldType::Bfield_fp, max_level);
+    MultiLevelVectorField E_fp = fields.get_mr_levels_alldirs(FieldType::E_fp, max_level);
+    MultiLevelVectorField B_fp = fields.get_mr_levels_alldirs(FieldType::B_fp, max_level);
 
     // Loop over the species and add their space-charge contribution to E and B.
     // Note that the fields calculated here does not include the E field
     // due to simulation boundary potentials
     for (auto const& species : mpc) {
         if (always_run_solve || (species->initialize_self_fields)) {
-            AddSpaceChargeField(*species, Efield_fp, Bfield_fp);
+            AddSpaceChargeField(*species, E_fp, B_fp);
         }
     }
 
     // Add the field due to the boundary potentials
     if (always_run_solve || (m_poisson_boundary_handler->m_boundary_potential_specified))
     {
-        AddBoundaryField(Efield_fp);
+        AddBoundaryField(E_fp);
     }
 }
 
 void RelativisticExplicitES::AddSpaceChargeField (
     WarpXParticleContainer& pc,
-    ablastr::fields::MultiLevelVectorField& Efield_fp,
-    ablastr::fields::MultiLevelVectorField& Bfield_fp)
+    ablastr::fields::MultiLevelVectorField& E_fp,
+    ablastr::fields::MultiLevelVectorField& B_fp)
 {
     WARPX_PROFILE("RelativisticExplicitES::AddSpaceChargeField");
 
@@ -133,12 +133,12 @@ void RelativisticExplicitES::AddSpaceChargeField (
                 pc.self_fields_verbosity );
 
     // Compute the corresponding electric and magnetic field, from the potential phi
-    computeE( Efield_fp, amrex::GetVecOfPtrs(phi), beta );
-    computeB( Bfield_fp, amrex::GetVecOfPtrs(phi), beta );
+    computeE( E_fp, amrex::GetVecOfPtrs(phi), beta );
+    computeB( B_fp, amrex::GetVecOfPtrs(phi), beta );
 
 }
 
-void RelativisticExplicitES::AddBoundaryField (ablastr::fields::MultiLevelVectorField& Efield_fp)
+void RelativisticExplicitES::AddBoundaryField (ablastr::fields::MultiLevelVectorField& E_fp)
 {
     WARPX_PROFILE("RelativisticExplicitES::AddBoundaryField");
 
@@ -171,5 +171,5 @@ void RelativisticExplicitES::AddBoundaryField (ablastr::fields::MultiLevelVector
                 self_fields_verbosity );
 
     // Compute the corresponding electric field, from the potential phi.
-    computeE( Efield_fp, amrex::GetVecOfPtrs(phi), beta );
+    computeE( E_fp, amrex::GetVecOfPtrs(phi), beta );
 }

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
@@ -61,9 +61,9 @@ void FiniteDifferenceSolver::EvolveB (
     using warpx::fields::FieldType;
 
     const ablastr::fields::VectorField Bfield = patch_type == PatchType::fine ?
-        fields.get_alldirs(FieldType::Bfield_fp, lev) : fields.get_alldirs(FieldType::Bfield_cp, lev);
+        fields.get_alldirs(FieldType::B_fp, lev) : fields.get_alldirs(FieldType::B_cp, lev);
     const ablastr::fields::VectorField Efield = patch_type == PatchType::fine ?
-        fields.get_alldirs(FieldType::Efield_fp, lev) : fields.get_alldirs(FieldType::Efield_cp, lev);
+        fields.get_alldirs(FieldType::E_fp, lev) : fields.get_alldirs(FieldType::E_cp, lev);
 
     // Select algorithm (The choice of algorithm is a runtime option,
     // but we compile code for each algorithm, using templates)

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveE.cpp
@@ -62,7 +62,7 @@ void FiniteDifferenceSolver::EvolveE (
     using warpx::fields::FieldType;
 
     const ablastr::fields::VectorField Bfield = patch_type == PatchType::fine ?
-        fields.get_alldirs(FieldType::Bfield_fp, lev) : fields.get_alldirs(FieldType::Bfield_cp, lev);
+        fields.get_alldirs(FieldType::B_fp, lev) : fields.get_alldirs(FieldType::B_cp, lev);
     const ablastr::fields::VectorField Jfield = patch_type == PatchType::fine ?
         fields.get_alldirs(FieldType::current_fp, lev) : fields.get_alldirs(FieldType::current_cp, lev);
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -150,12 +150,12 @@ void HybridPICModel::InitData ()
     amrex::IntVect Jx_stag = warpx.m_fields.get(FieldType::current_fp, Direction{0}, 0)->ixType().toIntVect();
     amrex::IntVect Jy_stag = warpx.m_fields.get(FieldType::current_fp, Direction{1}, 0)->ixType().toIntVect();
     amrex::IntVect Jz_stag = warpx.m_fields.get(FieldType::current_fp, Direction{2}, 0)->ixType().toIntVect();
-    amrex::IntVect Bx_stag = warpx.m_fields.get(FieldType::Bfield_fp, Direction{0}, 0)->ixType().toIntVect();
-    amrex::IntVect By_stag = warpx.m_fields.get(FieldType::Bfield_fp, Direction{1}, 0)->ixType().toIntVect();
-    amrex::IntVect Bz_stag = warpx.m_fields.get(FieldType::Bfield_fp, Direction{2}, 0)->ixType().toIntVect();
-    amrex::IntVect Ex_stag = warpx.m_fields.get(FieldType::Efield_fp, Direction{0}, 0)->ixType().toIntVect();
-    amrex::IntVect Ey_stag = warpx.m_fields.get(FieldType::Efield_fp, Direction{1}, 0)->ixType().toIntVect();
-    amrex::IntVect Ez_stag = warpx.m_fields.get(FieldType::Efield_fp, Direction{2}, 0)->ixType().toIntVect();
+    amrex::IntVect Bx_stag = warpx.m_fields.get(FieldType::B_fp, Direction{0}, 0)->ixType().toIntVect();
+    amrex::IntVect By_stag = warpx.m_fields.get(FieldType::B_fp, Direction{1}, 0)->ixType().toIntVect();
+    amrex::IntVect Bz_stag = warpx.m_fields.get(FieldType::B_fp, Direction{2}, 0)->ixType().toIntVect();
+    amrex::IntVect Ex_stag = warpx.m_fields.get(FieldType::E_fp, Direction{0}, 0)->ixType().toIntVect();
+    amrex::IntVect Ey_stag = warpx.m_fields.get(FieldType::E_fp, Direction{1}, 0)->ixType().toIntVect();
+    amrex::IntVect Ez_stag = warpx.m_fields.get(FieldType::E_fp, Direction{2}, 0)->ixType().toIntVect();
 
     // Check that the grid types are appropriate
     const bool appropriate_grids = (

--- a/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
@@ -20,7 +20,7 @@ void SemiImplicitEM::Define ( WarpX*  a_WarpX )
     m_WarpX = a_WarpX;
 
     // Define E and Eold vectors
-    m_E.Define( m_WarpX, "Efield_fp" );
+    m_E.Define( m_WarpX, "E_fp" );
     m_Eold.Define( m_E );
 
     // Parse implicit solver parameters
@@ -65,9 +65,9 @@ void SemiImplicitEM::OneStep ( amrex::Real  a_time,
     m_WarpX->SaveParticlesAtImplicitStepStart ( );
 
     // Save Eg at the start of the time step
-    m_Eold.Copy( FieldType::Efield_fp );
+    m_Eold.Copy( FieldType::E_fp );
 
-    // Advance WarpX owned Bfield_fp to t_{n+1/2}
+    // Advance WarpX owned B_fp to t_{n+1/2}
     m_WarpX->EvolveB(a_dt, DtType::Full);
     m_WarpX->ApplyMagneticFieldBCs();
 
@@ -78,7 +78,7 @@ void SemiImplicitEM::OneStep ( amrex::Real  a_time,
     m_E.Copy(m_Eold); // initial guess for Eg^{n+1/2}
     m_nlsolver->Solve( m_E, m_Eold, half_time, a_dt );
 
-    // Update WarpX owned Efield_fp to t_{n+1/2}
+    // Update WarpX owned E_fp to t_{n+1/2}
     m_WarpX->SetElectricFieldAndApplyBCs( m_E );
 
     // Advance particles from time n+1/2 to time n+1
@@ -98,7 +98,7 @@ void SemiImplicitEM::ComputeRHS ( WarpXSolverVec&  a_RHS,
                                   int              a_nl_iter,
                                   bool             a_from_jacobian )
 {
-    // Update WarpX-owned Efield_fp using current state of Eg from
+    // Update WarpX-owned E_fp using current state of Eg from
     // the nonlinear solver at time n+theta
     m_WarpX->SetElectricFieldAndApplyBCs( a_E );
 

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
@@ -37,11 +37,11 @@ void WarpXSolverVec::Define ( WarpX*  a_WarpX,
     m_vector_type_name = a_vector_type_name;
     m_scalar_type_name = a_scalar_type_name;
 
-    if (m_vector_type_name=="Efield_fp") {
-        m_array_type = FieldType::Efield_fp;
+    if (m_vector_type_name=="E_fp") {
+        m_array_type = FieldType::E_fp;
     }
-    else if (m_vector_type_name=="Bfield_fp") {
-        m_array_type = FieldType::Bfield_fp;
+    else if (m_vector_type_name=="B_fp") {
+        m_array_type = FieldType::B_fp;
     }
     else if (m_vector_type_name=="vector_potential_fp_nodal") {
         m_array_type = FieldType::vector_potential_fp;
@@ -49,7 +49,7 @@ void WarpXSolverVec::Define ( WarpX*  a_WarpX,
     else if (m_vector_type_name!="none") {
         WARPX_ABORT_WITH_MESSAGE(a_vector_type_name
                     +"is not a valid option for array type used in Definining"
-                    +"a WarpXSolverVec. Valid array types are: Efield_fp, Bfield_fp,"
+                    +"a WarpXSolverVec. Valid array types are: E_fp, B_fp,"
                     +"and vector_potential_fp_nodal");
     }
 

--- a/Source/FieldSolver/MagnetostaticSolver/MagnetostaticSolver.cpp
+++ b/Source/FieldSolver/MagnetostaticSolver/MagnetostaticSolver.cpp
@@ -179,10 +179,10 @@ WarpX::computeVectorPotential (ablastr::fields::MultiLevelVectorField const& cur
     }
 
 #if defined(AMREX_USE_EB)
-    const ablastr::fields::MultiLevelVectorField Bfield_fp = m_fields.get_mr_levels_alldirs(FieldType::Bfield_fp, finest_level);
+    const ablastr::fields::MultiLevelVectorField B_fp = m_fields.get_mr_levels_alldirs(FieldType::B_fp, finest_level);
     const std::optional<MagnetostaticSolver::EBCalcBfromVectorPotentialPerLevel> post_A_calculation(
     {
-        Bfield_fp,
+        B_fp,
         m_fields.get_mr_levels_alldirs(FieldType::vector_potential_grad_buf_e_stag, finest_level),
         m_fields.get_mr_levels_alldirs(FieldType::vector_potential_grad_buf_b_stag, finest_level)
     });

--- a/Source/FieldSolver/WarpXPushFieldsEM.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsEM.cpp
@@ -106,30 +106,30 @@ void WarpX::PSATDForwardTransformEB ()
 {
     const SpectralFieldIndex& Idx = spectral_solver_fp[0]->m_spectral_index;
 
-    const std::string Efield_fp_string = "Efield_fp";
-    const std::string Efield_cp_string = "Efield_cp";
-    const std::string Bfield_fp_string = "Bfield_fp";
-    const std::string Bfield_cp_string = "Bfield_cp";
+    const std::string E_fp_string = "E_fp";
+    const std::string E_cp_string = "E_cp";
+    const std::string B_fp_string = "B_fp";
+    const std::string B_cp_string = "B_cp";
 
     for (int lev = 0; lev <= finest_level; ++lev)
     {
-        if (m_fields.has_vector(Efield_fp_string, lev)) {
-            ablastr::fields::VectorField const E_fp =  m_fields.get_alldirs(Efield_fp_string, lev);
+        if (m_fields.has_vector(E_fp_string, lev)) {
+            ablastr::fields::VectorField const E_fp =  m_fields.get_alldirs(E_fp_string, lev);
             ForwardTransformVect(lev, *spectral_solver_fp[lev], E_fp, Idx.Ex, Idx.Ey, Idx.Ez);
         }
-        if (m_fields.has_vector(Bfield_fp_string, lev)) {
-            ablastr::fields::VectorField const B_fp =  m_fields.get_alldirs(Bfield_fp_string, lev);
+        if (m_fields.has_vector(B_fp_string, lev)) {
+            ablastr::fields::VectorField const B_fp =  m_fields.get_alldirs(B_fp_string, lev);
             ForwardTransformVect(lev, *spectral_solver_fp[lev], B_fp, Idx.Bx, Idx.By, Idx.Bz);
         }
 
         if (spectral_solver_cp[lev])
         {
-            if (m_fields.has_vector(Efield_cp_string, lev)) {
-                ablastr::fields::VectorField const E_cp =  m_fields.get_alldirs(Efield_cp_string, lev);
+            if (m_fields.has_vector(E_cp_string, lev)) {
+                ablastr::fields::VectorField const E_cp =  m_fields.get_alldirs(E_cp_string, lev);
                 ForwardTransformVect(lev, *spectral_solver_cp[lev], E_cp, Idx.Ex, Idx.Ey, Idx.Ez);
             }
-            if (m_fields.has_vector(Bfield_cp_string, lev)) {
-                ablastr::fields::VectorField const B_cp =  m_fields.get_alldirs(Bfield_cp_string, lev);
+            if (m_fields.has_vector(B_cp_string, lev)) {
+                ablastr::fields::VectorField const B_cp =  m_fields.get_alldirs(B_cp_string, lev);
                 ForwardTransformVect(lev, *spectral_solver_cp[lev], B_cp, Idx.Bx, Idx.By, Idx.Bz);
             }
         }
@@ -140,33 +140,33 @@ void WarpX::PSATDBackwardTransformEB ()
 {
     const SpectralFieldIndex& Idx = spectral_solver_fp[0]->m_spectral_index;
 
-    const std::string Efield_fp_string = "Efield_fp";
-    const std::string Efield_cp_string = "Efield_cp";
-    const std::string Bfield_fp_string = "Bfield_fp";
-    const std::string Bfield_cp_string = "Bfield_cp";
+    const std::string E_fp_string = "E_fp";
+    const std::string E_cp_string = "E_cp";
+    const std::string B_fp_string = "B_fp";
+    const std::string B_cp_string = "B_cp";
 
     for (int lev = 0; lev <= finest_level; ++lev)
     {
-        if (m_fields.has_vector(Efield_fp_string, lev)) {
-            ablastr::fields::VectorField const E_fp =  m_fields.get_alldirs(Efield_fp_string, lev);
+        if (m_fields.has_vector(E_fp_string, lev)) {
+            ablastr::fields::VectorField const E_fp =  m_fields.get_alldirs(E_fp_string, lev);
             BackwardTransformVect(lev, *spectral_solver_fp[lev], E_fp,
                                   Idx.Ex, Idx.Ey, Idx.Ez, m_fill_guards_fields);
         }
-        if (m_fields.has_vector(Bfield_fp_string, lev)) {
-            ablastr::fields::VectorField const B_fp =  m_fields.get_alldirs(Bfield_fp_string, lev);
+        if (m_fields.has_vector(B_fp_string, lev)) {
+            ablastr::fields::VectorField const B_fp =  m_fields.get_alldirs(B_fp_string, lev);
             BackwardTransformVect(lev, *spectral_solver_fp[lev], B_fp,
                                   Idx.Bx, Idx.By, Idx.Bz, m_fill_guards_fields);
         }
 
         if (spectral_solver_cp[lev])
         {
-            if (m_fields.has_vector(Efield_cp_string, lev)) {
-                ablastr::fields::VectorField const E_cp =  m_fields.get_alldirs(Efield_cp_string, lev);
+            if (m_fields.has_vector(E_cp_string, lev)) {
+                ablastr::fields::VectorField const E_cp =  m_fields.get_alldirs(E_cp_string, lev);
                 BackwardTransformVect(lev, *spectral_solver_cp[lev], E_cp,
                                       Idx.Ex, Idx.Ey, Idx.Ez, m_fill_guards_fields);
             }
-            if (m_fields.has_vector(Bfield_cp_string, lev)) {
-                ablastr::fields::VectorField const B_cp =  m_fields.get_alldirs(Bfield_cp_string, lev);
+            if (m_fields.has_vector(B_cp_string, lev)) {
+                ablastr::fields::VectorField const B_cp =  m_fields.get_alldirs(B_cp_string, lev);
                 BackwardTransformVect(lev, *spectral_solver_cp[lev], B_cp,
                                       Idx.Bx, Idx.By, Idx.Bz, m_fill_guards_fields);
             }
@@ -176,9 +176,9 @@ void WarpX::PSATDBackwardTransformEB ()
     // Damp the fields in the guard cells
     for (int lev = 0; lev <= finest_level; ++lev)
     {
-        if (m_fields.has_vector(Efield_fp_string, lev) && m_fields.has_vector(Bfield_fp_string, lev)) {
-            ablastr::fields::VectorField const E_fp =  m_fields.get_alldirs(Efield_fp_string, lev);
-            ablastr::fields::VectorField const B_fp =  m_fields.get_alldirs(Bfield_fp_string, lev);
+        if (m_fields.has_vector(E_fp_string, lev) && m_fields.has_vector(B_fp_string, lev)) {
+            ablastr::fields::VectorField const E_fp =  m_fields.get_alldirs(E_fp_string, lev);
+            ablastr::fields::VectorField const B_fp =  m_fields.get_alldirs(B_fp_string, lev);
             DampFieldsInGuards(lev, E_fp, B_fp);
         }
     }
@@ -850,11 +850,11 @@ WarpX::PushPSATD ()
     // Inverse FFT of E, B, F, and G
     PSATDBackwardTransformEB();
     if (WarpX::fft_do_time_averaging) {
-        auto Efield_avg_fp = m_fields.get_mr_levels_alldirs(FieldType::Efield_avg_fp, finest_level);
-        auto Bfield_avg_fp = m_fields.get_mr_levels_alldirs(FieldType::Bfield_avg_fp, finest_level);
-        auto Efield_avg_cp = m_fields.get_mr_levels_alldirs(FieldType::Efield_avg_cp, finest_level);
-        auto Bfield_avg_cp = m_fields.get_mr_levels_alldirs(FieldType::Bfield_avg_cp, finest_level);
-        PSATDBackwardTransformEBavg(Efield_avg_fp, Bfield_avg_fp, Efield_avg_cp, Bfield_avg_cp);
+        auto E_avg_fp = m_fields.get_mr_levels_alldirs(FieldType::E_avg_fp, finest_level);
+        auto B_avg_fp = m_fields.get_mr_levels_alldirs(FieldType::B_avg_fp, finest_level);
+        auto E_avg_cp = m_fields.get_mr_levels_alldirs(FieldType::E_avg_cp, finest_level);
+        auto B_avg_cp = m_fields.get_mr_levels_alldirs(FieldType::B_avg_cp, finest_level);
+        PSATDBackwardTransformEBavg(E_avg_fp, B_avg_fp, E_avg_cp, B_avg_cp);
     }
     if (WarpX::do_dive_cleaning) { PSATDBackwardTransformF(); }
     if (WarpX::do_divb_cleaning) { PSATDBackwardTransformG(); }
@@ -958,13 +958,13 @@ WarpX::EvolveE (int lev, PatchType patch_type, amrex::Real a_dt)
         m_fdtd_solver_fp[lev]->EvolveE( m_fields,
                                         lev,
                                         patch_type,
-                                        m_fields.get_alldirs(FieldType::Efield_fp, lev),
+                                        m_fields.get_alldirs(FieldType::E_fp, lev),
                                         a_dt );
     } else {
         m_fdtd_solver_cp[lev]->EvolveE( m_fields,
                                         lev,
                                         patch_type,
-                                        m_fields.get_alldirs(FieldType::Efield_cp, lev),
+                                        m_fields.get_alldirs(FieldType::E_cp, lev),
                                         a_dt );
     }
 
@@ -994,13 +994,13 @@ WarpX::EvolveE (int lev, PatchType patch_type, amrex::Real a_dt)
 #ifdef AMREX_USE_EB
     if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT) {
         if (patch_type == PatchType::fine) {
-            m_fdtd_solver_fp[lev]->EvolveECTRho( m_fields.get_alldirs(FieldType::Efield_fp, lev),
+            m_fdtd_solver_fp[lev]->EvolveECTRho( m_fields.get_alldirs(FieldType::E_fp, lev),
                                                  m_fields.get_alldirs(FieldType::edge_lengths, lev),
                                                  m_fields.get_alldirs(FieldType::face_areas, lev),
                                                  m_fields.get_alldirs(FieldType::ECTRhofield, lev),
                                                  lev );
         } else {
-            m_fdtd_solver_cp[lev]->EvolveECTRho( m_fields.get_alldirs(FieldType::Efield_cp, lev),
+            m_fdtd_solver_cp[lev]->EvolveECTRho( m_fields.get_alldirs(FieldType::E_cp, lev),
                                                  m_fields.get_alldirs(FieldType::edge_lengths, lev),
                                                  m_fields.get_alldirs(FieldType::face_areas, lev),
                                                  m_fields.get_alldirs(FieldType::ECTRhofield, lev),
@@ -1043,11 +1043,11 @@ WarpX::EvolveF (int lev, PatchType patch_type, amrex::Real a_dt, DtType a_dt_typ
     // Evolve F field in regular cells
     if (patch_type == PatchType::fine) {
         m_fdtd_solver_fp[lev]->EvolveF( m_fields.get(FieldType::F_fp, lev),
-                                        m_fields.get_alldirs(FieldType::Efield_fp, lev),
+                                        m_fields.get_alldirs(FieldType::E_fp, lev),
                                         m_fields.get(FieldType::rho_fp,lev), rhocomp, a_dt );
     } else {
         m_fdtd_solver_cp[lev]->EvolveF( m_fields.get(FieldType::F_cp, lev),
-                                        m_fields.get_alldirs(FieldType::Efield_cp, lev),
+                                        m_fields.get_alldirs(FieldType::E_cp, lev),
                                         m_fields.get(FieldType::rho_cp,lev), rhocomp, a_dt );
     }
 
@@ -1101,17 +1101,17 @@ WarpX::EvolveG (int lev, PatchType patch_type, amrex::Real a_dt, DtType /*a_dt_t
     // Evolve G field in regular cells
     if (patch_type == PatchType::fine)
     {
-        ablastr::fields::MultiLevelVectorField const& Bfield_fp = m_fields.get_mr_levels_alldirs(FieldType::Bfield_fp, finest_level);
+        ablastr::fields::MultiLevelVectorField const& B_fp = m_fields.get_mr_levels_alldirs(FieldType::B_fp, finest_level);
         m_fdtd_solver_fp[lev]->EvolveG(
             m_fields.get(FieldType::G_fp, lev),
-            Bfield_fp[lev], a_dt);
+            B_fp[lev], a_dt);
     }
     else // coarse patch
     {
-        ablastr::fields::MultiLevelVectorField const& Bfield_cp_new = m_fields.get_mr_levels_alldirs(FieldType::Bfield_cp, finest_level);
+        ablastr::fields::MultiLevelVectorField const& B_cp_new = m_fields.get_mr_levels_alldirs(FieldType::B_cp, finest_level);
         m_fdtd_solver_cp[lev]->EvolveG(
             m_fields.get(FieldType::G_cp, lev),
-            Bfield_cp_new[lev], a_dt);
+            B_cp_new[lev], a_dt);
     }
 
     // TODO Evolution in PML cells will go here
@@ -1147,8 +1147,8 @@ WarpX::MacroscopicEvolveE (int lev, PatchType patch_type, amrex::Real a_dt) {
     );
 
     m_fdtd_solver_fp[lev]->MacroscopicEvolveE(
-        m_fields.get_alldirs(FieldType::Efield_fp, lev),
-        m_fields.get_alldirs(FieldType::Bfield_fp, lev),
+        m_fields.get_alldirs(FieldType::E_fp, lev),
+        m_fields.get_alldirs(FieldType::B_fp, lev),
         m_fields.get_alldirs(FieldType::current_fp, lev),
         m_fields.get_alldirs(FieldType::edge_lengths, lev),
         a_dt, m_macroscopic_properties);

--- a/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
@@ -106,8 +106,8 @@ void WarpX::HybridPICEvolveFields ()
     for (int sub_step = 0; sub_step < sub_steps; sub_step++)
     {
         m_hybrid_pic_model->BfieldEvolveRK(
-            m_fields.get_mr_levels_alldirs(FieldType::Bfield_fp, finest_level),
-            m_fields.get_mr_levels_alldirs(FieldType::Efield_fp, finest_level),
+            m_fields.get_mr_levels_alldirs(FieldType::B_fp, finest_level),
+            m_fields.get_mr_levels_alldirs(FieldType::E_fp, finest_level),
             current_fp_temp, rho_fp_temp,
             m_fields.get_mr_levels_alldirs(FieldType::edge_lengths, finest_level),
             0.5_rt/sub_steps*dt[0],
@@ -132,8 +132,8 @@ void WarpX::HybridPICEvolveFields ()
     for (int sub_step = 0; sub_step < sub_steps; sub_step++)
     {
         m_hybrid_pic_model->BfieldEvolveRK(
-            m_fields.get_mr_levels_alldirs(FieldType::Bfield_fp, finest_level),
-            m_fields.get_mr_levels_alldirs(FieldType::Efield_fp, finest_level),
+            m_fields.get_mr_levels_alldirs(FieldType::B_fp, finest_level),
+            m_fields.get_mr_levels_alldirs(FieldType::E_fp, finest_level),
             m_fields.get_mr_levels_alldirs(FieldType::current_fp, finest_level),
             rho_fp_temp,
             m_fields.get_mr_levels_alldirs(FieldType::edge_lengths, finest_level),
@@ -166,12 +166,12 @@ void WarpX::HybridPICEvolveFields ()
 
     // Update the E field to t=n+1 using the extrapolated J_i^n+1 value
     m_hybrid_pic_model->CalculateCurrentAmpere(
-        m_fields.get_mr_levels_alldirs(FieldType::Bfield_fp, finest_level),
+        m_fields.get_mr_levels_alldirs(FieldType::B_fp, finest_level),
         m_fields.get_mr_levels_alldirs(FieldType::edge_lengths, finest_level));
     m_hybrid_pic_model->HybridPICSolveE(
-        m_fields.get_mr_levels_alldirs(FieldType::Efield_fp, finest_level),
+        m_fields.get_mr_levels_alldirs(FieldType::E_fp, finest_level),
         current_fp_temp,
-        m_fields.get_mr_levels_alldirs(FieldType::Bfield_fp, finest_level),
+        m_fields.get_mr_levels_alldirs(FieldType::B_fp, finest_level),
         m_fields.get_mr_levels(FieldType::rho_fp, finest_level),
         m_fields.get_mr_levels_alldirs(FieldType::edge_lengths, finest_level), false
     );

--- a/Source/FieldSolver/WarpXSolveFieldsES.cpp
+++ b/Source/FieldSolver/WarpXSolveFieldsES.cpp
@@ -24,8 +24,8 @@ void WarpX::ComputeSpaceChargeField (bool const reset_fields)
         WARPX_PROFILE("WarpX::ComputeSpaceChargeField::reset_fields");
         for (int lev = 0; lev <= max_level; lev++) {
             for (int comp=0; comp<3; comp++) {
-                m_fields.get(FieldType::Efield_fp, Direction{comp}, lev)->setVal(0);
-                m_fields.get(FieldType::Bfield_fp, Direction{comp}, lev)->setVal(0);
+                m_fields.get(FieldType::E_fp, Direction{comp}, lev)->setVal(0);
+                m_fields.get(FieldType::B_fp, Direction{comp}, lev)->setVal(0);
             }
         }
     }

--- a/Source/FieldSolver/WarpX_QED_Field_Pushers.cpp
+++ b/Source/FieldSolver/WarpX_QED_Field_Pushers.cpp
@@ -84,24 +84,24 @@ WarpX::Hybrid_QED_Push (int lev, PatchType patch_type, amrex::Real a_dt)
     MultiFab *Ex, *Ey, *Ez, *Bx, *By, *Bz, *Jx, *Jy, *Jz;
     if (patch_type == PatchType::fine)
     {
-        Ex = m_fields.get(FieldType::Efield_fp, Direction{0}, lev);
-        Ey = m_fields.get(FieldType::Efield_fp, Direction{1}, lev);
-        Ez = m_fields.get(FieldType::Efield_fp, Direction{2}, lev);
-        Bx = m_fields.get(FieldType::Bfield_fp, Direction{0}, lev);
-        By = m_fields.get(FieldType::Bfield_fp, Direction{1}, lev);
-        Bz = m_fields.get(FieldType::Bfield_fp, Direction{2}, lev);
+        Ex = m_fields.get(FieldType::E_fp, Direction{0}, lev);
+        Ey = m_fields.get(FieldType::E_fp, Direction{1}, lev);
+        Ez = m_fields.get(FieldType::E_fp, Direction{2}, lev);
+        Bx = m_fields.get(FieldType::B_fp, Direction{0}, lev);
+        By = m_fields.get(FieldType::B_fp, Direction{1}, lev);
+        Bz = m_fields.get(FieldType::B_fp, Direction{2}, lev);
         Jx = m_fields.get(FieldType::current_fp, Direction{0}, lev);
         Jy = m_fields.get(FieldType::current_fp, Direction{1}, lev);
         Jz = m_fields.get(FieldType::current_fp, Direction{2}, lev);
     }
     else
     {
-        Ex = m_fields.get(FieldType::Efield_cp, Direction{0}, lev);
-        Ey = m_fields.get(FieldType::Efield_cp, Direction{1}, lev);
-        Ez = m_fields.get(FieldType::Efield_cp, Direction{2}, lev);
-        Bx = m_fields.get(FieldType::Bfield_cp, Direction{0}, lev);
-        By = m_fields.get(FieldType::Bfield_cp, Direction{1}, lev);
-        Bz = m_fields.get(FieldType::Bfield_cp, Direction{2}, lev);
+        Ex = m_fields.get(FieldType::E_cp, Direction{0}, lev);
+        Ey = m_fields.get(FieldType::E_cp, Direction{1}, lev);
+        Ez = m_fields.get(FieldType::E_cp, Direction{2}, lev);
+        Bx = m_fields.get(FieldType::B_cp, Direction{0}, lev);
+        By = m_fields.get(FieldType::B_cp, Direction{1}, lev);
+        Bz = m_fields.get(FieldType::B_cp, Direction{2}, lev);
         Jx = m_fields.get(FieldType::current_cp, Direction{0}, lev);
         Jy = m_fields.get(FieldType::current_cp, Direction{1}, lev);
         Jz = m_fields.get(FieldType::current_cp, Direction{2}, lev);

--- a/Source/Fields.H
+++ b/Source/Fields.H
@@ -20,12 +20,12 @@ namespace warpx::fields
 {
     AMREX_ENUM(FieldType,
         None,
-        Efield_aux, //!< Field that the particles gather from. Obtained from Efield_fp (and Efield_cp when using MR); see UpdateAuxilaryData
-        Bfield_aux, //!< Field that the particles gather from. Obtained from Bfield_fp (and Bfield_cp when using MR); see UpdateAuxilaryData
-        Efield_fp,  //!< The field that is updated by the field solver at each timestep
-        Bfield_fp,  //!< The field that is updated by the field solver at each timestep
-        Efield_fp_external, //!< Stores grid particle fields provided by the user as  through an openPMD file
-        Bfield_fp_external, //!< Stores grid particle fields provided by the user as  through an openPMD file
+        E_aux, //!< Field that the particles gather from. Obtained from E_fp (and E_cp when using MR); see UpdateAuxilaryData
+        B_aux, //!< Field that the particles gather from. Obtained from B_fp (and B_cp when using MR); see UpdateAuxilaryData
+        E_fp,  //!< The field that is updated by the field solver at each timestep
+        B_fp,  //!< The field that is updated by the field solver at each timestep
+        E_fp_external, //!< Stores grid particle fields provided by the user as  through an openPMD file
+        B_fp_external, //!< Stores grid particle fields provided by the user as  through an openPMD file
         current_fp, //!< The current that is used as a source for the field solver
         current_fp_nodal, //!< Only used when using nodal current deposition
         current_fp_vay,   //!< Only used when using Vay current deposition
@@ -45,14 +45,14 @@ namespace warpx::fields
         hybrid_current_fp_temp,
         hybrid_current_fp_ampere,
         hybrid_current_fp_external,
-        Efield_cp,  //!< Only used with MR. The field that is updated by the field solver at each timestep, on the coarse patch of each level
-        Bfield_cp,  //!< Only used with MR. The field that is updated by the field solver at each timestep, on the coarse patch of each level
+        E_cp,  //!< Only used with MR. The field that is updated by the field solver at each timestep, on the coarse patch of each level
+        B_cp,  //!< Only used with MR. The field that is updated by the field solver at each timestep, on the coarse patch of each level
         current_cp, //!< Only used with MR. The current that is used as a source for the field solver, on the coarse patch of each level
         rho_cp, //!< Only used with MR. The charge density that is used as a source for the field solver, on the coarse patch of each level
         F_cp,   //!< Only used with MR. Used for divE cleaning, on the coarse patch of each level
         G_cp,   //!< Only used with MR. Used for divB cleaning, on the coarse patch of each level
-        Efield_cax, //!< Only used with MR. Particles that are close to the edge of the MR patch (i.e. in the gather buffer) gather from this field
-        Bfield_cax, //!< Only used with MR. Particles that are close to the edge of the MR patch (i.e. in the gather buffer) gather from this field
+        E_cax, //!< Only used with MR. Particles that are close to the edge of the MR patch (i.e. in the gather buffer) gather from this field
+        B_cax, //!< Only used with MR. Particles that are close to the edge of the MR patch (i.e. in the gather buffer) gather from this field
         E_external_particle_field, //!< Stores external particle fields provided by the user as  through an openPMD file
         B_external_particle_field, //!< Stores external particle fields provided by the user as  through an openPMD file
         distance_to_eb, //!< Only used with embedded boundaries (EB). Stores the distance to the nearest EB
@@ -70,10 +70,10 @@ namespace warpx::fields
         pml_F_cp,
         pml_G_cp,
         pml_edge_lengths,
-        Efield_avg_fp,
-        Bfield_avg_fp,
-        Efield_avg_cp,
-        Bfield_avg_cp,
+        E_avg_fp,
+        B_avg_fp,
+        E_avg_cp,
+        B_avg_cp,
         B_old, //!< Stores the value of B at the beginning of the timestep, for the implicit solver
         ECTRhofield,
         Venl
@@ -81,10 +81,10 @@ namespace warpx::fields
 
     /** these are vector fields */
     constexpr FieldType ArrayFieldTypes[] = {
-        FieldType::Efield_aux,
-        FieldType::Bfield_aux,
-        FieldType::Efield_fp,
-        FieldType::Bfield_fp,
+        FieldType::E_aux,
+        FieldType::B_aux,
+        FieldType::E_fp,
+        FieldType::B_fp,
         FieldType::current_fp,
         FieldType::current_fp_nodal,
         FieldType::current_fp_vay,
@@ -97,11 +97,11 @@ namespace warpx::fields
         FieldType::hybrid_current_fp_temp,
         FieldType::hybrid_current_fp_ampere,
         FieldType::hybrid_current_fp_external,
-        FieldType::Efield_cp,
-        FieldType::Bfield_cp,
+        FieldType::E_cp,
+        FieldType::B_cp,
         FieldType::current_cp,
-        FieldType::Efield_cax,
-        FieldType::Bfield_cax,
+        FieldType::E_cax,
+        FieldType::B_cax,
         FieldType::E_external_particle_field,
         FieldType::B_external_particle_field,
         FieldType::pml_E_fp,
@@ -110,10 +110,10 @@ namespace warpx::fields
         FieldType::pml_E_cp,
         FieldType::pml_B_cp,
         FieldType::pml_j_cp,
-        FieldType::Efield_avg_fp,
-        FieldType::Bfield_avg_fp,
-        FieldType::Efield_avg_cp,
-        FieldType::Bfield_avg_cp,
+        FieldType::E_avg_fp,
+        FieldType::B_avg_fp,
+        FieldType::E_avg_cp,
+        FieldType::B_avg_cp,
         FieldType::B_old,
         FieldType::ECTRhofield,
         FieldType::Venl

--- a/Source/Fluids/WarpXFluidContainer.cpp
+++ b/Source/Fluids/WarpXFluidContainer.cpp
@@ -274,12 +274,12 @@ void WarpXFluidContainer::Evolve(
     // Step the Lorentz Term
     if(!do_not_gather){
         GatherAndPush(fields,
-                    *fields.get(FieldType::Efield_aux, Direction{0}, lev),
-                    *fields.get(FieldType::Efield_aux, Direction{1}, lev),
-                    *fields.get(FieldType::Efield_aux, Direction{2}, lev),
-                    *fields.get(FieldType::Bfield_aux, Direction{0}, lev),
-                    *fields.get(FieldType::Bfield_aux, Direction{1}, lev),
-                    *fields.get(FieldType::Bfield_aux, Direction{2}, lev),
+                    *fields.get(FieldType::E_aux, Direction{0}, lev),
+                    *fields.get(FieldType::E_aux, Direction{1}, lev),
+                    *fields.get(FieldType::E_aux, Direction{2}, lev),
+                    *fields.get(FieldType::B_aux, Direction{0}, lev),
+                    *fields.get(FieldType::B_aux, Direction{1}, lev),
+                    *fields.get(FieldType::B_aux, Direction{2}, lev),
                     cur_time, lev);
     }
 

--- a/Source/Initialization/DivCleaner/ProjectionDivCleaner.cpp
+++ b/Source/Initialization/DivCleaner/ProjectionDivCleaner.cpp
@@ -344,7 +344,7 @@ WarpX::ProjectionCleanDivB() {
                 ablastr::warn_manager::WarnPriority::low);
         }
 
-        warpx::initialization::ProjectionDivCleaner dc("Bfield_fp_external");
+        warpx::initialization::ProjectionDivCleaner dc("B_fp_external");
 
 
         dc.setSourceFromBfield();

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -558,9 +558,9 @@ WarpX::InitData ()
         const int lev_zero = 0;
         m_macroscopic_properties->InitData(
             Geom(lev_zero),
-            m_fields.get(FieldType::Efield_fp, Direction{0}, lev_zero)->ixType().toIntVect(),
-            m_fields.get(FieldType::Efield_fp, Direction{1}, lev_zero)->ixType().toIntVect(),
-            m_fields.get(FieldType::Efield_fp, Direction{2}, lev_zero)->ixType().toIntVect()
+            m_fields.get(FieldType::E_fp, Direction{0}, lev_zero)->ixType().toIntVect(),
+            m_fields.get(FieldType::E_fp, Direction{1}, lev_zero)->ixType().toIntVect(),
+            m_fields.get(FieldType::E_fp, Direction{2}, lev_zero)->ixType().toIntVect()
         );
     }
 
@@ -639,29 +639,29 @@ WarpX::AddExternalFields (int const lev)
 
     // FIXME: RZ multimode has more than one component for all these
     if (m_p_ext_field_params->E_ext_grid_type != ExternalFieldType::default_zero) {
-        ablastr::fields::MultiLevelVectorField Efield_fp = m_fields.get_mr_levels_alldirs(FieldType::Efield_fp, max_level);
+        ablastr::fields::MultiLevelVectorField E_fp = m_fields.get_mr_levels_alldirs(FieldType::E_fp, max_level);
         if (m_p_ext_field_params->E_ext_grid_type == ExternalFieldType::constant) {
-            Efield_fp[lev][0]->plus(m_p_ext_field_params->E_external_grid[0], guard_cells.ng_alloc_EB.min());
-            Efield_fp[lev][1]->plus(m_p_ext_field_params->E_external_grid[1], guard_cells.ng_alloc_EB.min());
-            Efield_fp[lev][2]->plus(m_p_ext_field_params->E_external_grid[2], guard_cells.ng_alloc_EB.min());
+            E_fp[lev][0]->plus(m_p_ext_field_params->E_external_grid[0], guard_cells.ng_alloc_EB.min());
+            E_fp[lev][1]->plus(m_p_ext_field_params->E_external_grid[1], guard_cells.ng_alloc_EB.min());
+            E_fp[lev][2]->plus(m_p_ext_field_params->E_external_grid[2], guard_cells.ng_alloc_EB.min());
         }
         else {
-            amrex::MultiFab::Add(*Efield_fp[lev][0], *m_fields.get(FieldType::Efield_fp_external, Direction{0}, lev), 0, 0, 1, guard_cells.ng_alloc_EB);
-            amrex::MultiFab::Add(*Efield_fp[lev][1], *m_fields.get(FieldType::Efield_fp_external, Direction{1}, lev), 0, 0, 1, guard_cells.ng_alloc_EB);
-            amrex::MultiFab::Add(*Efield_fp[lev][2], *m_fields.get(FieldType::Efield_fp_external, Direction{2}, lev), 0, 0, 1, guard_cells.ng_alloc_EB);
+            amrex::MultiFab::Add(*E_fp[lev][0], *m_fields.get(FieldType::E_fp_external, Direction{0}, lev), 0, 0, 1, guard_cells.ng_alloc_EB);
+            amrex::MultiFab::Add(*E_fp[lev][1], *m_fields.get(FieldType::E_fp_external, Direction{1}, lev), 0, 0, 1, guard_cells.ng_alloc_EB);
+            amrex::MultiFab::Add(*E_fp[lev][2], *m_fields.get(FieldType::E_fp_external, Direction{2}, lev), 0, 0, 1, guard_cells.ng_alloc_EB);
         }
     }
     if (m_p_ext_field_params->B_ext_grid_type != ExternalFieldType::default_zero) {
-        ablastr::fields::MultiLevelVectorField const& Bfield_fp = m_fields.get_mr_levels_alldirs(FieldType::Bfield_fp, max_level);
+        ablastr::fields::MultiLevelVectorField const& B_fp = m_fields.get_mr_levels_alldirs(FieldType::B_fp, max_level);
         if (m_p_ext_field_params->B_ext_grid_type == ExternalFieldType::constant) {
-            Bfield_fp[lev][0]->plus(m_p_ext_field_params->B_external_grid[0], guard_cells.ng_alloc_EB.min());
-            Bfield_fp[lev][1]->plus(m_p_ext_field_params->B_external_grid[1], guard_cells.ng_alloc_EB.min());
-            Bfield_fp[lev][2]->plus(m_p_ext_field_params->B_external_grid[2], guard_cells.ng_alloc_EB.min());
+            B_fp[lev][0]->plus(m_p_ext_field_params->B_external_grid[0], guard_cells.ng_alloc_EB.min());
+            B_fp[lev][1]->plus(m_p_ext_field_params->B_external_grid[1], guard_cells.ng_alloc_EB.min());
+            B_fp[lev][2]->plus(m_p_ext_field_params->B_external_grid[2], guard_cells.ng_alloc_EB.min());
         }
         else {
-            amrex::MultiFab::Add(*Bfield_fp[lev][0], *m_fields.get(FieldType::Bfield_fp_external, Direction{0}, lev), 0, 0, 1, guard_cells.ng_alloc_EB);
-            amrex::MultiFab::Add(*Bfield_fp[lev][1], *m_fields.get(FieldType::Bfield_fp_external, Direction{1}, lev), 0, 0, 1, guard_cells.ng_alloc_EB);
-            amrex::MultiFab::Add(*Bfield_fp[lev][2], *m_fields.get(FieldType::Bfield_fp_external, Direction{2}, lev), 0, 0, 1, guard_cells.ng_alloc_EB);
+            amrex::MultiFab::Add(*B_fp[lev][0], *m_fields.get(FieldType::B_fp_external, Direction{0}, lev), 0, 0, 1, guard_cells.ng_alloc_EB);
+            amrex::MultiFab::Add(*B_fp[lev][1], *m_fields.get(FieldType::B_fp_external, Direction{1}, lev), 0, 0, 1, guard_cells.ng_alloc_EB);
+            amrex::MultiFab::Add(*B_fp[lev][2], *m_fields.get(FieldType::B_fp_external, Direction{2}, lev), 0, 0, 1, guard_cells.ng_alloc_EB);
         }
     }
 }
@@ -928,14 +928,14 @@ WarpX::InitLevelData (int lev, Real /*time*/)
         if ( is_B_ext_const && (lev <= maxlevel_extEMfield_init) )
         {
             if (fft_do_time_averaging) {
-                m_fields.get(FieldType::Bfield_avg_fp, Direction{i}, lev)->setVal(m_p_ext_field_params->B_external_grid[i]);
+                m_fields.get(FieldType::B_avg_fp, Direction{i}, lev)->setVal(m_p_ext_field_params->B_external_grid[i]);
             }
 
            if (lev > 0) {
-                m_fields.get(FieldType::Bfield_aux, Direction{i}, lev)->setVal(m_p_ext_field_params->B_external_grid[i]);
-                m_fields.get(FieldType::Bfield_cp, Direction{i}, lev)->setVal(m_p_ext_field_params->B_external_grid[i]);
+                m_fields.get(FieldType::B_aux, Direction{i}, lev)->setVal(m_p_ext_field_params->B_external_grid[i]);
+                m_fields.get(FieldType::B_cp, Direction{i}, lev)->setVal(m_p_ext_field_params->B_external_grid[i]);
                 if (fft_do_time_averaging) {
-                    m_fields.get(FieldType::Bfield_avg_cp, Direction{i}, lev)->setVal(m_p_ext_field_params->B_external_grid[i]);
+                    m_fields.get(FieldType::B_avg_cp, Direction{i}, lev)->setVal(m_p_ext_field_params->B_external_grid[i]);
                 }
            }
         }
@@ -948,13 +948,13 @@ WarpX::InitLevelData (int lev, Real /*time*/)
         if ( is_E_ext_const && (lev <= maxlevel_extEMfield_init) )
         {
             if (fft_do_time_averaging) {
-                m_fields.get(FieldType::Efield_avg_fp, Direction{i}, lev)->setVal(m_p_ext_field_params->E_external_grid[i]);
+                m_fields.get(FieldType::E_avg_fp, Direction{i}, lev)->setVal(m_p_ext_field_params->E_external_grid[i]);
             }
             if (lev > 0) {
-                m_fields.get(FieldType::Efield_aux, Direction{i}, lev)->setVal(m_p_ext_field_params->E_external_grid[i]);
-                m_fields.get(FieldType::Efield_cp, Direction{i}, lev)->setVal(m_p_ext_field_params->E_external_grid[i]);
+                m_fields.get(FieldType::E_aux, Direction{i}, lev)->setVal(m_p_ext_field_params->E_external_grid[i]);
+                m_fields.get(FieldType::E_cp, Direction{i}, lev)->setVal(m_p_ext_field_params->E_external_grid[i]);
                 if (fft_do_time_averaging) {
-                    m_fields.get(FieldType::Efield_avg_cp, Direction{i}, lev)->setVal(m_p_ext_field_params->E_external_grid[i]);
+                    m_fields.get(FieldType::E_avg_cp, Direction{i}, lev)->setVal(m_p_ext_field_params->E_external_grid[i]);
                 }
             }
         }
@@ -974,9 +974,9 @@ WarpX::InitLevelData (int lev, Real /*time*/)
          && (lev > 0) && (lev <= maxlevel_extEMfield_init)) {
 
         InitializeExternalFieldsOnGridUsingParser(
-            m_fields.get(FieldType::Bfield_aux, Direction{0}, lev),
-            m_fields.get(FieldType::Bfield_aux, Direction{1}, lev),
-            m_fields.get(FieldType::Bfield_aux, Direction{2}, lev),
+            m_fields.get(FieldType::B_aux, Direction{0}, lev),
+            m_fields.get(FieldType::B_aux, Direction{1}, lev),
+            m_fields.get(FieldType::B_aux, Direction{2}, lev),
             m_p_ext_field_params->Bxfield_parser->compile<3>(),
             m_p_ext_field_params->Byfield_parser->compile<3>(),
             m_p_ext_field_params->Bzfield_parser->compile<3>(),
@@ -986,9 +986,9 @@ WarpX::InitLevelData (int lev, Real /*time*/)
             lev, PatchType::fine);
 
         InitializeExternalFieldsOnGridUsingParser(
-            m_fields.get(FieldType::Bfield_cp, Direction{0}, lev),
-            m_fields.get(FieldType::Bfield_cp, Direction{1}, lev),
-            m_fields.get(FieldType::Bfield_cp, Direction{2}, lev),
+            m_fields.get(FieldType::B_cp, Direction{0}, lev),
+            m_fields.get(FieldType::B_cp, Direction{1}, lev),
+            m_fields.get(FieldType::B_cp, Direction{2}, lev),
             m_p_ext_field_params->Bxfield_parser->compile<3>(),
             m_p_ext_field_params->Byfield_parser->compile<3>(),
             m_p_ext_field_params->Bzfield_parser->compile<3>(),
@@ -1011,7 +1011,7 @@ WarpX::InitLevelData (int lev, Real /*time*/)
             // We initialize ECTRhofield consistently with the Efield
             if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT) {
                 m_fdtd_solver_fp[lev]->EvolveECTRho(
-                    m_fields.get_alldirs(FieldType::Efield_fp, lev),
+                    m_fields.get_alldirs(FieldType::E_fp, lev),
                     m_fields.get_alldirs(FieldType::edge_lengths, lev),
                     m_fields.get_mr_levels_alldirs(FieldType::face_areas, max_level)[lev],
                     m_fields.get_alldirs(FieldType::ECTRhofield, lev),
@@ -1022,9 +1022,9 @@ WarpX::InitLevelData (int lev, Real /*time*/)
 
         if (lev > 0) {
             InitializeExternalFieldsOnGridUsingParser(
-                m_fields.get(FieldType::Efield_aux, Direction{0}, lev),
-                m_fields.get(FieldType::Efield_aux, Direction{1}, lev),
-                m_fields.get(FieldType::Efield_aux, Direction{2}, lev),
+                m_fields.get(FieldType::E_aux, Direction{0}, lev),
+                m_fields.get(FieldType::E_aux, Direction{1}, lev),
+                m_fields.get(FieldType::E_aux, Direction{2}, lev),
                 m_p_ext_field_params->Exfield_parser->compile<3>(),
                 m_p_ext_field_params->Eyfield_parser->compile<3>(),
                 m_p_ext_field_params->Ezfield_parser->compile<3>(),
@@ -1034,9 +1034,9 @@ WarpX::InitLevelData (int lev, Real /*time*/)
                 lev, PatchType::fine);
 
             InitializeExternalFieldsOnGridUsingParser(
-                m_fields.get(FieldType::Efield_cp, Direction{0}, lev),
-                m_fields.get(FieldType::Efield_cp, Direction{1}, lev),
-                m_fields.get(FieldType::Efield_cp, Direction{2}, lev),
+                m_fields.get(FieldType::E_cp, Direction{0}, lev),
+                m_fields.get(FieldType::E_cp, Direction{1}, lev),
+                m_fields.get(FieldType::E_cp, Direction{2}, lev),
                 m_p_ext_field_params->Exfield_parser->compile<3>(),
                 m_p_ext_field_params->Eyfield_parser->compile<3>(),
                 m_p_ext_field_params->Ezfield_parser->compile<3>(),
@@ -1049,7 +1049,7 @@ WarpX::InitLevelData (int lev, Real /*time*/)
                 if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT) {
                     // We initialize ECTRhofield consistently with the Efield
                     m_fdtd_solver_cp[lev]->EvolveECTRho(
-                        m_fields.get_alldirs(FieldType::Efield_cp, lev),
+                        m_fields.get_alldirs(FieldType::E_cp, lev),
                         m_fields.get_alldirs(FieldType::edge_lengths, lev),
                         m_fields.get_mr_levels_alldirs(FieldType::face_areas, max_level)[lev],
                         m_fields.get_alldirs(FieldType::ECTRhofield, lev),
@@ -1060,7 +1060,7 @@ WarpX::InitLevelData (int lev, Real /*time*/)
        }
     }
 
-    // load external grid fields into E/Bfield_fp_external multifabs
+    // load external grid fields into E/B_fp_external multifabs
     LoadExternalFields(lev);
 
     if (costs[lev]) {
@@ -1239,14 +1239,14 @@ void WarpX::CheckGuardCells()
     {
         for (int dim = 0; dim < 3; ++dim)
         {
-            ::CheckGuardCells(m_fields, "Efield_fp[" + std::to_string(dim) + "]", lev);
-            ::CheckGuardCells(m_fields, "Bfield_fp[" + std::to_string(dim) + "]", lev);
+            ::CheckGuardCells(m_fields, "E_fp[" + std::to_string(dim) + "]", lev);
+            ::CheckGuardCells(m_fields, "B_fp[" + std::to_string(dim) + "]", lev);
             ::CheckGuardCells(m_fields, "current_fp[" + std::to_string(dim) + "]", lev);
 
             if (WarpX::fft_do_time_averaging)
             {
-                ::CheckGuardCells(m_fields, "Efield_avg_fp[" + std::to_string(dim) + "]", lev);
-                ::CheckGuardCells(m_fields, "Bfield_avg_fp[" + std::to_string(dim) + "]", lev);
+                ::CheckGuardCells(m_fields, "E_avg_fp[" + std::to_string(dim) + "]", lev);
+                ::CheckGuardCells(m_fields, "B_avg_fp[" + std::to_string(dim) + "]", lev);
             }
         }
 
@@ -1259,14 +1259,14 @@ void WarpX::CheckGuardCells()
         {
             for (int dim = 0; dim < 3; ++dim)
             {
-                ::CheckGuardCells(m_fields, "Efield_cp[" + std::to_string(dim) + "]", lev);
-                ::CheckGuardCells(m_fields, "Bfield_cp[" + std::to_string(dim) + "]", lev);
+                ::CheckGuardCells(m_fields, "E_cp[" + std::to_string(dim) + "]", lev);
+                ::CheckGuardCells(m_fields, "B_cp[" + std::to_string(dim) + "]", lev);
                 ::CheckGuardCells(m_fields, "current_cp[" + std::to_string(dim) + "]", lev);
 
                 if (WarpX::fft_do_time_averaging)
                 {
-                    ::CheckGuardCells(m_fields, "Efield_avg_cp[" + std::to_string(dim) + "]", lev);
-                    ::CheckGuardCells(m_fields, "Bfield_avg_cp[" + std::to_string(dim) + "]", lev);
+                    ::CheckGuardCells(m_fields, "E_avg_cp[" + std::to_string(dim) + "]", lev);
+                    ::CheckGuardCells(m_fields, "B_avg_cp[" + std::to_string(dim) + "]", lev);
                 }
             }
 
@@ -1385,11 +1385,11 @@ WarpX::LoadExternalFields (int const lev)
 
     // External grid fields
     if (m_p_ext_field_params->B_ext_grid_type == ExternalFieldType::parse_ext_grid_function) {
-        // Initialize Bfield_fp_external with external function
+        // Initialize B_fp_external with external function
         InitializeExternalFieldsOnGridUsingParser(
-            m_fields.get(FieldType::Bfield_fp_external, Direction{0}, lev),
-            m_fields.get(FieldType::Bfield_fp_external, Direction{1}, lev),
-            m_fields.get(FieldType::Bfield_fp_external, Direction{2}, lev),
+            m_fields.get(FieldType::B_fp_external, Direction{0}, lev),
+            m_fields.get(FieldType::B_fp_external, Direction{1}, lev),
+            m_fields.get(FieldType::B_fp_external, Direction{2}, lev),
             m_p_ext_field_params->Bxfield_parser->compile<3>(),
             m_p_ext_field_params->Byfield_parser->compile<3>(),
             m_p_ext_field_params->Bzfield_parser->compile<3>(),
@@ -1402,22 +1402,22 @@ WarpX::LoadExternalFields (int const lev)
 #if defined(WARPX_DIM_RZ)
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(n_rz_azimuthal_modes == 1,
                                          "External field reading is not implemented for more than one RZ mode (see #3829)");
-        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::Bfield_fp_external,Direction{0},lev), "B", "r");
-        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::Bfield_fp_external,Direction{1},lev), "B", "t");
-        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::Bfield_fp_external,Direction{2},lev), "B", "z");
+        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::B_fp_external,Direction{0},lev), "B", "r");
+        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::B_fp_external,Direction{1},lev), "B", "t");
+        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::B_fp_external,Direction{2},lev), "B", "z");
 #else
-        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::Bfield_fp_external, Direction{0}, lev), "B", "x");
-        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::Bfield_fp_external, Direction{1}, lev), "B", "y");
-        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::Bfield_fp_external, Direction{2}, lev), "B", "z");
+        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::B_fp_external, Direction{0}, lev), "B", "x");
+        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::B_fp_external, Direction{1}, lev), "B", "y");
+        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::B_fp_external, Direction{2}, lev), "B", "z");
 #endif
     }
 
     if (m_p_ext_field_params->E_ext_grid_type == ExternalFieldType::parse_ext_grid_function) {
-        // Initialize Efield_fp_external with external function
+        // Initialize E_fp_external with external function
         InitializeExternalFieldsOnGridUsingParser(
-            m_fields.get(FieldType::Efield_fp_external, Direction{0}, lev),
-            m_fields.get(FieldType::Efield_fp_external, Direction{1}, lev),
-            m_fields.get(FieldType::Efield_fp_external, Direction{2}, lev),
+            m_fields.get(FieldType::E_fp_external, Direction{0}, lev),
+            m_fields.get(FieldType::E_fp_external, Direction{1}, lev),
+            m_fields.get(FieldType::E_fp_external, Direction{2}, lev),
             m_p_ext_field_params->Exfield_parser->compile<3>(),
             m_p_ext_field_params->Eyfield_parser->compile<3>(),
             m_p_ext_field_params->Ezfield_parser->compile<3>(),
@@ -1430,13 +1430,13 @@ WarpX::LoadExternalFields (int const lev)
 #if defined(WARPX_DIM_RZ)
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(n_rz_azimuthal_modes == 1,
                                          "External field reading is not implemented for more than one RZ mode (see #3829)");
-        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::Efield_fp_external,Direction{0},lev), "E", "r");
-        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::Efield_fp_external,Direction{1},lev), "E", "t");
-        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::Efield_fp_external,Direction{2},lev), "E", "z");
+        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::E_fp_external,Direction{0},lev), "E", "r");
+        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::E_fp_external,Direction{1},lev), "E", "t");
+        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::E_fp_external,Direction{2},lev), "E", "z");
 #else
-        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::Efield_fp_external, Direction{0}, lev), "E", "x");
-        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::Efield_fp_external, Direction{1}, lev), "E", "y");
-        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::Efield_fp_external, Direction{2}, lev), "E", "z");
+        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::E_fp_external, Direction{0}, lev), "E", "x");
+        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::E_fp_external, Direction{1}, lev), "E", "y");
+        ReadExternalFieldFromFile(m_p_ext_field_params->external_fields_path, m_fields.get(FieldType::E_fp_external, Direction{2}, lev), "E", "z");
 #endif
     }
 

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -60,11 +60,11 @@ WarpX::UpdateAuxilaryData ()
 
     using ablastr::fields::Direction;
 
-    amrex::MultiFab *Bfield_aux_lvl0_0 = m_fields.get(FieldType::Bfield_aux, Direction{0}, 0);
+    amrex::MultiFab *B_aux_lvl0_0 = m_fields.get(FieldType::B_aux, Direction{0}, 0);
 
-    ablastr::fields::MultiLevelVectorField const& Bfield_fp = m_fields.get_mr_levels_alldirs(FieldType::Bfield_fp, finest_level);
+    ablastr::fields::MultiLevelVectorField const& B_fp = m_fields.get_mr_levels_alldirs(FieldType::B_fp, finest_level);
 
-    if (Bfield_aux_lvl0_0->ixType() == Bfield_fp[0][0]->ixType()) {
+    if (B_aux_lvl0_0->ixType() == B_fp[0][0]->ixType()) {
         UpdateAuxilaryDataSameType();
     } else {
         UpdateAuxilaryDataStagToNodal();
@@ -73,18 +73,18 @@ WarpX::UpdateAuxilaryData ()
     // When loading particle fields from file: add the external fields:
     for (int lev = 0; lev <= finest_level; ++lev) {
         if (mypc->m_E_ext_particle_s == "read_from_file") {
-            ablastr::fields::VectorField Efield_aux = m_fields.get_alldirs(FieldType::Efield_aux, lev);
+            ablastr::fields::VectorField E_aux = m_fields.get_alldirs(FieldType::E_aux, lev);
             const auto& E_ext_lev = m_fields.get_alldirs(FieldType::E_external_particle_field, lev);
-            amrex::MultiFab::Add(*Efield_aux[0], *E_ext_lev[0], 0, 0, E_ext_lev[0]->nComp(), guard_cells.ng_FieldGather);
-            amrex::MultiFab::Add(*Efield_aux[1], *E_ext_lev[1], 0, 0, E_ext_lev[1]->nComp(), guard_cells.ng_FieldGather);
-            amrex::MultiFab::Add(*Efield_aux[2], *E_ext_lev[2], 0, 0, E_ext_lev[2]->nComp(), guard_cells.ng_FieldGather);
+            amrex::MultiFab::Add(*E_aux[0], *E_ext_lev[0], 0, 0, E_ext_lev[0]->nComp(), guard_cells.ng_FieldGather);
+            amrex::MultiFab::Add(*E_aux[1], *E_ext_lev[1], 0, 0, E_ext_lev[1]->nComp(), guard_cells.ng_FieldGather);
+            amrex::MultiFab::Add(*E_aux[2], *E_ext_lev[2], 0, 0, E_ext_lev[2]->nComp(), guard_cells.ng_FieldGather);
         }
         if (mypc->m_B_ext_particle_s == "read_from_file") {
-            ablastr::fields::VectorField Bfield_aux = m_fields.get_alldirs(FieldType::Bfield_aux, lev);
+            ablastr::fields::VectorField B_aux = m_fields.get_alldirs(FieldType::B_aux, lev);
             const auto& B_ext_lev = m_fields.get_alldirs(FieldType::B_external_particle_field, lev);
-            amrex::MultiFab::Add(*Bfield_aux[0], *B_ext_lev[0], 0, 0, B_ext_lev[0]->nComp(), guard_cells.ng_FieldGather);
-            amrex::MultiFab::Add(*Bfield_aux[1], *B_ext_lev[1], 0, 0, B_ext_lev[1]->nComp(), guard_cells.ng_FieldGather);
-            amrex::MultiFab::Add(*Bfield_aux[2], *B_ext_lev[2], 0, 0, B_ext_lev[2]->nComp(), guard_cells.ng_FieldGather);
+            amrex::MultiFab::Add(*B_aux[0], *B_ext_lev[0], 0, 0, B_ext_lev[0]->nComp(), guard_cells.ng_FieldGather);
+            amrex::MultiFab::Add(*B_aux[1], *B_ext_lev[1], 0, 0, B_ext_lev[1]->nComp(), guard_cells.ng_FieldGather);
+            amrex::MultiFab::Add(*B_aux[2], *B_ext_lev[2], 0, 0, B_ext_lev[2]->nComp(), guard_cells.ng_FieldGather);
         }
     }
 
@@ -102,19 +102,19 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
 #endif
     using ablastr::fields::Direction;
 
-    ablastr::fields::MultiLevelVectorField const& Bfield_fp = m_fields.get_mr_levels_alldirs(FieldType::Bfield_fp, finest_level);
-    ablastr::fields::MultiLevelVectorField const& Efield_fp = m_fields.get_mr_levels_alldirs(FieldType::Efield_fp, finest_level);
-    ablastr::fields::MultiLevelVectorField const& Efield_aux = m_fields.get_mr_levels_alldirs(FieldType::Efield_aux, finest_level);
-    ablastr::fields::MultiLevelVectorField const& Bfield_aux = m_fields.get_mr_levels_alldirs(FieldType::Bfield_aux, finest_level);
+    ablastr::fields::MultiLevelVectorField const& B_fp = m_fields.get_mr_levels_alldirs(FieldType::B_fp, finest_level);
+    ablastr::fields::MultiLevelVectorField const& E_fp = m_fields.get_mr_levels_alldirs(FieldType::E_fp, finest_level);
+    ablastr::fields::MultiLevelVectorField const& E_aux = m_fields.get_mr_levels_alldirs(FieldType::E_aux, finest_level);
+    ablastr::fields::MultiLevelVectorField const& B_aux = m_fields.get_mr_levels_alldirs(FieldType::B_aux, finest_level);
 
     ablastr::fields::MultiLevelVectorField const & Bmf =
         WarpX::fft_do_time_averaging ?
-        m_fields.get_mr_levels_alldirs(FieldType::Bfield_avg_fp, finest_level) :
-        Bfield_fp;
+        m_fields.get_mr_levels_alldirs(FieldType::B_avg_fp, finest_level) :
+        B_fp;
     ablastr::fields::MultiLevelVectorField const & Emf =
         WarpX::fft_do_time_averaging ?
-        m_fields.get_mr_levels_alldirs(FieldType::Efield_avg_fp, finest_level) :
-        Efield_fp;
+        m_fields.get_mr_levels_alldirs(FieldType::E_avg_fp, finest_level) :
+        E_fp;
 
     const amrex::IntVect& Bx_stag = Bmf[0][0]->ixType().toIntVect();
     const amrex::IntVect& By_stag = Bmf[0][1]->ixType().toIntVect();
@@ -131,18 +131,18 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-    for (MFIter mfi(*Bfield_aux[0][0], TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    for (MFIter mfi(*B_aux[0][0], TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
-        Array4<Real> const& bx_aux = Bfield_aux[0][0]->array(mfi);
-        Array4<Real> const& by_aux = Bfield_aux[0][1]->array(mfi);
-        Array4<Real> const& bz_aux = Bfield_aux[0][2]->array(mfi);
+        Array4<Real> const& bx_aux = B_aux[0][0]->array(mfi);
+        Array4<Real> const& by_aux = B_aux[0][1]->array(mfi);
+        Array4<Real> const& bz_aux = B_aux[0][2]->array(mfi);
         Array4<Real const> const& bx_fp = Bmf[0][0]->const_array(mfi);
         Array4<Real const> const& by_fp = Bmf[0][1]->const_array(mfi);
         Array4<Real const> const& bz_fp = Bmf[0][2]->const_array(mfi);
 
-        Array4<Real> const& ex_aux = Efield_aux[0][0]->array(mfi);
-        Array4<Real> const& ey_aux = Efield_aux[0][1]->array(mfi);
-        Array4<Real> const& ez_aux = Efield_aux[0][2]->array(mfi);
+        Array4<Real> const& ex_aux = E_aux[0][0]->array(mfi);
+        Array4<Real> const& ey_aux = E_aux[0][1]->array(mfi);
+        Array4<Real> const& ez_aux = E_aux[0][2]->array(mfi);
         Array4<Real const> const& ex_fp = Emf[0][0]->const_array(mfi);
         Array4<Real const> const& ey_fp = Emf[0][1]->const_array(mfi);
         Array4<Real const> const& ez_fp = Emf[0][2]->const_array(mfi);
@@ -187,22 +187,22 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
     // NOTE: high-order interpolation is not implemented for mesh refinement
     for (int lev = 1; lev <= finest_level; ++lev)
     {
-        BoxArray const& nba = Bfield_aux[lev][0]->boxArray();
+        BoxArray const& nba = B_aux[lev][0]->boxArray();
         BoxArray const& cnba = amrex::coarsen(nba,2);
-        DistributionMapping const& dm = Bfield_aux[lev][0]->DistributionMap();
+        DistributionMapping const& dm = B_aux[lev][0]->DistributionMap();
         amrex::Periodicity const& cperiod = Geom(lev-1).periodicity();
 
         // Bfield
         {
             if (electromagnetic_solver_id != ElectromagneticSolverAlgo::None) {
                 Array<std::unique_ptr<MultiFab>,3> Btmp;
-                if (m_fields.has(FieldType::Bfield_cax, Direction{0}, lev)) {
+                if (m_fields.has(FieldType::B_cax, Direction{0}, lev)) {
                     for (int i = 0; i < 3; ++i) {
                         Btmp[i] = std::make_unique<MultiFab>(
-                            *m_fields.get(FieldType::Bfield_cax, Direction{i}, lev), amrex::make_alias, 0, 1);
+                            *m_fields.get(FieldType::B_cax, Direction{i}, lev), amrex::make_alias, 0, 1);
                     }
                 } else {
-                    const IntVect ngtmp = Bfield_aux[lev-1][0]->nGrowVect();
+                    const IntVect ngtmp = B_aux[lev-1][0]->nGrowVect();
                     for (int i = 0; i < 3; ++i) {
                         Btmp[i] = std::make_unique<MultiFab>(cnba, dm, 1, ngtmp);
                     }
@@ -215,36 +215,36 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
                     const IntVect ng = Btmp[i]->nGrowVect();
                     // Guard cells may not be up to date beyond ng_FieldGather
                     const amrex::IntVect& ng_src = guard_cells.ng_FieldGather;
-                    // Copy Bfield_aux to Btmp, using up to ng_src (=ng_FieldGather) guard cells from
-                    // Bfield_aux and filling up to ng (=nGrow) guard cells in Btmp
-                    ablastr::utils::communication::ParallelCopy(*Btmp[i], *Bfield_aux[lev - 1][i], 0, 0, 1,
+                    // Copy B_aux to Btmp, using up to ng_src (=ng_FieldGather) guard cells from
+                    // B_aux and filling up to ng (=nGrow) guard cells in Btmp
+                    ablastr::utils::communication::ParallelCopy(*Btmp[i], *B_aux[lev - 1][i], 0, 0, 1,
                                                                 ng_src, ng, WarpX::do_single_precision_comms, cperiod);
                 }
 
                 const amrex::IntVect& refinement_ratio = refRatio(lev-1);
 
-                const amrex::IntVect& Bx_fp_stag = m_fields.get(FieldType::Bfield_fp, Direction{0}, lev)->ixType().toIntVect();
-                const amrex::IntVect& By_fp_stag = m_fields.get(FieldType::Bfield_fp, Direction{1}, lev)->ixType().toIntVect();
-                const amrex::IntVect& Bz_fp_stag = m_fields.get(FieldType::Bfield_fp, Direction{2}, lev)->ixType().toIntVect();
+                const amrex::IntVect& Bx_fp_stag = m_fields.get(FieldType::B_fp, Direction{0}, lev)->ixType().toIntVect();
+                const amrex::IntVect& By_fp_stag = m_fields.get(FieldType::B_fp, Direction{1}, lev)->ixType().toIntVect();
+                const amrex::IntVect& Bz_fp_stag = m_fields.get(FieldType::B_fp, Direction{2}, lev)->ixType().toIntVect();
 
-                const amrex::IntVect& Bx_cp_stag = m_fields.get(FieldType::Bfield_cp, Direction{0}, lev)->ixType().toIntVect();
-                const amrex::IntVect& By_cp_stag = m_fields.get(FieldType::Bfield_cp, Direction{1}, lev)->ixType().toIntVect();
-                const amrex::IntVect& Bz_cp_stag = m_fields.get(FieldType::Bfield_cp, Direction{2}, lev)->ixType().toIntVect();
+                const amrex::IntVect& Bx_cp_stag = m_fields.get(FieldType::B_cp, Direction{0}, lev)->ixType().toIntVect();
+                const amrex::IntVect& By_cp_stag = m_fields.get(FieldType::B_cp, Direction{1}, lev)->ixType().toIntVect();
+                const amrex::IntVect& Bz_cp_stag = m_fields.get(FieldType::B_cp, Direction{2}, lev)->ixType().toIntVect();
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-                for (MFIter mfi(*Bfield_aux[lev][0], TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                for (MFIter mfi(*B_aux[lev][0], TilingIfNotGPU()); mfi.isValid(); ++mfi)
                 {
-                    Array4<Real> const& bx_aux = Bfield_aux[lev][0]->array(mfi);
-                    Array4<Real> const& by_aux = Bfield_aux[lev][1]->array(mfi);
-                    Array4<Real> const& bz_aux = Bfield_aux[lev][2]->array(mfi);
-                    Array4<Real const> const& bx_fp = m_fields.get(FieldType::Bfield_fp, Direction{0}, lev)->const_array(mfi);
-                    Array4<Real const> const& by_fp = m_fields.get(FieldType::Bfield_fp, Direction{1}, lev)->const_array(mfi);
-                    Array4<Real const> const& bz_fp = m_fields.get(FieldType::Bfield_fp, Direction{2}, lev)->const_array(mfi);
-                    Array4<Real const> const& bx_cp = m_fields.get(FieldType::Bfield_cp, Direction{0}, lev)->const_array(mfi);
-                    Array4<Real const> const& by_cp = m_fields.get(FieldType::Bfield_cp, Direction{1}, lev)->const_array(mfi);
-                    Array4<Real const> const& bz_cp = m_fields.get(FieldType::Bfield_cp, Direction{2}, lev)->const_array(mfi);
+                    Array4<Real> const& bx_aux = B_aux[lev][0]->array(mfi);
+                    Array4<Real> const& by_aux = B_aux[lev][1]->array(mfi);
+                    Array4<Real> const& bz_aux = B_aux[lev][2]->array(mfi);
+                    Array4<Real const> const& bx_fp = m_fields.get(FieldType::B_fp, Direction{0}, lev)->const_array(mfi);
+                    Array4<Real const> const& by_fp = m_fields.get(FieldType::B_fp, Direction{1}, lev)->const_array(mfi);
+                    Array4<Real const> const& bz_fp = m_fields.get(FieldType::B_fp, Direction{2}, lev)->const_array(mfi);
+                    Array4<Real const> const& bx_cp = m_fields.get(FieldType::B_cp, Direction{0}, lev)->const_array(mfi);
+                    Array4<Real const> const& by_cp = m_fields.get(FieldType::B_cp, Direction{1}, lev)->const_array(mfi);
+                    Array4<Real const> const& bz_cp = m_fields.get(FieldType::B_cp, Direction{2}, lev)->const_array(mfi);
                     Array4<Real const> const& bx_c = Btmp[0]->const_array(mfi);
                     Array4<Real const> const& by_c = Btmp[1]->const_array(mfi);
                     Array4<Real const> const& bz_c = Btmp[2]->const_array(mfi);
@@ -260,20 +260,20 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
                 }
             }
             else { // electrostatic
-                const amrex::IntVect& Bx_fp_stag = Bfield_fp[lev][0]->ixType().toIntVect();
-                const amrex::IntVect& By_fp_stag = Bfield_fp[lev][1]->ixType().toIntVect();
-                const amrex::IntVect& Bz_fp_stag = Bfield_fp[lev][2]->ixType().toIntVect();
+                const amrex::IntVect& Bx_fp_stag = B_fp[lev][0]->ixType().toIntVect();
+                const amrex::IntVect& By_fp_stag = B_fp[lev][1]->ixType().toIntVect();
+                const amrex::IntVect& Bz_fp_stag = B_fp[lev][2]->ixType().toIntVect();
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-                for (MFIter mfi(*Bfield_aux[lev][0], TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                for (MFIter mfi(*B_aux[lev][0], TilingIfNotGPU()); mfi.isValid(); ++mfi)
                 {
-                    Array4<Real> const& bx_aux = Bfield_aux[lev][0]->array(mfi);
-                    Array4<Real> const& by_aux = Bfield_aux[lev][1]->array(mfi);
-                    Array4<Real> const& bz_aux = Bfield_aux[lev][2]->array(mfi);
-                    Array4<Real const> const& bx_fp = Bfield_fp[lev][0]->const_array(mfi);
-                    Array4<Real const> const& by_fp = Bfield_fp[lev][1]->const_array(mfi);
-                    Array4<Real const> const& bz_fp = Bfield_fp[lev][2]->const_array(mfi);
+                    Array4<Real> const& bx_aux = B_aux[lev][0]->array(mfi);
+                    Array4<Real> const& by_aux = B_aux[lev][1]->array(mfi);
+                    Array4<Real> const& bz_aux = B_aux[lev][2]->array(mfi);
+                    Array4<Real const> const& bx_fp = B_fp[lev][0]->const_array(mfi);
+                    Array4<Real const> const& by_fp = B_fp[lev][1]->const_array(mfi);
+                    Array4<Real const> const& bz_fp = B_fp[lev][2]->const_array(mfi);
 
                     const Box& bx = mfi.growntilebox();
                     amrex::ParallelFor(bx,
@@ -290,13 +290,13 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
         {
             if (electromagnetic_solver_id != ElectromagneticSolverAlgo::None) {
                 Array<std::unique_ptr<MultiFab>,3> Etmp;
-                if (m_fields.has(FieldType::Efield_cax, Direction{0}, lev)) {
+                if (m_fields.has(FieldType::E_cax, Direction{0}, lev)) {
                     for (int i = 0; i < 3; ++i) {
                         Etmp[i] = std::make_unique<MultiFab>(
-                            *m_fields.get(FieldType::Efield_cax, Direction{i}, lev), amrex::make_alias, 0, 1);
+                            *m_fields.get(FieldType::E_cax, Direction{i}, lev), amrex::make_alias, 0, 1);
                     }
                 } else {
-                    const IntVect ngtmp = Efield_aux[lev-1][0]->nGrowVect();
+                    const IntVect ngtmp = E_aux[lev-1][0]->nGrowVect();
                     for (int i = 0; i < 3; ++i) {
                         Etmp[i] = std::make_unique<MultiFab>(
                             cnba, dm, 1, ngtmp);
@@ -310,36 +310,36 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
                     const IntVect ng = Etmp[i]->nGrowVect();
                     // Guard cells may not be up to date beyond ng_FieldGather
                     const amrex::IntVect& ng_src = guard_cells.ng_FieldGather;
-                    // Copy Efield_aux to Etmp, using up to ng_src (=ng_FieldGather) guard cells from
-                    // Efield_aux and filling up to ng (=nGrow) guard cells in Etmp
-                    ablastr::utils::communication::ParallelCopy(*Etmp[i], *Efield_aux[lev - 1][i], 0, 0, 1,
+                    // Copy E_aux to Etmp, using up to ng_src (=ng_FieldGather) guard cells from
+                    // E_aux and filling up to ng (=nGrow) guard cells in Etmp
+                    ablastr::utils::communication::ParallelCopy(*Etmp[i], *E_aux[lev - 1][i], 0, 0, 1,
                                                                 ng_src, ng, WarpX::do_single_precision_comms, cperiod);
                 }
 
                 const amrex::IntVect& refinement_ratio = refRatio(lev-1);
 
-                const amrex::IntVect& Ex_fp_stag = m_fields.get(FieldType::Efield_fp, Direction{0}, lev)->ixType().toIntVect();
-                const amrex::IntVect& Ey_fp_stag = m_fields.get(FieldType::Efield_fp, Direction{1}, lev)->ixType().toIntVect();
-                const amrex::IntVect& Ez_fp_stag = m_fields.get(FieldType::Efield_fp, Direction{2}, lev)->ixType().toIntVect();
+                const amrex::IntVect& Ex_fp_stag = m_fields.get(FieldType::E_fp, Direction{0}, lev)->ixType().toIntVect();
+                const amrex::IntVect& Ey_fp_stag = m_fields.get(FieldType::E_fp, Direction{1}, lev)->ixType().toIntVect();
+                const amrex::IntVect& Ez_fp_stag = m_fields.get(FieldType::E_fp, Direction{2}, lev)->ixType().toIntVect();
 
-                const amrex::IntVect& Ex_cp_stag = m_fields.get(FieldType::Efield_cp, Direction{0}, lev)->ixType().toIntVect();
-                const amrex::IntVect& Ey_cp_stag = m_fields.get(FieldType::Efield_cp, Direction{1}, lev)->ixType().toIntVect();
-                const amrex::IntVect& Ez_cp_stag = m_fields.get(FieldType::Efield_cp, Direction{2}, lev)->ixType().toIntVect();
+                const amrex::IntVect& Ex_cp_stag = m_fields.get(FieldType::E_cp, Direction{0}, lev)->ixType().toIntVect();
+                const amrex::IntVect& Ey_cp_stag = m_fields.get(FieldType::E_cp, Direction{1}, lev)->ixType().toIntVect();
+                const amrex::IntVect& Ez_cp_stag = m_fields.get(FieldType::E_cp, Direction{2}, lev)->ixType().toIntVect();
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-                for (MFIter mfi(*Efield_aux[lev][0], TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                for (MFIter mfi(*E_aux[lev][0], TilingIfNotGPU()); mfi.isValid(); ++mfi)
                 {
-                    Array4<Real> const& ex_aux = Efield_aux[lev][0]->array(mfi);
-                    Array4<Real> const& ey_aux = Efield_aux[lev][1]->array(mfi);
-                    Array4<Real> const& ez_aux = Efield_aux[lev][2]->array(mfi);
-                    Array4<Real const> const& ex_fp = m_fields.get(FieldType::Efield_fp, Direction{0}, lev)->const_array(mfi);
-                    Array4<Real const> const& ey_fp = m_fields.get(FieldType::Efield_fp, Direction{1}, lev)->const_array(mfi);
-                    Array4<Real const> const& ez_fp = m_fields.get(FieldType::Efield_fp, Direction{2}, lev)->const_array(mfi);
-                    Array4<Real const> const& ex_cp = m_fields.get(FieldType::Efield_cp, Direction{0}, lev)->const_array(mfi);
-                    Array4<Real const> const& ey_cp = m_fields.get(FieldType::Efield_cp, Direction{1}, lev)->const_array(mfi);
-                    Array4<Real const> const& ez_cp = m_fields.get(FieldType::Efield_cp, Direction{2}, lev)->const_array(mfi);
+                    Array4<Real> const& ex_aux = E_aux[lev][0]->array(mfi);
+                    Array4<Real> const& ey_aux = E_aux[lev][1]->array(mfi);
+                    Array4<Real> const& ez_aux = E_aux[lev][2]->array(mfi);
+                    Array4<Real const> const& ex_fp = m_fields.get(FieldType::E_fp, Direction{0}, lev)->const_array(mfi);
+                    Array4<Real const> const& ey_fp = m_fields.get(FieldType::E_fp, Direction{1}, lev)->const_array(mfi);
+                    Array4<Real const> const& ez_fp = m_fields.get(FieldType::E_fp, Direction{2}, lev)->const_array(mfi);
+                    Array4<Real const> const& ex_cp = m_fields.get(FieldType::E_cp, Direction{0}, lev)->const_array(mfi);
+                    Array4<Real const> const& ey_cp = m_fields.get(FieldType::E_cp, Direction{1}, lev)->const_array(mfi);
+                    Array4<Real const> const& ez_cp = m_fields.get(FieldType::E_cp, Direction{2}, lev)->const_array(mfi);
                     Array4<Real const> const& ex_c = Etmp[0]->const_array(mfi);
                     Array4<Real const> const& ey_c = Etmp[1]->const_array(mfi);
                     Array4<Real const> const& ez_c = Etmp[2]->const_array(mfi);
@@ -355,20 +355,20 @@ WarpX::UpdateAuxilaryDataStagToNodal ()
                 }
             }
             else { // electrostatic
-                const amrex::IntVect& Ex_fp_stag = m_fields.get(FieldType::Efield_fp, Direction{0}, lev)->ixType().toIntVect();
-                const amrex::IntVect& Ey_fp_stag = m_fields.get(FieldType::Efield_fp, Direction{1}, lev)->ixType().toIntVect();
-                const amrex::IntVect& Ez_fp_stag = m_fields.get(FieldType::Efield_fp, Direction{2}, lev)->ixType().toIntVect();
+                const amrex::IntVect& Ex_fp_stag = m_fields.get(FieldType::E_fp, Direction{0}, lev)->ixType().toIntVect();
+                const amrex::IntVect& Ey_fp_stag = m_fields.get(FieldType::E_fp, Direction{1}, lev)->ixType().toIntVect();
+                const amrex::IntVect& Ez_fp_stag = m_fields.get(FieldType::E_fp, Direction{2}, lev)->ixType().toIntVect();
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-                for (MFIter mfi(*Efield_aux[lev][0], TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                for (MFIter mfi(*E_aux[lev][0], TilingIfNotGPU()); mfi.isValid(); ++mfi)
                 {
-                    Array4<Real> const& ex_aux = Efield_aux[lev][0]->array(mfi);
-                    Array4<Real> const& ey_aux = Efield_aux[lev][1]->array(mfi);
-                    Array4<Real> const& ez_aux = Efield_aux[lev][2]->array(mfi);
-                    Array4<Real const> const& ex_fp = m_fields.get(FieldType::Efield_fp, Direction{0}, lev)->const_array(mfi);
-                    Array4<Real const> const& ey_fp = m_fields.get(FieldType::Efield_fp, Direction{1}, lev)->const_array(mfi);
-                    Array4<Real const> const& ez_fp = m_fields.get(FieldType::Efield_fp, Direction{2}, lev)->const_array(mfi);
+                    Array4<Real> const& ex_aux = E_aux[lev][0]->array(mfi);
+                    Array4<Real> const& ey_aux = E_aux[lev][1]->array(mfi);
+                    Array4<Real> const& ez_aux = E_aux[lev][2]->array(mfi);
+                    Array4<Real const> const& ex_fp = m_fields.get(FieldType::E_fp, Direction{0}, lev)->const_array(mfi);
+                    Array4<Real const> const& ey_fp = m_fields.get(FieldType::E_fp, Direction{1}, lev)->const_array(mfi);
+                    Array4<Real const> const& ez_fp = m_fields.get(FieldType::E_fp, Direction{2}, lev)->const_array(mfi);
 
                     const Box& bx = mfi.growntilebox();
                     amrex::ParallelFor(bx,
@@ -391,95 +391,95 @@ WarpX::UpdateAuxilaryDataSameType ()
     const amrex::IntVect& ng_src = guard_cells.ng_FieldGather;
 
     using ablastr::fields::Direction;
-    ablastr::fields::MultiLevelVectorField Efield_fp = m_fields.get_mr_levels_alldirs(FieldType::Efield_fp, finest_level);
-    ablastr::fields::MultiLevelVectorField Bfield_fp = m_fields.get_mr_levels_alldirs(FieldType::Bfield_fp, finest_level);
-    ablastr::fields::MultiLevelVectorField Efield_aux = m_fields.get_mr_levels_alldirs(FieldType::Efield_aux, finest_level);
-    ablastr::fields::MultiLevelVectorField Bfield_aux = m_fields.get_mr_levels_alldirs(FieldType::Bfield_aux, finest_level);
+    ablastr::fields::MultiLevelVectorField E_fp = m_fields.get_mr_levels_alldirs(FieldType::E_fp, finest_level);
+    ablastr::fields::MultiLevelVectorField B_fp = m_fields.get_mr_levels_alldirs(FieldType::B_fp, finest_level);
+    ablastr::fields::MultiLevelVectorField E_aux = m_fields.get_mr_levels_alldirs(FieldType::E_aux, finest_level);
+    ablastr::fields::MultiLevelVectorField B_aux = m_fields.get_mr_levels_alldirs(FieldType::B_aux, finest_level);
 
     // Level 0: Copy from fine to aux
-    // Note: in some configurations, Efield_aux/Bfield_aux and Efield_fp/Bfield_fp are simply aliases to the
+    // Note: in some configurations, E_aux/B_aux and E_fp/B_fp are simply aliases to the
     // same MultiFab object. MultiFab::Copy operation automatically detects this and does nothing in this case.
     if (WarpX::fft_do_time_averaging)
     {
-        MultiFab::Copy(*Efield_aux[0][0], *m_fields.get(FieldType::Efield_avg_fp, Direction{0}, 0), 0, 0, Efield_aux[0][0]->nComp(), ng_src);
-        MultiFab::Copy(*Efield_aux[0][1], *m_fields.get(FieldType::Efield_avg_fp, Direction{1}, 0), 0, 0, Efield_aux[0][1]->nComp(), ng_src);
-        MultiFab::Copy(*Efield_aux[0][2], *m_fields.get(FieldType::Efield_avg_fp, Direction{2}, 0), 0, 0, Efield_aux[0][2]->nComp(), ng_src);
-        MultiFab::Copy(*Bfield_aux[0][0], *m_fields.get(FieldType::Bfield_avg_fp, Direction{0}, 0), 0, 0, Bfield_aux[0][0]->nComp(), ng_src);
-        MultiFab::Copy(*Bfield_aux[0][1], *m_fields.get(FieldType::Bfield_avg_fp, Direction{1}, 0), 0, 0, Bfield_aux[0][1]->nComp(), ng_src);
-        MultiFab::Copy(*Bfield_aux[0][2], *m_fields.get(FieldType::Bfield_avg_fp, Direction{2}, 0), 0, 0, Bfield_aux[0][2]->nComp(), ng_src);
+        MultiFab::Copy(*E_aux[0][0], *m_fields.get(FieldType::E_avg_fp, Direction{0}, 0), 0, 0, E_aux[0][0]->nComp(), ng_src);
+        MultiFab::Copy(*E_aux[0][1], *m_fields.get(FieldType::E_avg_fp, Direction{1}, 0), 0, 0, E_aux[0][1]->nComp(), ng_src);
+        MultiFab::Copy(*E_aux[0][2], *m_fields.get(FieldType::E_avg_fp, Direction{2}, 0), 0, 0, E_aux[0][2]->nComp(), ng_src);
+        MultiFab::Copy(*B_aux[0][0], *m_fields.get(FieldType::B_avg_fp, Direction{0}, 0), 0, 0, B_aux[0][0]->nComp(), ng_src);
+        MultiFab::Copy(*B_aux[0][1], *m_fields.get(FieldType::B_avg_fp, Direction{1}, 0), 0, 0, B_aux[0][1]->nComp(), ng_src);
+        MultiFab::Copy(*B_aux[0][2], *m_fields.get(FieldType::B_avg_fp, Direction{2}, 0), 0, 0, B_aux[0][2]->nComp(), ng_src);
     }
     else
     {
-        MultiFab::Copy(*Efield_aux[0][0], *Efield_fp[0][0], 0, 0, Efield_aux[0][0]->nComp(), ng_src);
-        MultiFab::Copy(*Efield_aux[0][1], *Efield_fp[0][1], 0, 0, Efield_aux[0][1]->nComp(), ng_src);
-        MultiFab::Copy(*Efield_aux[0][2], *Efield_fp[0][2], 0, 0, Efield_aux[0][2]->nComp(), ng_src);
-        MultiFab::Copy(*Bfield_aux[0][0], *Bfield_fp[0][0], 0, 0, Bfield_aux[0][0]->nComp(), ng_src);
-        MultiFab::Copy(*Bfield_aux[0][1], *Bfield_fp[0][1], 0, 0, Bfield_aux[0][1]->nComp(), ng_src);
-        MultiFab::Copy(*Bfield_aux[0][2], *Bfield_fp[0][2], 0, 0, Bfield_aux[0][2]->nComp(), ng_src);
+        MultiFab::Copy(*E_aux[0][0], *E_fp[0][0], 0, 0, E_aux[0][0]->nComp(), ng_src);
+        MultiFab::Copy(*E_aux[0][1], *E_fp[0][1], 0, 0, E_aux[0][1]->nComp(), ng_src);
+        MultiFab::Copy(*E_aux[0][2], *E_fp[0][2], 0, 0, E_aux[0][2]->nComp(), ng_src);
+        MultiFab::Copy(*B_aux[0][0], *B_fp[0][0], 0, 0, B_aux[0][0]->nComp(), ng_src);
+        MultiFab::Copy(*B_aux[0][1], *B_fp[0][1], 0, 0, B_aux[0][1]->nComp(), ng_src);
+        MultiFab::Copy(*B_aux[0][2], *B_fp[0][2], 0, 0, B_aux[0][2]->nComp(), ng_src);
     }
     for (int lev = 1; lev <= finest_level; ++lev)
     {
         const amrex::Periodicity& crse_period = Geom(lev-1).periodicity();
-        const IntVect& ng = m_fields.get(FieldType::Bfield_cp, Direction{0}, lev)->nGrowVect();
-        const DistributionMapping& dm = m_fields.get(FieldType::Bfield_cp, Direction{0}, lev)->DistributionMap();
+        const IntVect& ng = m_fields.get(FieldType::B_cp, Direction{0}, lev)->nGrowVect();
+        const DistributionMapping& dm = m_fields.get(FieldType::B_cp, Direction{0}, lev)->DistributionMap();
 
         // B field
         {
             if (electromagnetic_solver_id != ElectromagneticSolverAlgo::None)
             {
-                MultiFab dBx(m_fields.get(FieldType::Bfield_cp, Direction{0}, lev)->boxArray(), dm,
-                             m_fields.get(FieldType::Bfield_cp, Direction{0}, lev)->nComp(), ng);
-                MultiFab dBy(m_fields.get(FieldType::Bfield_cp, Direction{1}, lev)->boxArray(), dm,
-                             m_fields.get(FieldType::Bfield_cp, Direction{1}, lev)->nComp(), ng);
-                MultiFab dBz(m_fields.get(FieldType::Bfield_cp, Direction{2}, lev)->boxArray(), dm,
-                             m_fields.get(FieldType::Bfield_cp, Direction{2}, lev)->nComp(), ng);
+                MultiFab dBx(m_fields.get(FieldType::B_cp, Direction{0}, lev)->boxArray(), dm,
+                             m_fields.get(FieldType::B_cp, Direction{0}, lev)->nComp(), ng);
+                MultiFab dBy(m_fields.get(FieldType::B_cp, Direction{1}, lev)->boxArray(), dm,
+                             m_fields.get(FieldType::B_cp, Direction{1}, lev)->nComp(), ng);
+                MultiFab dBz(m_fields.get(FieldType::B_cp, Direction{2}, lev)->boxArray(), dm,
+                             m_fields.get(FieldType::B_cp, Direction{2}, lev)->nComp(), ng);
                 dBx.setVal(0.0);
                 dBy.setVal(0.0);
                 dBz.setVal(0.0);
 
-                // Copy Bfield_aux to the dB MultiFabs, using up to ng_src (=ng_FieldGather) guard
-                // cells from Bfield_aux and filling up to ng (=nGrow) guard cells in the dB MultiFabs
+                // Copy B_aux to the dB MultiFabs, using up to ng_src (=ng_FieldGather) guard
+                // cells from B_aux and filling up to ng (=nGrow) guard cells in the dB MultiFabs
 
-                ablastr::utils::communication::ParallelCopy(dBx, *Bfield_aux[lev - 1][0], 0, 0,
-                                                            Bfield_aux[lev - 1][0]->nComp(), ng_src, ng, WarpX::do_single_precision_comms,
+                ablastr::utils::communication::ParallelCopy(dBx, *B_aux[lev - 1][0], 0, 0,
+                                                            B_aux[lev - 1][0]->nComp(), ng_src, ng, WarpX::do_single_precision_comms,
                                                             crse_period);
-                ablastr::utils::communication::ParallelCopy(dBy, *Bfield_aux[lev - 1][1], 0, 0,
-                                                            Bfield_aux[lev - 1][1]->nComp(), ng_src, ng, WarpX::do_single_precision_comms,
+                ablastr::utils::communication::ParallelCopy(dBy, *B_aux[lev - 1][1], 0, 0,
+                                                            B_aux[lev - 1][1]->nComp(), ng_src, ng, WarpX::do_single_precision_comms,
                                                             crse_period);
-                ablastr::utils::communication::ParallelCopy(dBz, *Bfield_aux[lev - 1][2], 0, 0,
-                                                            Bfield_aux[lev - 1][2]->nComp(), ng_src, ng, WarpX::do_single_precision_comms,
+                ablastr::utils::communication::ParallelCopy(dBz, *B_aux[lev - 1][2], 0, 0,
+                                                            B_aux[lev - 1][2]->nComp(), ng_src, ng, WarpX::do_single_precision_comms,
                                                             crse_period);
 
-                if (m_fields.has(FieldType::Bfield_cax, Direction{0}, lev))
+                if (m_fields.has(FieldType::B_cax, Direction{0}, lev))
                 {
-                    MultiFab::Copy(*m_fields.get(FieldType::Bfield_cax, Direction{0}, lev), dBx, 0, 0, m_fields.get(FieldType::Bfield_cax, Direction{0}, lev)->nComp(), ng);
-                    MultiFab::Copy(*m_fields.get(FieldType::Bfield_cax, Direction{1}, lev), dBy, 0, 0, m_fields.get(FieldType::Bfield_cax, Direction{1}, lev)->nComp(), ng);
-                    MultiFab::Copy(*m_fields.get(FieldType::Bfield_cax, Direction{2}, lev), dBz, 0, 0, m_fields.get(FieldType::Bfield_cax, Direction{2}, lev)->nComp(), ng);
+                    MultiFab::Copy(*m_fields.get(FieldType::B_cax, Direction{0}, lev), dBx, 0, 0, m_fields.get(FieldType::B_cax, Direction{0}, lev)->nComp(), ng);
+                    MultiFab::Copy(*m_fields.get(FieldType::B_cax, Direction{1}, lev), dBy, 0, 0, m_fields.get(FieldType::B_cax, Direction{1}, lev)->nComp(), ng);
+                    MultiFab::Copy(*m_fields.get(FieldType::B_cax, Direction{2}, lev), dBz, 0, 0, m_fields.get(FieldType::B_cax, Direction{2}, lev)->nComp(), ng);
                 }
-                MultiFab::Subtract(dBx, *m_fields.get(FieldType::Bfield_cp, Direction{0}, lev),
-                                   0, 0, m_fields.get(FieldType::Bfield_cp, Direction{0}, lev)->nComp(), ng);
-                MultiFab::Subtract(dBy, *m_fields.get(FieldType::Bfield_cp, Direction{1}, lev),
-                                   0, 0, m_fields.get(FieldType::Bfield_cp, Direction{1}, lev)->nComp(), ng);
-                MultiFab::Subtract(dBz, *m_fields.get(FieldType::Bfield_cp, Direction{2}, lev),
-                                   0, 0, m_fields.get(FieldType::Bfield_cp, Direction{2}, lev)->nComp(), ng);
+                MultiFab::Subtract(dBx, *m_fields.get(FieldType::B_cp, Direction{0}, lev),
+                                   0, 0, m_fields.get(FieldType::B_cp, Direction{0}, lev)->nComp(), ng);
+                MultiFab::Subtract(dBy, *m_fields.get(FieldType::B_cp, Direction{1}, lev),
+                                   0, 0, m_fields.get(FieldType::B_cp, Direction{1}, lev)->nComp(), ng);
+                MultiFab::Subtract(dBz, *m_fields.get(FieldType::B_cp, Direction{2}, lev),
+                                   0, 0, m_fields.get(FieldType::B_cp, Direction{2}, lev)->nComp(), ng);
 
                 const amrex::IntVect& refinement_ratio = refRatio(lev-1);
 
-                const amrex::IntVect& Bx_stag = Bfield_aux[lev-1][0]->ixType().toIntVect();
-                const amrex::IntVect& By_stag = Bfield_aux[lev-1][1]->ixType().toIntVect();
-                const amrex::IntVect& Bz_stag = Bfield_aux[lev-1][2]->ixType().toIntVect();
+                const amrex::IntVect& Bx_stag = B_aux[lev-1][0]->ixType().toIntVect();
+                const amrex::IntVect& By_stag = B_aux[lev-1][1]->ixType().toIntVect();
+                const amrex::IntVect& Bz_stag = B_aux[lev-1][2]->ixType().toIntVect();
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-                for (MFIter mfi(*Bfield_aux[lev][0]); mfi.isValid(); ++mfi)
+                for (MFIter mfi(*B_aux[lev][0]); mfi.isValid(); ++mfi)
                 {
-                    Array4<Real> const& bx_aux = Bfield_aux[lev][0]->array(mfi);
-                    Array4<Real> const& by_aux = Bfield_aux[lev][1]->array(mfi);
-                    Array4<Real> const& bz_aux = Bfield_aux[lev][2]->array(mfi);
-                    Array4<Real const> const& bx_fp = Bfield_fp[lev][0]->const_array(mfi);
-                    Array4<Real const> const& by_fp = Bfield_fp[lev][1]->const_array(mfi);
-                    Array4<Real const> const& bz_fp = Bfield_fp[lev][2]->const_array(mfi);
+                    Array4<Real> const& bx_aux = B_aux[lev][0]->array(mfi);
+                    Array4<Real> const& by_aux = B_aux[lev][1]->array(mfi);
+                    Array4<Real> const& bz_aux = B_aux[lev][2]->array(mfi);
+                    Array4<Real const> const& bx_fp = B_fp[lev][0]->const_array(mfi);
+                    Array4<Real const> const& by_fp = B_fp[lev][1]->const_array(mfi);
+                    Array4<Real const> const& bz_fp = B_fp[lev][2]->const_array(mfi);
                     Array4<Real const> const& bx_c = dBx.const_array(mfi);
                     Array4<Real const> const& by_c = dBy.const_array(mfi);
                     Array4<Real const> const& bz_c = dBz.const_array(mfi);
@@ -501,70 +501,70 @@ WarpX::UpdateAuxilaryDataSameType ()
             }
             else // electrostatic
             {
-                MultiFab::Copy(*Bfield_aux[lev][0], *Bfield_fp[lev][0], 0, 0, Bfield_aux[lev][0]->nComp(), Bfield_aux[lev][0]->nGrowVect());
-                MultiFab::Copy(*Bfield_aux[lev][1], *Bfield_fp[lev][1], 0, 0, Bfield_aux[lev][1]->nComp(), Bfield_aux[lev][1]->nGrowVect());
-                MultiFab::Copy(*Bfield_aux[lev][2], *Bfield_fp[lev][2], 0, 0, Bfield_aux[lev][2]->nComp(), Bfield_aux[lev][2]->nGrowVect());
+                MultiFab::Copy(*B_aux[lev][0], *B_fp[lev][0], 0, 0, B_aux[lev][0]->nComp(), B_aux[lev][0]->nGrowVect());
+                MultiFab::Copy(*B_aux[lev][1], *B_fp[lev][1], 0, 0, B_aux[lev][1]->nComp(), B_aux[lev][1]->nGrowVect());
+                MultiFab::Copy(*B_aux[lev][2], *B_fp[lev][2], 0, 0, B_aux[lev][2]->nComp(), B_aux[lev][2]->nGrowVect());
             }
         }
         // E field
         {
             if (electromagnetic_solver_id != ElectromagneticSolverAlgo::None)
             {
-                MultiFab dEx(m_fields.get(FieldType::Efield_cp, Direction{0}, lev)->boxArray(), dm,
-                             m_fields.get(FieldType::Efield_cp, Direction{0}, lev)->nComp(), ng);
-                MultiFab dEy(m_fields.get(FieldType::Efield_cp, Direction{1}, lev)->boxArray(), dm,
-                             m_fields.get(FieldType::Efield_cp, Direction{1}, lev)->nComp(), ng);
-                MultiFab dEz(m_fields.get(FieldType::Efield_cp, Direction{2}, lev)->boxArray(), dm,
-                             m_fields.get(FieldType::Efield_cp, Direction{2}, lev)->nComp(), ng);
+                MultiFab dEx(m_fields.get(FieldType::E_cp, Direction{0}, lev)->boxArray(), dm,
+                             m_fields.get(FieldType::E_cp, Direction{0}, lev)->nComp(), ng);
+                MultiFab dEy(m_fields.get(FieldType::E_cp, Direction{1}, lev)->boxArray(), dm,
+                             m_fields.get(FieldType::E_cp, Direction{1}, lev)->nComp(), ng);
+                MultiFab dEz(m_fields.get(FieldType::E_cp, Direction{2}, lev)->boxArray(), dm,
+                             m_fields.get(FieldType::E_cp, Direction{2}, lev)->nComp(), ng);
                 dEx.setVal(0.0);
                 dEy.setVal(0.0);
                 dEz.setVal(0.0);
 
-                // Copy Efield_aux to the dE MultiFabs, using up to ng_src (=ng_FieldGather) guard
-                // cells from Efield_aux and filling up to ng (=nGrow) guard cells in the dE MultiFabs
-                ablastr::utils::communication::ParallelCopy(dEx, *Efield_aux[lev - 1][0], 0, 0,
-                                                            Efield_aux[lev - 1][0]->nComp(), ng_src, ng,
+                // Copy E_aux to the dE MultiFabs, using up to ng_src (=ng_FieldGather) guard
+                // cells from E_aux and filling up to ng (=nGrow) guard cells in the dE MultiFabs
+                ablastr::utils::communication::ParallelCopy(dEx, *E_aux[lev - 1][0], 0, 0,
+                                                            E_aux[lev - 1][0]->nComp(), ng_src, ng,
                                                             WarpX::do_single_precision_comms,
                                                             crse_period);
-                ablastr::utils::communication::ParallelCopy(dEy, *Efield_aux[lev - 1][1], 0, 0,
-                                                            Efield_aux[lev - 1][1]->nComp(), ng_src, ng,
+                ablastr::utils::communication::ParallelCopy(dEy, *E_aux[lev - 1][1], 0, 0,
+                                                            E_aux[lev - 1][1]->nComp(), ng_src, ng,
                                                             WarpX::do_single_precision_comms,
                                                             crse_period);
-                ablastr::utils::communication::ParallelCopy(dEz, *Efield_aux[lev - 1][2], 0, 0,
-                                                            Efield_aux[lev - 1][2]->nComp(), ng_src, ng,
+                ablastr::utils::communication::ParallelCopy(dEz, *E_aux[lev - 1][2], 0, 0,
+                                                            E_aux[lev - 1][2]->nComp(), ng_src, ng,
                                                             WarpX::do_single_precision_comms,
                                                             crse_period);
 
-                if (m_fields.has(FieldType::Efield_cax, Direction{0}, lev))
+                if (m_fields.has(FieldType::E_cax, Direction{0}, lev))
                 {
-                    MultiFab::Copy(*m_fields.get(FieldType::Efield_cax, Direction{0}, lev), dEx, 0, 0, m_fields.get(FieldType::Efield_cax, Direction{0}, lev)->nComp(), ng);
-                    MultiFab::Copy(*m_fields.get(FieldType::Efield_cax, Direction{1}, lev), dEy, 0, 0, m_fields.get(FieldType::Efield_cax, Direction{1}, lev)->nComp(), ng);
-                    MultiFab::Copy(*m_fields.get(FieldType::Efield_cax, Direction{2}, lev), dEz, 0, 0, m_fields.get(FieldType::Efield_cax, Direction{2}, lev)->nComp(), ng);
+                    MultiFab::Copy(*m_fields.get(FieldType::E_cax, Direction{0}, lev), dEx, 0, 0, m_fields.get(FieldType::E_cax, Direction{0}, lev)->nComp(), ng);
+                    MultiFab::Copy(*m_fields.get(FieldType::E_cax, Direction{1}, lev), dEy, 0, 0, m_fields.get(FieldType::E_cax, Direction{1}, lev)->nComp(), ng);
+                    MultiFab::Copy(*m_fields.get(FieldType::E_cax, Direction{2}, lev), dEz, 0, 0, m_fields.get(FieldType::E_cax, Direction{2}, lev)->nComp(), ng);
                 }
-                MultiFab::Subtract(dEx, *m_fields.get(FieldType::Efield_cp, Direction{0}, lev),
-                                   0, 0, m_fields.get(FieldType::Efield_cp, Direction{0}, lev)->nComp(), ng);
-                MultiFab::Subtract(dEy, *m_fields.get(FieldType::Efield_cp, Direction{1}, lev),
-                                   0, 0, m_fields.get(FieldType::Efield_cp, Direction{1}, lev)->nComp(), ng);
-                MultiFab::Subtract(dEz, *m_fields.get(FieldType::Efield_cp, Direction{2}, lev),
-                                   0, 0, m_fields.get(FieldType::Efield_cp, Direction{2}, lev)->nComp(), ng);
+                MultiFab::Subtract(dEx, *m_fields.get(FieldType::E_cp, Direction{0}, lev),
+                                   0, 0, m_fields.get(FieldType::E_cp, Direction{0}, lev)->nComp(), ng);
+                MultiFab::Subtract(dEy, *m_fields.get(FieldType::E_cp, Direction{1}, lev),
+                                   0, 0, m_fields.get(FieldType::E_cp, Direction{1}, lev)->nComp(), ng);
+                MultiFab::Subtract(dEz, *m_fields.get(FieldType::E_cp, Direction{2}, lev),
+                                   0, 0, m_fields.get(FieldType::E_cp, Direction{2}, lev)->nComp(), ng);
 
                 const amrex::IntVect& refinement_ratio = refRatio(lev-1);
 
-                const amrex::IntVect& Ex_stag = Efield_aux[lev-1][0]->ixType().toIntVect();
-                const amrex::IntVect& Ey_stag = Efield_aux[lev-1][1]->ixType().toIntVect();
-                const amrex::IntVect& Ez_stag = Efield_aux[lev-1][2]->ixType().toIntVect();
+                const amrex::IntVect& Ex_stag = E_aux[lev-1][0]->ixType().toIntVect();
+                const amrex::IntVect& Ey_stag = E_aux[lev-1][1]->ixType().toIntVect();
+                const amrex::IntVect& Ez_stag = E_aux[lev-1][2]->ixType().toIntVect();
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
-                for (MFIter mfi(*Efield_aux[lev][0]); mfi.isValid(); ++mfi)
+                for (MFIter mfi(*E_aux[lev][0]); mfi.isValid(); ++mfi)
                 {
-                    Array4<Real> const& ex_aux = Efield_aux[lev][0]->array(mfi);
-                    Array4<Real> const& ey_aux = Efield_aux[lev][1]->array(mfi);
-                    Array4<Real> const& ez_aux = Efield_aux[lev][2]->array(mfi);
-                    Array4<Real const> const& ex_fp = m_fields.get(FieldType::Efield_fp, Direction{0}, lev)->const_array(mfi);
-                    Array4<Real const> const& ey_fp = m_fields.get(FieldType::Efield_fp, Direction{1}, lev)->const_array(mfi);
-                    Array4<Real const> const& ez_fp = m_fields.get(FieldType::Efield_fp, Direction{2}, lev)->const_array(mfi);
+                    Array4<Real> const& ex_aux = E_aux[lev][0]->array(mfi);
+                    Array4<Real> const& ey_aux = E_aux[lev][1]->array(mfi);
+                    Array4<Real> const& ez_aux = E_aux[lev][2]->array(mfi);
+                    Array4<Real const> const& ex_fp = m_fields.get(FieldType::E_fp, Direction{0}, lev)->const_array(mfi);
+                    Array4<Real const> const& ey_fp = m_fields.get(FieldType::E_fp, Direction{1}, lev)->const_array(mfi);
+                    Array4<Real const> const& ez_fp = m_fields.get(FieldType::E_fp, Direction{2}, lev)->const_array(mfi);
                     Array4<Real const> const& ex_c = dEx.const_array(mfi);
                     Array4<Real const> const& ey_c = dEy.const_array(mfi);
                     Array4<Real const> const& ez_c = dEz.const_array(mfi);
@@ -586,9 +586,9 @@ WarpX::UpdateAuxilaryDataSameType ()
             }
             else // electrostatic
             {
-                MultiFab::Copy(*Efield_aux[lev][0], *m_fields.get(FieldType::Efield_fp, Direction{0}, lev), 0, 0, Efield_aux[lev][0]->nComp(), Efield_aux[lev][0]->nGrowVect());
-                MultiFab::Copy(*Efield_aux[lev][1], *m_fields.get(FieldType::Efield_fp, Direction{1}, lev), 0, 0, Efield_aux[lev][1]->nComp(), Efield_aux[lev][1]->nGrowVect());
-                MultiFab::Copy(*Efield_aux[lev][2], *m_fields.get(FieldType::Efield_fp, Direction{2}, lev), 0, 0, Efield_aux[lev][2]->nComp(), Efield_aux[lev][2]->nGrowVect());
+                MultiFab::Copy(*E_aux[lev][0], *m_fields.get(FieldType::E_fp, Direction{0}, lev), 0, 0, E_aux[lev][0]->nComp(), E_aux[lev][0]->nGrowVect());
+                MultiFab::Copy(*E_aux[lev][1], *m_fields.get(FieldType::E_fp, Direction{1}, lev), 0, 0, E_aux[lev][1]->nComp(), E_aux[lev][1]->nGrowVect());
+                MultiFab::Copy(*E_aux[lev][2], *m_fields.get(FieldType::E_fp, Direction{2}, lev), 0, 0, E_aux[lev][2]->nComp(), E_aux[lev][2]->nGrowVect());
             }
         }
     }
@@ -713,16 +713,16 @@ WarpX::FillBoundaryE (const int lev, const PatchType patch_type, const amrex::In
 
     if (patch_type == PatchType::fine)
     {
-        mf     = {m_fields.get(FieldType::Efield_fp, Direction{0}, lev),
-                  m_fields.get(FieldType::Efield_fp, Direction{1}, lev),
-                  m_fields.get(FieldType::Efield_fp, Direction{2}, lev)};
+        mf     = {m_fields.get(FieldType::E_fp, Direction{0}, lev),
+                  m_fields.get(FieldType::E_fp, Direction{1}, lev),
+                  m_fields.get(FieldType::E_fp, Direction{2}, lev)};
         period = Geom(lev).periodicity();
     }
     else // coarse patch
     {
-        mf     = {m_fields.get(FieldType::Efield_cp, Direction{0}, lev),
-                  m_fields.get(FieldType::Efield_cp, Direction{1}, lev),
-                  m_fields.get(FieldType::Efield_cp, Direction{2}, lev)};
+        mf     = {m_fields.get(FieldType::E_cp, Direction{0}, lev),
+                  m_fields.get(FieldType::E_cp, Direction{1}, lev),
+                  m_fields.get(FieldType::E_cp, Direction{2}, lev)};
         period = Geom(lev-1).periodicity();
     }
 
@@ -778,16 +778,16 @@ WarpX::FillBoundaryB (const int lev, const PatchType patch_type, const amrex::In
 
     if (patch_type == PatchType::fine)
     {
-        mf     = {m_fields.get(FieldType::Bfield_fp, Direction{0}, lev),
-                  m_fields.get(FieldType::Bfield_fp, Direction{1}, lev),
-                  m_fields.get(FieldType::Bfield_fp, Direction{2}, lev)};
+        mf     = {m_fields.get(FieldType::B_fp, Direction{0}, lev),
+                  m_fields.get(FieldType::B_fp, Direction{1}, lev),
+                  m_fields.get(FieldType::B_fp, Direction{2}, lev)};
         period = Geom(lev).periodicity();
     }
     else // coarse patch
     {
-        mf     = {m_fields.get(FieldType::Bfield_cp, Direction{0}, lev),
-                  m_fields.get(FieldType::Bfield_cp, Direction{1}, lev),
-                  m_fields.get(FieldType::Bfield_cp, Direction{2}, lev)};
+        mf     = {m_fields.get(FieldType::B_cp, Direction{0}, lev),
+                  m_fields.get(FieldType::B_cp, Direction{1}, lev),
+                  m_fields.get(FieldType::B_cp, Direction{2}, lev)};
         period = Geom(lev-1).periodicity();
     }
 
@@ -843,19 +843,19 @@ WarpX::FillBoundaryE_avg (int lev, PatchType patch_type, IntVect ng)
             WARPX_ABORT_WITH_MESSAGE("Averaged Galilean PSATD with PML is not yet implemented");
         }
 
-        ablastr::fields::MultiLevelVectorField Efield_avg_fp = m_fields.get_mr_levels_alldirs(FieldType::Efield_avg_fp, finest_level);
+        ablastr::fields::MultiLevelVectorField E_avg_fp = m_fields.get_mr_levels_alldirs(FieldType::E_avg_fp, finest_level);
 
         const amrex::Periodicity& period = Geom(lev).periodicity();
         if ( safe_guard_cells ){
-            const Vector<MultiFab*> mf{Efield_avg_fp[lev][0],Efield_avg_fp[lev][1],Efield_avg_fp[lev][2]};
+            const Vector<MultiFab*> mf{E_avg_fp[lev][0],E_avg_fp[lev][1],E_avg_fp[lev][2]};
             ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, period);
         } else {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                ng.allLE(Efield_avg_fp[lev][0]->nGrowVect()),
+                ng.allLE(E_avg_fp[lev][0]->nGrowVect()),
                 "Error: in FillBoundaryE_avg, requested more guard cells than allocated");
-            ablastr::utils::communication::FillBoundary(*Efield_avg_fp[lev][0], ng, WarpX::do_single_precision_comms, period);
-            ablastr::utils::communication::FillBoundary(*Efield_avg_fp[lev][1], ng, WarpX::do_single_precision_comms, period);
-            ablastr::utils::communication::FillBoundary(*Efield_avg_fp[lev][2], ng, WarpX::do_single_precision_comms, period);
+            ablastr::utils::communication::FillBoundary(*E_avg_fp[lev][0], ng, WarpX::do_single_precision_comms, period);
+            ablastr::utils::communication::FillBoundary(*E_avg_fp[lev][1], ng, WarpX::do_single_precision_comms, period);
+            ablastr::utils::communication::FillBoundary(*E_avg_fp[lev][2], ng, WarpX::do_single_precision_comms, period);
         }
     }
     else if (patch_type == PatchType::coarse)
@@ -865,20 +865,20 @@ WarpX::FillBoundaryE_avg (int lev, PatchType patch_type, IntVect ng)
             WARPX_ABORT_WITH_MESSAGE("Averaged Galilean PSATD with PML is not yet implemented");
         }
 
-        ablastr::fields::MultiLevelVectorField Efield_avg_cp = m_fields.get_mr_levels_alldirs(FieldType::Efield_avg_cp, finest_level);
+        ablastr::fields::MultiLevelVectorField E_avg_cp = m_fields.get_mr_levels_alldirs(FieldType::E_avg_cp, finest_level);
 
         const amrex::Periodicity& cperiod = Geom(lev-1).periodicity();
         if ( safe_guard_cells ) {
-            const Vector<MultiFab*> mf{Efield_avg_cp[lev][0],Efield_avg_cp[lev][1],Efield_avg_cp[lev][2]};
+            const Vector<MultiFab*> mf{E_avg_cp[lev][0],E_avg_cp[lev][1],E_avg_cp[lev][2]};
             ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, cperiod);
 
         } else {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                ng.allLE(Efield_avg_cp[lev][0]->nGrowVect()),
+                ng.allLE(E_avg_cp[lev][0]->nGrowVect()),
                 "Error: in FillBoundaryE, requested more guard cells than allocated");
-            ablastr::utils::communication::FillBoundary(*Efield_avg_cp[lev][0], ng, WarpX::do_single_precision_comms, cperiod);
-            ablastr::utils::communication::FillBoundary(*Efield_avg_cp[lev][1], ng, WarpX::do_single_precision_comms, cperiod);
-            ablastr::utils::communication::FillBoundary(*Efield_avg_cp[lev][2], ng, WarpX::do_single_precision_comms, cperiod);
+            ablastr::utils::communication::FillBoundary(*E_avg_cp[lev][0], ng, WarpX::do_single_precision_comms, cperiod);
+            ablastr::utils::communication::FillBoundary(*E_avg_cp[lev][1], ng, WarpX::do_single_precision_comms, cperiod);
+            ablastr::utils::communication::FillBoundary(*E_avg_cp[lev][2], ng, WarpX::do_single_precision_comms, cperiod);
         }
     }
 }
@@ -903,19 +903,19 @@ WarpX::FillBoundaryB_avg (int lev, PatchType patch_type, IntVect ng)
             WARPX_ABORT_WITH_MESSAGE("Averaged Galilean PSATD with PML is not yet implemented");
         }
 
-        ablastr::fields::MultiLevelVectorField Bfield_avg_fp = m_fields.get_mr_levels_alldirs(FieldType::Bfield_avg_fp, finest_level);
+        ablastr::fields::MultiLevelVectorField B_avg_fp = m_fields.get_mr_levels_alldirs(FieldType::B_avg_fp, finest_level);
 
         const amrex::Periodicity& period = Geom(lev).periodicity();
         if ( safe_guard_cells ) {
-            const Vector<MultiFab*> mf{Bfield_avg_fp[lev][0],Bfield_avg_fp[lev][1],Bfield_avg_fp[lev][2]};
+            const Vector<MultiFab*> mf{B_avg_fp[lev][0],B_avg_fp[lev][1],B_avg_fp[lev][2]};
             ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, period);
         } else {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                ng.allLE(m_fields.get(FieldType::Bfield_fp, Direction{0}, lev)->nGrowVect()),
+                ng.allLE(m_fields.get(FieldType::B_fp, Direction{0}, lev)->nGrowVect()),
                 "Error: in FillBoundaryB, requested more guard cells than allocated");
-            ablastr::utils::communication::FillBoundary(*Bfield_avg_fp[lev][0], ng, WarpX::do_single_precision_comms, period);
-            ablastr::utils::communication::FillBoundary(*Bfield_avg_fp[lev][1], ng, WarpX::do_single_precision_comms, period);
-            ablastr::utils::communication::FillBoundary(*Bfield_avg_fp[lev][2], ng, WarpX::do_single_precision_comms, period);
+            ablastr::utils::communication::FillBoundary(*B_avg_fp[lev][0], ng, WarpX::do_single_precision_comms, period);
+            ablastr::utils::communication::FillBoundary(*B_avg_fp[lev][1], ng, WarpX::do_single_precision_comms, period);
+            ablastr::utils::communication::FillBoundary(*B_avg_fp[lev][2], ng, WarpX::do_single_precision_comms, period);
         }
     }
     else if (patch_type == PatchType::coarse)
@@ -925,19 +925,19 @@ WarpX::FillBoundaryB_avg (int lev, PatchType patch_type, IntVect ng)
             WARPX_ABORT_WITH_MESSAGE("Averaged Galilean PSATD with PML is not yet implemented");
         }
 
-        ablastr::fields::MultiLevelVectorField Bfield_avg_cp = m_fields.get_mr_levels_alldirs(FieldType::Bfield_avg_cp, finest_level);
+        ablastr::fields::MultiLevelVectorField B_avg_cp = m_fields.get_mr_levels_alldirs(FieldType::B_avg_cp, finest_level);
 
         const amrex::Periodicity& cperiod = Geom(lev-1).periodicity();
         if ( safe_guard_cells ){
-            const Vector<MultiFab*> mf{Bfield_avg_cp[lev][0],Bfield_avg_cp[lev][1],Bfield_avg_cp[lev][2]};
+            const Vector<MultiFab*> mf{B_avg_cp[lev][0],B_avg_cp[lev][1],B_avg_cp[lev][2]};
             ablastr::utils::communication::FillBoundary(mf, WarpX::do_single_precision_comms, cperiod);
         } else {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                ng.allLE(Bfield_avg_cp[lev][0]->nGrowVect()),
+                ng.allLE(B_avg_cp[lev][0]->nGrowVect()),
                 "Error: in FillBoundaryB_avg, requested more guard cells than allocated");
-            ablastr::utils::communication::FillBoundary(*Bfield_avg_cp[lev][0], ng, WarpX::do_single_precision_comms, cperiod);
-            ablastr::utils::communication::FillBoundary(*Bfield_avg_cp[lev][1], ng, WarpX::do_single_precision_comms, cperiod);
-            ablastr::utils::communication::FillBoundary(*Bfield_avg_cp[lev][2], ng, WarpX::do_single_precision_comms, cperiod);
+            ablastr::utils::communication::FillBoundary(*B_avg_cp[lev][0], ng, WarpX::do_single_precision_comms, cperiod);
+            ablastr::utils::communication::FillBoundary(*B_avg_cp[lev][1], ng, WarpX::do_single_precision_comms, cperiod);
+            ablastr::utils::communication::FillBoundary(*B_avg_cp[lev][2], ng, WarpX::do_single_precision_comms, cperiod);
         }
     }
 }
@@ -1058,16 +1058,16 @@ WarpX::FillBoundaryAux (IntVect ng)
 void
 WarpX::FillBoundaryAux (int lev, IntVect ng)
 {
-    ablastr::fields::MultiLevelVectorField Efield_aux = m_fields.get_mr_levels_alldirs(FieldType::Efield_aux, finest_level);
-    ablastr::fields::MultiLevelVectorField Bfield_aux = m_fields.get_mr_levels_alldirs(FieldType::Bfield_aux, finest_level);
+    ablastr::fields::MultiLevelVectorField E_aux = m_fields.get_mr_levels_alldirs(FieldType::E_aux, finest_level);
+    ablastr::fields::MultiLevelVectorField B_aux = m_fields.get_mr_levels_alldirs(FieldType::B_aux, finest_level);
 
     const amrex::Periodicity& period = Geom(lev).periodicity();
-    ablastr::utils::communication::FillBoundary(*Efield_aux[lev][0], ng, WarpX::do_single_precision_comms, period);
-    ablastr::utils::communication::FillBoundary(*Efield_aux[lev][1], ng, WarpX::do_single_precision_comms, period);
-    ablastr::utils::communication::FillBoundary(*Efield_aux[lev][2], ng, WarpX::do_single_precision_comms, period);
-    ablastr::utils::communication::FillBoundary(*Bfield_aux[lev][0], ng, WarpX::do_single_precision_comms, period);
-    ablastr::utils::communication::FillBoundary(*Bfield_aux[lev][1], ng, WarpX::do_single_precision_comms, period);
-    ablastr::utils::communication::FillBoundary(*Bfield_aux[lev][2], ng, WarpX::do_single_precision_comms, period);
+    ablastr::utils::communication::FillBoundary(*E_aux[lev][0], ng, WarpX::do_single_precision_comms, period);
+    ablastr::utils::communication::FillBoundary(*E_aux[lev][1], ng, WarpX::do_single_precision_comms, period);
+    ablastr::utils::communication::FillBoundary(*E_aux[lev][2], ng, WarpX::do_single_precision_comms, period);
+    ablastr::utils::communication::FillBoundary(*B_aux[lev][0], ng, WarpX::do_single_precision_comms, period);
+    ablastr::utils::communication::FillBoundary(*B_aux[lev][1], ng, WarpX::do_single_precision_comms, period);
+    ablastr::utils::communication::FillBoundary(*B_aux[lev][2], ng, WarpX::do_single_precision_comms, period);
 }
 
 void

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -182,13 +182,13 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
         m_fields.remake_level(lev, dm);
 
         // Fine patch
-        ablastr::fields::MultiLevelVectorField const& Bfield_fp = m_fields.get_mr_levels_alldirs(FieldType::Bfield_fp, finest_level);
+        ablastr::fields::MultiLevelVectorField const& B_fp = m_fields.get_mr_levels_alldirs(FieldType::B_fp, finest_level);
         for (int idim=0; idim < 3; ++idim)
         {
             if (eb_enabled) {
                 if (WarpX::electromagnetic_solver_id != ElectromagneticSolverAlgo::PSATD) {
                     if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT) {
-                        m_borrowing[lev][idim] = std::make_unique<amrex::LayoutData<FaceInfoBox>>(amrex::convert(ba, Bfield_fp[lev][idim]->ixType().toIntVect()), dm);
+                        m_borrowing[lev][idim] = std::make_unique<amrex::LayoutData<FaceInfoBox>>(amrex::convert(ba, B_fp[lev][idim]->ixType().toIntVect()), dm);
                     }
                 }
             }
@@ -336,7 +336,7 @@ WarpX::ComputeCostsHeuristic (amrex::Vector<std::unique_ptr<amrex::LayoutData<am
         }
 
         // Cell loop
-        MultiFab* Ex = m_fields.get(FieldType::Efield_fp, Direction{0}, lev);
+        MultiFab* Ex = m_fields.get(FieldType::E_fp, Direction{0}, lev);
         for (MFIter mfi(*Ex, false); mfi.isValid(); ++mfi)
         {
             const Box& gbx = mfi.growntilebox();

--- a/Source/Particles/Gather/GetExternalFields.cpp
+++ b/Source/Particles/Gather/GetExternalFields.cpp
@@ -87,7 +87,7 @@ GetExternalEBField::GetExternalEBField (const WarpXParIter& a_pti, long a_offset
     // the external fields are not added directly inside the gather kernel.
     // (Hence of `None`, which ensures that the gather kernel is compiled without support
     // for external fields.) Instead, the external fields are added to the MultiFab
-    // Efield_aux and Bfield_aux before the particles gather from these MultiFab.
+    // E_aux and B_aux before the particles gather from these MultiFab.
     if (mypc.m_E_ext_particle_s == "read_from_file") {
         m_Etype = ExternalFieldInitType::None;
     }

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -1357,12 +1357,12 @@ MultiParticleContainer::doQEDSchwinger ()
     pc_product_pos->defineAllParticleTiles();
 
     using ablastr::fields::Direction;
-    const MultiFab & Ex = *warpx.m_fields.get(FieldType::Efield_aux, Direction{0}, level_0);
-    const MultiFab & Ey = *warpx.m_fields.get(FieldType::Efield_aux, Direction{1}, level_0);
-    const MultiFab & Ez = *warpx.m_fields.get(FieldType::Efield_aux, Direction{2}, level_0);
-    const MultiFab & Bx = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{0}, level_0);
-    const MultiFab & By = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{1}, level_0);
-    const MultiFab & Bz = *warpx.m_fields.get(FieldType::Bfield_aux, Direction{2}, level_0);
+    const MultiFab & Ex = *warpx.m_fields.get(FieldType::E_aux, Direction{0}, level_0);
+    const MultiFab & Ey = *warpx.m_fields.get(FieldType::E_aux, Direction{1}, level_0);
+    const MultiFab & Ez = *warpx.m_fields.get(FieldType::E_aux, Direction{2}, level_0);
+    const MultiFab & Bx = *warpx.m_fields.get(FieldType::B_aux, Direction{0}, level_0);
+    const MultiFab & By = *warpx.m_fields.get(FieldType::B_aux, Direction{1}, level_0);
+    const MultiFab & Bz = *warpx.m_fields.get(FieldType::B_aux, Direction{2}, level_0);
 
 #ifdef AMREX_USE_OMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -1754,15 +1754,15 @@ PhysicalParticleContainer::Evolve (ablastr::fields::MultiFabRegister& fields,
 
     const bool has_rho = fields.has(FieldType::rho_fp, lev);
     const bool has_cjx = fields.has(FieldType::current_buf, Direction{0}, lev);
-    const bool has_cEx = fields.has(FieldType::Efield_cax, Direction{0}, lev);
+    const bool has_cEx = fields.has(FieldType::E_cax, Direction{0}, lev);
     const bool has_buffer = has_cEx || has_cjx;
 
-    amrex::MultiFab & Ex = *fields.get(FieldType::Efield_aux, Direction{0}, lev);
-    amrex::MultiFab & Ey = *fields.get(FieldType::Efield_aux, Direction{1}, lev);
-    amrex::MultiFab & Ez = *fields.get(FieldType::Efield_aux, Direction{2}, lev);
-    amrex::MultiFab & Bx = *fields.get(FieldType::Bfield_aux, Direction{0}, lev);
-    amrex::MultiFab & By = *fields.get(FieldType::Bfield_aux, Direction{1}, lev);
-    amrex::MultiFab & Bz = *fields.get(FieldType::Bfield_aux, Direction{2}, lev);
+    amrex::MultiFab & Ex = *fields.get(FieldType::E_aux, Direction{0}, lev);
+    amrex::MultiFab & Ey = *fields.get(FieldType::E_aux, Direction{1}, lev);
+    amrex::MultiFab & Ez = *fields.get(FieldType::E_aux, Direction{2}, lev);
+    amrex::MultiFab & Bx = *fields.get(FieldType::B_aux, Direction{0}, lev);
+    amrex::MultiFab & By = *fields.get(FieldType::B_aux, Direction{1}, lev);
+    amrex::MultiFab & Bz = *fields.get(FieldType::B_aux, Direction{2}, lev);
 
     if (m_do_back_transformed_particles)
     {
@@ -1897,12 +1897,12 @@ PhysicalParticleContainer::Evolve (ablastr::fields::MultiFabRegister& fields,
                     const IntVect& ref_ratio = WarpX::RefRatio(lev-1);
                     const Box& cbox = amrex::coarsen(box,ref_ratio);
 
-                    amrex::MultiFab & cEx = *fields.get(FieldType::Efield_cax, Direction{0}, lev);
-                    amrex::MultiFab & cEy = *fields.get(FieldType::Efield_cax, Direction{1}, lev);
-                    amrex::MultiFab & cEz = *fields.get(FieldType::Efield_cax, Direction{2}, lev);
-                    amrex::MultiFab & cBx = *fields.get(FieldType::Bfield_cax, Direction{0}, lev);
-                    amrex::MultiFab & cBy = *fields.get(FieldType::Bfield_cax, Direction{1}, lev);
-                    amrex::MultiFab & cBz = *fields.get(FieldType::Bfield_cax, Direction{2}, lev);
+                    amrex::MultiFab & cEx = *fields.get(FieldType::E_cax, Direction{0}, lev);
+                    amrex::MultiFab & cEy = *fields.get(FieldType::E_cax, Direction{1}, lev);
+                    amrex::MultiFab & cEz = *fields.get(FieldType::E_cax, Direction{2}, lev);
+                    amrex::MultiFab & cBx = *fields.get(FieldType::B_cax, Direction{0}, lev);
+                    amrex::MultiFab & cBy = *fields.get(FieldType::B_cax, Direction{1}, lev);
+                    amrex::MultiFab & cBz = *fields.get(FieldType::B_cax, Direction{2}, lev);
 
                     // Data on the grid
                     FArrayBox const* cexfab = &cEx[pti];

--- a/Source/Python/WarpX.cpp
+++ b/Source/Python/WarpX.cpp
@@ -130,7 +130,7 @@ void init_WarpX (py::module& m)
             py::arg("multifab_name"),
             py::arg("level"),
             py::return_value_policy::reference_internal,
-            R"doc(Return MultiFabs by name and level, e.g., ``\"Efield_aux\"``, ``\"Efield_fp"``, ...
+            R"doc(Return MultiFabs by name and level, e.g., ``\"E_aux\"``, ``\"E_fp"``, ...
 
 The physical fields in WarpX have the following naming:
 
@@ -152,7 +152,7 @@ The physical fields in WarpX have the following naming:
             py::arg("dir"),
             py::arg("level"),
             py::return_value_policy::reference_internal,
-            R"doc(Return MultiFabs by name, direction, and level, e.g., ``\"Efield_aux\"``, ``\"Efield_fp"``, ...
+            R"doc(Return MultiFabs by name, direction, and level, e.g., ``\"E_aux\"``, ``\"E_fp"``, ...
 
 The physical fields in WarpX have the following naming:
 
@@ -233,7 +233,7 @@ The physical fields in WarpX have the following naming:
         )
         .def_static("run_div_cleaner",
             [] () { WarpX::ProjectionCleanDivB(); },
-            "Executes projection based divergence cleaner on loaded Bfield_fp_external."
+            "Executes projection based divergence cleaner on loaded B_fp_external."
         )
     ;
 

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -220,35 +220,35 @@ WarpX::MoveWindow (const int step, bool move_j)
         // Shift each component of vector fields (E, B, j)
         for (int dim = 0; dim < 3; ++dim) {
             // Fine grid
-            amrex::ParserExecutor<3> Bfield_parser;
-            amrex::ParserExecutor<3> Efield_parser;
+            amrex::ParserExecutor<3> B_parser;
+            amrex::ParserExecutor<3> E_parser;
             bool use_Bparser = false;
             bool use_Eparser = false;
             if (m_p_ext_field_params->B_ext_grid_type ==
                     ExternalFieldType::parse_ext_grid_function) {
                 use_Bparser = true;
-                if (dim == 0) { Bfield_parser = m_p_ext_field_params->Bxfield_parser->compile<3>(); }
-                if (dim == 1) { Bfield_parser = m_p_ext_field_params->Byfield_parser->compile<3>(); }
-                if (dim == 2) { Bfield_parser = m_p_ext_field_params->Bzfield_parser->compile<3>(); }
+                if (dim == 0) { B_parser = m_p_ext_field_params->Bxfield_parser->compile<3>(); }
+                if (dim == 1) { B_parser = m_p_ext_field_params->Byfield_parser->compile<3>(); }
+                if (dim == 2) { B_parser = m_p_ext_field_params->Bzfield_parser->compile<3>(); }
             }
             if (m_p_ext_field_params->E_ext_grid_type ==
                     ExternalFieldType::parse_ext_grid_function) {
                 use_Eparser = true;
-                if (dim == 0) { Efield_parser = m_p_ext_field_params->Exfield_parser->compile<3>(); }
-                if (dim == 1) { Efield_parser = m_p_ext_field_params->Eyfield_parser->compile<3>(); }
-                if (dim == 2) { Efield_parser = m_p_ext_field_params->Ezfield_parser->compile<3>(); }
+                if (dim == 0) { E_parser = m_p_ext_field_params->Exfield_parser->compile<3>(); }
+                if (dim == 1) { E_parser = m_p_ext_field_params->Eyfield_parser->compile<3>(); }
+                if (dim == 2) { E_parser = m_p_ext_field_params->Ezfield_parser->compile<3>(); }
             }
-            shiftMF(*m_fields.get(FieldType::Bfield_fp, Direction{dim}, lev), geom[lev], num_shift, dir, lev, do_update_cost,
-                m_p_ext_field_params->B_external_grid[dim], use_Bparser, Bfield_parser);
-            shiftMF(*m_fields.get(FieldType::Efield_fp, Direction{dim}, lev), geom[lev], num_shift, dir, lev, do_update_cost,
-                m_p_ext_field_params->E_external_grid[dim], use_Eparser, Efield_parser);
+            shiftMF(*m_fields.get(FieldType::B_fp, Direction{dim}, lev), geom[lev], num_shift, dir, lev, do_update_cost,
+                m_p_ext_field_params->B_external_grid[dim], use_Bparser, B_parser);
+            shiftMF(*m_fields.get(FieldType::E_fp, Direction{dim}, lev), geom[lev], num_shift, dir, lev, do_update_cost,
+                m_p_ext_field_params->E_external_grid[dim], use_Eparser, E_parser);
             if (fft_do_time_averaging) {
-                ablastr::fields::MultiLevelVectorField Efield_avg_fp = m_fields.get_mr_levels_alldirs(FieldType::Efield_avg_fp, finest_level);
-                ablastr::fields::MultiLevelVectorField Bfield_avg_fp = m_fields.get_mr_levels_alldirs(FieldType::Bfield_avg_fp, finest_level);
-                shiftMF(*Bfield_avg_fp[lev][dim], geom[lev], num_shift, dir, lev, do_update_cost,
-                    m_p_ext_field_params->B_external_grid[dim], use_Bparser, Bfield_parser);
-                shiftMF(*Efield_avg_fp[lev][dim], geom[lev], num_shift, dir, lev, do_update_cost,
-                   m_p_ext_field_params-> E_external_grid[dim], use_Eparser, Efield_parser);
+                ablastr::fields::MultiLevelVectorField E_avg_fp = m_fields.get_mr_levels_alldirs(FieldType::E_avg_fp, finest_level);
+                ablastr::fields::MultiLevelVectorField B_avg_fp = m_fields.get_mr_levels_alldirs(FieldType::B_avg_fp, finest_level);
+                shiftMF(*B_avg_fp[lev][dim], geom[lev], num_shift, dir, lev, do_update_cost,
+                    m_p_ext_field_params->B_external_grid[dim], use_Bparser, B_parser);
+                shiftMF(*E_avg_fp[lev][dim], geom[lev], num_shift, dir, lev, do_update_cost,
+                   m_p_ext_field_params-> E_external_grid[dim], use_Eparser, E_parser);
             }
             if (move_j) {
                 shiftMF(*m_fields.get(FieldType::current_fp, Direction{dim}, lev), geom[lev], num_shift, dir, lev, do_update_cost);
@@ -269,19 +269,19 @@ WarpX::MoveWindow (const int step, bool move_j)
 #endif
             if (lev > 0) {
                 // coarse grid
-                shiftMF(*m_fields.get(FieldType::Bfield_cp, Direction{dim}, lev), geom[lev-1], num_shift_crse, dir, lev, do_update_cost,
-                    m_p_ext_field_params->B_external_grid[dim], use_Bparser, Bfield_parser);
-                shiftMF(*m_fields.get(FieldType::Efield_cp, Direction{dim}, lev), geom[lev-1], num_shift_crse, dir, lev, do_update_cost,
-                    m_p_ext_field_params->E_external_grid[dim], use_Eparser, Efield_parser);
-                shiftMF(*m_fields.get(FieldType::Bfield_aux, Direction{dim}, lev), geom[lev], num_shift, dir, lev, do_update_cost);
-                shiftMF(*m_fields.get(FieldType::Efield_aux, Direction{dim}, lev), geom[lev], num_shift, dir, lev, do_update_cost);
+                shiftMF(*m_fields.get(FieldType::B_cp, Direction{dim}, lev), geom[lev-1], num_shift_crse, dir, lev, do_update_cost,
+                    m_p_ext_field_params->B_external_grid[dim], use_Bparser, B_parser);
+                shiftMF(*m_fields.get(FieldType::E_cp, Direction{dim}, lev), geom[lev-1], num_shift_crse, dir, lev, do_update_cost,
+                    m_p_ext_field_params->E_external_grid[dim], use_Eparser, E_parser);
+                shiftMF(*m_fields.get(FieldType::B_aux, Direction{dim}, lev), geom[lev], num_shift, dir, lev, do_update_cost);
+                shiftMF(*m_fields.get(FieldType::E_aux, Direction{dim}, lev), geom[lev], num_shift, dir, lev, do_update_cost);
                 if (fft_do_time_averaging) {
-                    ablastr::fields::MultiLevelVectorField Efield_avg_cp = m_fields.get_mr_levels_alldirs(FieldType::Efield_avg_cp, finest_level);
-                    ablastr::fields::MultiLevelVectorField Bfield_avg_cp = m_fields.get_mr_levels_alldirs(FieldType::Bfield_avg_cp, finest_level);
-                    shiftMF(*Bfield_avg_cp[lev][dim], geom[lev-1], num_shift_crse, dir, lev, do_update_cost,
-                        m_p_ext_field_params->B_external_grid[dim], use_Bparser, Bfield_parser);
-                    shiftMF(*Efield_avg_cp[lev][dim], geom[lev-1], num_shift_crse, dir, lev, do_update_cost,
-                        m_p_ext_field_params->E_external_grid[dim], use_Eparser, Efield_parser);
+                    ablastr::fields::MultiLevelVectorField E_avg_cp = m_fields.get_mr_levels_alldirs(FieldType::E_avg_cp, finest_level);
+                    ablastr::fields::MultiLevelVectorField B_avg_cp = m_fields.get_mr_levels_alldirs(FieldType::B_avg_cp, finest_level);
+                    shiftMF(*B_avg_cp[lev][dim], geom[lev-1], num_shift_crse, dir, lev, do_update_cost,
+                        m_p_ext_field_params->B_external_grid[dim], use_Bparser, B_parser);
+                    shiftMF(*E_avg_cp[lev][dim], geom[lev-1], num_shift_crse, dir, lev, do_update_cost,
+                        m_p_ext_field_params->E_external_grid[dim], use_Eparser, E_parser);
                 }
                 if (move_j) {
                     shiftMF(*m_fields.get(FieldType::current_cp, Direction{dim}, lev), geom[lev-1], num_shift_crse, dir, lev, do_update_cost);
@@ -466,9 +466,9 @@ WarpX::MoveWindow (const int step, bool move_j)
         const int lev_zero = 0;
         m_macroscopic_properties->InitData(
             Geom(lev_zero),
-            m_fields.get(FieldType::Efield_fp, Direction{0}, lev_zero)->ixType().toIntVect(),
-            m_fields.get(FieldType::Efield_fp, Direction{1}, lev_zero)->ixType().toIntVect(),
-            m_fields.get(FieldType::Efield_fp, Direction{2}, lev_zero)->ixType().toIntVect()
+            m_fields.get(FieldType::E_fp, Direction{0}, lev_zero)->ixType().toIntVect(),
+            m_fields.get(FieldType::E_fp, Direction{1}, lev_zero)->ixType().toIntVect(),
+            m_fields.get(FieldType::E_fp, Direction{2}, lev_zero)->ixType().toIntVect()
         );
     }
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1426,8 +1426,8 @@ private:
 
     // Masks for computing dot product and global moments of fields when using grids that
     // have shared locations across different ranks (e.g., a Yee grid)
-    mutable amrex::Vector<std::array< std::unique_ptr<amrex::iMultiFab>,3 > > Efield_dotMask;
-    mutable amrex::Vector<std::array< std::unique_ptr<amrex::iMultiFab>,3 > > Bfield_dotMask;
+    mutable amrex::Vector<std::array< std::unique_ptr<amrex::iMultiFab>,3 > > E_dotMask;
+    mutable amrex::Vector<std::array< std::unique_ptr<amrex::iMultiFab>,3 > > B_dotMask;
     mutable amrex::Vector<std::array< std::unique_ptr<amrex::iMultiFab>,3 > > Afield_dotMask;
     mutable amrex::Vector<            std::unique_ptr<amrex::iMultiFab>     > phi_dotMask;
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -297,8 +297,8 @@ WarpX::WarpX ()
         myfl = std::make_unique<MultiFluidContainer>();
     }
 
-    Efield_dotMask.resize(nlevs_max);
-    Bfield_dotMask.resize(nlevs_max);
+    E_dotMask.resize(nlevs_max);
+    B_dotMask.resize(nlevs_max);
     Afield_dotMask.resize(nlevs_max);
     phi_dotMask.resize(nlevs_max);
 
@@ -1991,8 +1991,8 @@ WarpX::ClearLevel (int lev)
     m_fields.clear_level(lev);
 
     for (int i = 0; i < 3; ++i) {
-        Efield_dotMask [lev][i].reset();
-        Bfield_dotMask [lev][i].reset();
+        E_dotMask [lev][i].reset();
+        B_dotMask [lev][i].reset();
         Afield_dotMask [lev][i].reset();
     }
 
@@ -2194,13 +2194,13 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     //
     const std::array<Real,3> dx = CellSize(lev);
 
-    m_fields.alloc_init(FieldType::Bfield_fp, Direction{0}, lev, amrex::convert(ba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-    m_fields.alloc_init(FieldType::Bfield_fp, Direction{1}, lev, amrex::convert(ba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-    m_fields.alloc_init(FieldType::Bfield_fp, Direction{2}, lev, amrex::convert(ba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+    m_fields.alloc_init(FieldType::B_fp, Direction{0}, lev, amrex::convert(ba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+    m_fields.alloc_init(FieldType::B_fp, Direction{1}, lev, amrex::convert(ba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+    m_fields.alloc_init(FieldType::B_fp, Direction{2}, lev, amrex::convert(ba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
 
-    m_fields.alloc_init(FieldType::Efield_fp, Direction{0}, lev, amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-    m_fields.alloc_init(FieldType::Efield_fp, Direction{1}, lev, amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-    m_fields.alloc_init(FieldType::Efield_fp, Direction{2}, lev, amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+    m_fields.alloc_init(FieldType::E_fp, Direction{0}, lev, amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+    m_fields.alloc_init(FieldType::E_fp, Direction{1}, lev, amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+    m_fields.alloc_init(FieldType::E_fp, Direction{2}, lev, amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
 
     m_fields.alloc_init(FieldType::current_fp, Direction{0}, lev, amrex::convert(ba, jx_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
     m_fields.alloc_init(FieldType::current_fp, Direction{1}, lev, amrex::convert(ba, jy_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
@@ -2265,13 +2265,13 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
 
     if (fft_do_time_averaging)
     {
-        m_fields.alloc_init(FieldType::Bfield_avg_fp, Direction{0}, lev, amrex::convert(ba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Bfield_avg_fp, Direction{1}, lev, amrex::convert(ba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Bfield_avg_fp, Direction{2}, lev, amrex::convert(ba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::B_avg_fp, Direction{0}, lev, amrex::convert(ba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::B_avg_fp, Direction{1}, lev, amrex::convert(ba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::B_avg_fp, Direction{2}, lev, amrex::convert(ba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
 
-        m_fields.alloc_init(FieldType::Efield_avg_fp, Direction{0}, lev, amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Efield_avg_fp, Direction{1}, lev, amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Efield_avg_fp, Direction{2}, lev, amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::E_avg_fp, Direction{0}, lev, amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::E_avg_fp, Direction{1}, lev, amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::E_avg_fp, Direction{2}, lev, amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
     }
 
     if (EB::enabled()) {
@@ -2474,102 +2474,102 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         // Create aux multifabs on Nodal Box Array
         BoxArray const nba = amrex::convert(ba,IntVect::TheNodeVector());
 
-        m_fields.alloc_init(FieldType::Bfield_aux, Direction{0}, lev, nba, dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Bfield_aux, Direction{1}, lev, nba, dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Bfield_aux, Direction{2}, lev, nba, dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::B_aux, Direction{0}, lev, nba, dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::B_aux, Direction{1}, lev, nba, dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::B_aux, Direction{2}, lev, nba, dm, ncomps, ngEB, 0.0_rt);
 
-        m_fields.alloc_init(FieldType::Efield_aux, Direction{0}, lev, nba, dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Efield_aux, Direction{1}, lev, nba, dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Efield_aux, Direction{2}, lev, nba, dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::E_aux, Direction{0}, lev, nba, dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::E_aux, Direction{1}, lev, nba, dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::E_aux, Direction{2}, lev, nba, dm, ncomps, ngEB, 0.0_rt);
     } else if (lev == 0) {
         if (WarpX::fft_do_time_averaging) {
-            m_fields.alias_init(FieldType::Bfield_aux, FieldType::Bfield_avg_fp, Direction{0}, lev, 0.0_rt);
-            m_fields.alias_init(FieldType::Bfield_aux, FieldType::Bfield_avg_fp, Direction{1}, lev, 0.0_rt);
-            m_fields.alias_init(FieldType::Bfield_aux, FieldType::Bfield_avg_fp, Direction{2}, lev, 0.0_rt);
+            m_fields.alias_init(FieldType::B_aux, FieldType::B_avg_fp, Direction{0}, lev, 0.0_rt);
+            m_fields.alias_init(FieldType::B_aux, FieldType::B_avg_fp, Direction{1}, lev, 0.0_rt);
+            m_fields.alias_init(FieldType::B_aux, FieldType::B_avg_fp, Direction{2}, lev, 0.0_rt);
 
-            m_fields.alias_init(FieldType::Efield_aux, FieldType::Efield_avg_fp, Direction{0}, lev, 0.0_rt);
-            m_fields.alias_init(FieldType::Efield_aux, FieldType::Efield_avg_fp, Direction{1}, lev, 0.0_rt);
-            m_fields.alias_init(FieldType::Efield_aux, FieldType::Efield_avg_fp, Direction{2}, lev, 0.0_rt);
+            m_fields.alias_init(FieldType::E_aux, FieldType::E_avg_fp, Direction{0}, lev, 0.0_rt);
+            m_fields.alias_init(FieldType::E_aux, FieldType::E_avg_fp, Direction{1}, lev, 0.0_rt);
+            m_fields.alias_init(FieldType::E_aux, FieldType::E_avg_fp, Direction{2}, lev, 0.0_rt);
         } else {
             if (mypc->m_B_ext_particle_s == "read_from_file") {
-                m_fields.alloc_init(FieldType::Bfield_aux, Direction{0}, lev, amrex::convert(ba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-                m_fields.alloc_init(FieldType::Bfield_aux, Direction{1}, lev, amrex::convert(ba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-                m_fields.alloc_init(FieldType::Bfield_aux, Direction{2}, lev, amrex::convert(ba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+                m_fields.alloc_init(FieldType::B_aux, Direction{0}, lev, amrex::convert(ba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+                m_fields.alloc_init(FieldType::B_aux, Direction{1}, lev, amrex::convert(ba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+                m_fields.alloc_init(FieldType::B_aux, Direction{2}, lev, amrex::convert(ba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
             } else {
                 // In this case, the aux grid is simply an alias of the fp grid (most common case in WarpX)
-                m_fields.alias_init(FieldType::Bfield_aux, FieldType::Bfield_fp, Direction{0}, lev, 0.0_rt);
-                m_fields.alias_init(FieldType::Bfield_aux, FieldType::Bfield_fp, Direction{1}, lev, 0.0_rt);
-                m_fields.alias_init(FieldType::Bfield_aux, FieldType::Bfield_fp, Direction{2}, lev, 0.0_rt);
+                m_fields.alias_init(FieldType::B_aux, FieldType::B_fp, Direction{0}, lev, 0.0_rt);
+                m_fields.alias_init(FieldType::B_aux, FieldType::B_fp, Direction{1}, lev, 0.0_rt);
+                m_fields.alias_init(FieldType::B_aux, FieldType::B_fp, Direction{2}, lev, 0.0_rt);
             }
             if (mypc->m_E_ext_particle_s == "read_from_file") {
-                m_fields.alloc_init(FieldType::Efield_aux, Direction{0}, lev, amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-                m_fields.alloc_init(FieldType::Efield_aux, Direction{1}, lev, amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-                m_fields.alloc_init(FieldType::Efield_aux, Direction{2}, lev, amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+                m_fields.alloc_init(FieldType::E_aux, Direction{0}, lev, amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+                m_fields.alloc_init(FieldType::E_aux, Direction{1}, lev, amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+                m_fields.alloc_init(FieldType::E_aux, Direction{2}, lev, amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
             } else {
                 // In this case, the aux grid is simply an alias of the fp grid (most common case in WarpX)
-                m_fields.alias_init(FieldType::Efield_aux, FieldType::Efield_fp, Direction{0}, lev, 0.0_rt);
-                m_fields.alias_init(FieldType::Efield_aux, FieldType::Efield_fp, Direction{1}, lev, 0.0_rt);
-                m_fields.alias_init(FieldType::Efield_aux, FieldType::Efield_fp, Direction{2}, lev, 0.0_rt);
+                m_fields.alias_init(FieldType::E_aux, FieldType::E_fp, Direction{0}, lev, 0.0_rt);
+                m_fields.alias_init(FieldType::E_aux, FieldType::E_fp, Direction{1}, lev, 0.0_rt);
+                m_fields.alias_init(FieldType::E_aux, FieldType::E_fp, Direction{2}, lev, 0.0_rt);
             }
         }
     } else {
-        m_fields.alloc_init(FieldType::Bfield_aux, Direction{0}, lev, amrex::convert(ba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Bfield_aux, Direction{1}, lev, amrex::convert(ba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Bfield_aux, Direction{2}, lev, amrex::convert(ba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::B_aux, Direction{0}, lev, amrex::convert(ba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::B_aux, Direction{1}, lev, amrex::convert(ba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::B_aux, Direction{2}, lev, amrex::convert(ba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
 
-        m_fields.alloc_init(FieldType::Efield_aux, Direction{0}, lev, amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Efield_aux, Direction{1}, lev, amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Efield_aux, Direction{2}, lev, amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::E_aux, Direction{0}, lev, amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::E_aux, Direction{1}, lev, amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::E_aux, Direction{2}, lev, amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
     }
 
     // The external fields that are read from file
     if (m_p_ext_field_params->B_ext_grid_type != ExternalFieldType::default_zero && m_p_ext_field_params->B_ext_grid_type != ExternalFieldType::constant) {
         // These fields will be added directly to the grid, i.e. to fp, and need to match the index type
-        m_fields.alloc_init(FieldType::Bfield_fp_external, Direction{0}, lev,
-            amrex::convert(ba, m_fields.get(FieldType::Bfield_fp,Direction{0},lev)->ixType()),
+        m_fields.alloc_init(FieldType::B_fp_external, Direction{0}, lev,
+            amrex::convert(ba, m_fields.get(FieldType::B_fp,Direction{0},lev)->ixType()),
             dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Bfield_fp_external, Direction{1}, lev,
-            amrex::convert(ba, m_fields.get(FieldType::Bfield_fp,Direction{1},lev)->ixType()),
+        m_fields.alloc_init(FieldType::B_fp_external, Direction{1}, lev,
+            amrex::convert(ba, m_fields.get(FieldType::B_fp,Direction{1},lev)->ixType()),
             dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Bfield_fp_external, Direction{2}, lev,
-            amrex::convert(ba, m_fields.get(FieldType::Bfield_fp,Direction{2},lev)->ixType()),
+        m_fields.alloc_init(FieldType::B_fp_external, Direction{2}, lev,
+            amrex::convert(ba, m_fields.get(FieldType::B_fp,Direction{2},lev)->ixType()),
             dm, ncomps, ngEB, 0.0_rt);
     }
     if (mypc->m_B_ext_particle_s == "read_from_file") {
         //  These fields will be added to the fields that the particles see, and need to match the index type
-        auto *Bfield_aux_levl_0 = m_fields.get(FieldType::Bfield_aux, Direction{0}, lev);
-        auto *Bfield_aux_levl_1 = m_fields.get(FieldType::Bfield_aux, Direction{1}, lev);
-        auto *Bfield_aux_levl_2 = m_fields.get(FieldType::Bfield_aux, Direction{2}, lev);
+        auto *B_aux_levl_0 = m_fields.get(FieldType::B_aux, Direction{0}, lev);
+        auto *B_aux_levl_1 = m_fields.get(FieldType::B_aux, Direction{1}, lev);
+        auto *B_aux_levl_2 = m_fields.get(FieldType::B_aux, Direction{2}, lev);
 
-        // Same as Bfield_fp for reading external field data
-        m_fields.alloc_init(FieldType::B_external_particle_field, Direction{0}, lev, amrex::convert(ba, Bfield_aux_levl_0->ixType()),
+        // Same as B_fp for reading external field data
+        m_fields.alloc_init(FieldType::B_external_particle_field, Direction{0}, lev, amrex::convert(ba, B_aux_levl_0->ixType()),
             dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::B_external_particle_field, Direction{1}, lev, amrex::convert(ba, Bfield_aux_levl_1->ixType()),
+        m_fields.alloc_init(FieldType::B_external_particle_field, Direction{1}, lev, amrex::convert(ba, B_aux_levl_1->ixType()),
             dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::B_external_particle_field, Direction{2}, lev, amrex::convert(ba, Bfield_aux_levl_2->ixType()),
+        m_fields.alloc_init(FieldType::B_external_particle_field, Direction{2}, lev, amrex::convert(ba, B_aux_levl_2->ixType()),
             dm, ncomps, ngEB, 0.0_rt);
     }
     if (m_p_ext_field_params->E_ext_grid_type != ExternalFieldType::default_zero && m_p_ext_field_params->E_ext_grid_type != ExternalFieldType::constant) {
         // These fields will be added directly to the grid, i.e. to fp, and need to match the index type
-        m_fields.alloc_init(FieldType::Efield_fp_external, Direction{0}, lev, amrex::convert(ba, m_fields.get(FieldType::Efield_fp, Direction{0}, lev)->ixType()),
+        m_fields.alloc_init(FieldType::E_fp_external, Direction{0}, lev, amrex::convert(ba, m_fields.get(FieldType::E_fp, Direction{0}, lev)->ixType()),
             dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Efield_fp_external, Direction{1}, lev, amrex::convert(ba, m_fields.get(FieldType::Efield_fp, Direction{1}, lev)->ixType()),
+        m_fields.alloc_init(FieldType::E_fp_external, Direction{1}, lev, amrex::convert(ba, m_fields.get(FieldType::E_fp, Direction{1}, lev)->ixType()),
             dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Efield_fp_external, Direction{2}, lev, amrex::convert(ba, m_fields.get(FieldType::Efield_fp, Direction{2}, lev)->ixType()),
+        m_fields.alloc_init(FieldType::E_fp_external, Direction{2}, lev, amrex::convert(ba, m_fields.get(FieldType::E_fp, Direction{2}, lev)->ixType()),
             dm, ncomps, ngEB, 0.0_rt);
     }
     if (mypc->m_E_ext_particle_s == "read_from_file") {
         //  These fields will be added to the fields that the particles see, and need to match the index type
-        auto *Efield_aux_levl_0 = m_fields.get(FieldType::Efield_aux, Direction{0}, lev);
-        auto *Efield_aux_levl_1 = m_fields.get(FieldType::Efield_aux, Direction{1}, lev);
-        auto *Efield_aux_levl_2 = m_fields.get(FieldType::Efield_aux, Direction{2}, lev);
+        auto *E_aux_levl_0 = m_fields.get(FieldType::E_aux, Direction{0}, lev);
+        auto *E_aux_levl_1 = m_fields.get(FieldType::E_aux, Direction{1}, lev);
+        auto *E_aux_levl_2 = m_fields.get(FieldType::E_aux, Direction{2}, lev);
 
-        // Same as Efield_fp for reading external field data
-        m_fields.alloc_init(FieldType::E_external_particle_field, Direction{0}, lev, amrex::convert(ba, Efield_aux_levl_0->ixType()),
+        // Same as E_fp for reading external field data
+        m_fields.alloc_init(FieldType::E_external_particle_field, Direction{0}, lev, amrex::convert(ba, E_aux_levl_0->ixType()),
             dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::E_external_particle_field, Direction{1}, lev, amrex::convert(ba, Efield_aux_levl_1->ixType()),
+        m_fields.alloc_init(FieldType::E_external_particle_field, Direction{1}, lev, amrex::convert(ba, E_aux_levl_1->ixType()),
             dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::E_external_particle_field, Direction{2}, lev, amrex::convert(ba, Efield_aux_levl_2->ixType()),
+        m_fields.alloc_init(FieldType::E_external_particle_field, Direction{2}, lev, amrex::convert(ba, E_aux_levl_2->ixType()),
             dm, ncomps, ngEB, 0.0_rt);
     }
 
@@ -2583,24 +2583,24 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         const std::array<Real,3> cdx = CellSize(lev-1);
 
         // Create the MultiFabs for B
-        m_fields.alloc_init(FieldType::Bfield_cp, Direction{0}, lev, amrex::convert(cba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Bfield_cp, Direction{1}, lev, amrex::convert(cba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Bfield_cp, Direction{2}, lev, amrex::convert(cba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::B_cp, Direction{0}, lev, amrex::convert(cba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::B_cp, Direction{1}, lev, amrex::convert(cba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::B_cp, Direction{2}, lev, amrex::convert(cba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
 
         // Create the MultiFabs for E
-        m_fields.alloc_init(FieldType::Efield_cp, Direction{0}, lev, amrex::convert(cba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Efield_cp, Direction{1}, lev, amrex::convert(cba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Efield_cp, Direction{2}, lev, amrex::convert(cba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::E_cp, Direction{0}, lev, amrex::convert(cba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::E_cp, Direction{1}, lev, amrex::convert(cba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::E_cp, Direction{2}, lev, amrex::convert(cba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
 
         if (fft_do_time_averaging)
         {
-            m_fields.alloc_init(FieldType::Bfield_avg_cp, Direction{0}, lev, amrex::convert(cba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-            m_fields.alloc_init(FieldType::Bfield_avg_cp, Direction{1}, lev, amrex::convert(cba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-            m_fields.alloc_init(FieldType::Bfield_avg_cp, Direction{2}, lev, amrex::convert(cba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+            m_fields.alloc_init(FieldType::B_avg_cp, Direction{0}, lev, amrex::convert(cba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+            m_fields.alloc_init(FieldType::B_avg_cp, Direction{1}, lev, amrex::convert(cba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+            m_fields.alloc_init(FieldType::B_avg_cp, Direction{2}, lev, amrex::convert(cba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
 
-            m_fields.alloc_init(FieldType::Efield_avg_cp, Direction{0}, lev, amrex::convert(cba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-            m_fields.alloc_init(FieldType::Efield_avg_cp, Direction{1}, lev, amrex::convert(cba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-            m_fields.alloc_init(FieldType::Efield_avg_cp, Direction{2}, lev, amrex::convert(cba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+            m_fields.alloc_init(FieldType::E_avg_cp, Direction{0}, lev, amrex::convert(cba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+            m_fields.alloc_init(FieldType::E_avg_cp, Direction{1}, lev, amrex::convert(cba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+            m_fields.alloc_init(FieldType::E_avg_cp, Direction{2}, lev, amrex::convert(cba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
         }
 
         // Create the MultiFabs for the current
@@ -2692,24 +2692,24 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
             if (aux_is_nodal) {
                 BoxArray const& cnba = amrex::convert(cba,IntVect::TheNodeVector());
                 // Create the MultiFabs for B
-                m_fields.alloc_init(FieldType::Bfield_cax, Direction{0}, lev, cnba, dm, ncomps, ngEB, 0.0_rt);
-                m_fields.alloc_init(FieldType::Bfield_cax, Direction{1}, lev, cnba, dm, ncomps, ngEB, 0.0_rt);
-                m_fields.alloc_init(FieldType::Bfield_cax, Direction{2}, lev, cnba, dm, ncomps, ngEB, 0.0_rt);
+                m_fields.alloc_init(FieldType::B_cax, Direction{0}, lev, cnba, dm, ncomps, ngEB, 0.0_rt);
+                m_fields.alloc_init(FieldType::B_cax, Direction{1}, lev, cnba, dm, ncomps, ngEB, 0.0_rt);
+                m_fields.alloc_init(FieldType::B_cax, Direction{2}, lev, cnba, dm, ncomps, ngEB, 0.0_rt);
 
                 // Create the MultiFabs for E
-                m_fields.alloc_init(FieldType::Efield_cax, Direction{0}, lev, cnba, dm, ncomps, ngEB, 0.0_rt);
-                m_fields.alloc_init(FieldType::Efield_cax, Direction{1}, lev, cnba, dm, ncomps, ngEB, 0.0_rt);
-                m_fields.alloc_init(FieldType::Efield_cax, Direction{2}, lev, cnba, dm, ncomps, ngEB, 0.0_rt);
+                m_fields.alloc_init(FieldType::E_cax, Direction{0}, lev, cnba, dm, ncomps, ngEB, 0.0_rt);
+                m_fields.alloc_init(FieldType::E_cax, Direction{1}, lev, cnba, dm, ncomps, ngEB, 0.0_rt);
+                m_fields.alloc_init(FieldType::E_cax, Direction{2}, lev, cnba, dm, ncomps, ngEB, 0.0_rt);
             } else {
                 // Create the MultiFabs for B
-                m_fields.alloc_init(FieldType::Bfield_cax, Direction{0}, lev, amrex::convert(cba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-                m_fields.alloc_init(FieldType::Bfield_cax, Direction{1}, lev, amrex::convert(cba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-                m_fields.alloc_init(FieldType::Bfield_cax, Direction{2}, lev, amrex::convert(cba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+                m_fields.alloc_init(FieldType::B_cax, Direction{0}, lev, amrex::convert(cba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+                m_fields.alloc_init(FieldType::B_cax, Direction{1}, lev, amrex::convert(cba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+                m_fields.alloc_init(FieldType::B_cax, Direction{2}, lev, amrex::convert(cba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
 
                 // Create the MultiFabs for E
-                m_fields.alloc_init(FieldType::Efield_cax, Direction{0}, lev, amrex::convert(cba,Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-                m_fields.alloc_init(FieldType::Efield_cax, Direction{1}, lev, amrex::convert(cba,Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-                m_fields.alloc_init(FieldType::Efield_cax, Direction{2}, lev, amrex::convert(cba,Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+                m_fields.alloc_init(FieldType::E_cax, Direction{0}, lev, amrex::convert(cba,Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+                m_fields.alloc_init(FieldType::E_cax, Direction{1}, lev, amrex::convert(cba,Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+                m_fields.alloc_init(FieldType::E_cax, Direction{2}, lev, amrex::convert(cba,Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
             }
 
             AllocInitMultiFab(gather_buffer_masks[lev], ba, dm, ncomps, amrex::IntVect(1), lev, "gather_buffer_masks");
@@ -2973,15 +2973,15 @@ WarpX::ComputeDivE(amrex::MultiFab& divE, const int lev)
 {
     if ( WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD ) {
 #ifdef WARPX_USE_FFT
-        const ablastr::fields::VectorField Efield_aux_lev = m_fields.get_alldirs(FieldType::Efield_aux, lev);
-        spectral_solver_fp[lev]->ComputeSpectralDivE(lev, Efield_aux_lev, divE);
+        const ablastr::fields::VectorField E_aux_lev = m_fields.get_alldirs(FieldType::E_aux, lev);
+        spectral_solver_fp[lev]->ComputeSpectralDivE(lev, E_aux_lev, divE);
 #else
         WARPX_ABORT_WITH_MESSAGE(
             "ComputeDivE: PSATD requested but not compiled");
 #endif
     } else {
-        const ablastr::fields::VectorField Efield_aux_lev = m_fields.get_alldirs(FieldType::Efield_aux, lev);
-        m_fdtd_solver_fp[lev]->ComputeDivE(Efield_aux_lev, divE);
+        const ablastr::fields::VectorField E_aux_lev = m_fields.get_alldirs(FieldType::E_aux, lev);
+        m_fdtd_solver_fp[lev]->ComputeDivE(E_aux_lev, divE);
     }
 }
 
@@ -3399,12 +3399,12 @@ WarpX::getFieldDotMaskPointer ( FieldType field_type, int lev, int dir ) const
 {
     switch(field_type)
     {
-        case FieldType::Efield_fp :
-            SetDotMask( Efield_dotMask[lev][dir], "Efield_fp", lev, dir );
-            return Efield_dotMask[lev][dir].get();
-        case FieldType::Bfield_fp :
-            SetDotMask( Bfield_dotMask[lev][dir], "Bfield_fp", lev, dir );
-            return Bfield_dotMask[lev][dir].get();
+        case FieldType::E_fp :
+            SetDotMask( E_dotMask[lev][dir], "E_fp", lev, dir );
+            return E_dotMask[lev][dir].get();
+        case FieldType::B_fp :
+            SetDotMask( B_dotMask[lev][dir], "B_fp", lev, dir );
+            return B_dotMask[lev][dir].get();
         case FieldType::vector_potential_fp :
             SetDotMask( Afield_dotMask[lev][dir], "vector_potential_fp", lev, dir );
             return Afield_dotMask[lev][dir].get();
@@ -3413,7 +3413,7 @@ WarpX::getFieldDotMaskPointer ( FieldType field_type, int lev, int dir ) const
             return phi_dotMask[lev].get();
         default:
             WARPX_ABORT_WITH_MESSAGE("Invalid field type for dotMask");
-            return Efield_dotMask[lev][dir].get();
+            return E_dotMask[lev][dir].get();
     }
 }
 


### PR DESCRIPTION
This makes names shorter and more consistent.

This is a breaking change for Python users that access he E- and B-field directly by name.
Was, e.g.,:
```py
.multifab("Efield_fp", ...)
```
is now:
```py
.multifab("E_fp", ...)
```
For:
- `Efield_...`
- `Bfield_...`
- `.._fp`, `..._cp`, `..._aux`, `..._cax`, `..._fp_external`, `..._avg_fp`, `..._avg_cp`