### PR TITLE
PEC: Fix Uninit Var Warning (GCC)

### DIFF
--- a/Source/BoundaryConditions/PEC_Insulator.cpp
+++ b/Source/BoundaryConditions/PEC_Insulator.cpp
@@ -69,7 +69,7 @@ namespace
         bool GuardCell = false;
         bool isInsulatorBoundary = false;
         amrex::Real sign = +1._rt;
-        bool is_normal_to_boundary;
+        bool is_normal_to_boundary = false;
         amrex::Real field_value = 0._rt;
         bool set_field = false;
         // Loop over all dimensions


### PR DESCRIPTION
GCC 13 throws a compile-time warning in 3D that in some cases, `is_normal_to_boundary` is used as uninitialized. There are a lot of `if`s in its usage, so I simply changed the init value to `false` to silence it.