### PR TITLE
Doc: NVTX in Nvidia Conda

### DIFF
--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -117,7 +117,7 @@ For Nvidia CUDA GPU support, you will need to have `a recent CUDA driver install
 
 .. code-block:: bash
 
-   conda install -c nvidia -c conda-forge cuda cupy
+   conda install -c nvidia -c conda-forge cuda cuda-nvtx-dev cupy
 
 More info for `CUDA-enabled ML packages <https://twitter.com/jeremyphoward/status/1697435241152127369>`__.
 


### PR DESCRIPTION
The package `cuda-nvtx-dev` does not seem to be part of the `cuda` package.
https://anaconda.org/nvidia/repo

This fixes:
```
CMake Error at build/_deps/fetchedamrex-src/Tools/CMake/AMReXParallelBackends.cmake:71 (target_link_libraries):
  Target "amrex_3d" links to:

    CUDA::nvToolsExt

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  build/_deps/fetchedamrex-src/Src/CMakeLists.txt:40 (include)
```