### PR TITLE
Python: Warn old `warpx.multifab` Signature

### DIFF
--- a/Source/Python/WarpX.cpp
+++ b/Source/Python/WarpX.cpp
@@ -121,6 +121,11 @@ void init_WarpX (py::module& m)
         )
         .def("multifab",
              [](WarpX & wx, std::string internal_name) {
+                 py::print("WARNING: WarpX' multifab('internal_name') signature is deprecated.\nPlease use:\n"
+                           "- multifab('prefix', level=...) for scalar fields\n"
+                           "- multifab('prefix', dir=..., level=...) for vector field components\n"
+                           "where 'prefix' is the part of 'internal_name';'  before the []",
+                           py::arg("file") = py::module_::import("sys").attr("stderr"));
                  if (wx.m_fields.internal_has(internal_name)) {
                      return wx.m_fields.internal_get(internal_name);
                  } else {


### PR DESCRIPTION
Warn users that use the old `warpx.multifab("internal_name")` overload to use the new one that only requests a prefix, with dir and level as extra arguments.

Follow-up to #5321