### PR TITLE
Splitting: Remove `pc_tmp`

### DIFF
--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -327,8 +327,6 @@ public:
         return tmp;
     }
 
-    PhysicalParticleContainer& GetPCtmp () { return *pc_tmp; }
-
     void ScrapeParticlesAtEB (ablastr::fields::MultiLevelScalarField const& distance_to_eb);
 
     std::string m_B_ext_particle_s = "none";
@@ -525,8 +523,6 @@ private:
 
     // physical particles (+ laser)
     amrex::Vector<std::unique_ptr<WarpXParticleContainer>> allcontainers;
-    // Temporary particle container, used e.g. for particle splitting.
-    std::unique_ptr<PhysicalParticleContainer> pc_tmp;
 
     void ReadParameters ();
 

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -119,8 +119,6 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
         allcontainers[i]->m_deposit_on_main_grid = m_laser_deposit_on_main_grid[i-nspecies];
     }
 
-    pc_tmp = std::make_unique<PhysicalParticleContainer>(amr_core);
-
     // Setup particle collisions
     collisionhandler = std::make_unique<CollisionHandler>(this);
 
@@ -412,7 +410,6 @@ MultiParticleContainer::AllocData ()
     for (auto& pc : allcontainers) {
         pc->AllocData();
     }
-    pc_tmp->AllocData();
 }
 
 void
@@ -423,8 +420,6 @@ MultiParticleContainer::InitData ()
     for (auto& pc : allcontainers) {
         pc->InitData();
     }
-    pc_tmp->InitData();
-
 }
 
 void
@@ -435,7 +430,6 @@ MultiParticleContainer::PostRestart ()
     for (auto& pc : allcontainers) {
         pc->PostRestart();
     }
-    pc_tmp->PostRestart();
 }
 
 void

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -2323,8 +2323,7 @@ PhysicalParticleContainer::applyNCIFilter (
 void
 PhysicalParticleContainer::SplitParticles (int lev)
 {
-    auto& mypc = WarpX::GetInstance().GetPartContainer().GetParticleContainerFromName(this->species_name);
-    auto pctmp_split = mypc.make_alike<amrex::DefaultAllocator>();
+    PhysicalParticleContainer pctmp_split(&WarpX::GetInstance());
     RealVector psplit_x, psplit_y, psplit_z, psplit_w;
     RealVector psplit_ux, psplit_uy, psplit_uz;
     long np_split_to_add = 0;
@@ -2523,8 +2522,6 @@ PhysicalParticleContainer::SplitParticles (int lev)
     // Copy particles from tmp to current particle container
     constexpr bool local_flag = true;
     addParticles(pctmp_split,local_flag);
-    // Clear tmp container
-    pctmp_split.clearParticles();
 }
 
 void

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -2506,7 +2506,7 @@ PhysicalParticleContainer::SplitParticles (int lev)
     amrex::Vector<amrex::Vector<ParticleReal>> attr;
     attr.push_back(wp);
     const amrex::Vector<amrex::Vector<int>> attr_int;
-    pctmp_split.AddNParticles(lev,   // TODO
+    pctmp_split.AddNParticles(lev,
                               np_split_to_add,
                               xp,
                               yp,

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -224,7 +224,6 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
     : WarpXParticleContainer(amr_core, ispecies),
       species_name(name)
 {
-    amrex::Print() << "PhysicalParticleContainer::PhysicalParticleContainer\n";
     BackwardCompatibility();
 
     const ParmParse pp_species_name(species_name);

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -224,6 +224,7 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
     : WarpXParticleContainer(amr_core, ispecies),
       species_name(name)
 {
+    amrex::Print() << "PhysicalParticleContainer::PhysicalParticleContainer\n";
     BackwardCompatibility();
 
     const ParmParse pp_species_name(species_name);
@@ -2322,8 +2323,8 @@ PhysicalParticleContainer::applyNCIFilter (
 void
 PhysicalParticleContainer::SplitParticles (int lev)
 {
-    auto& mypc = WarpX::GetInstance().GetPartContainer();
-    auto& pctmp_split = mypc.GetPCtmp();
+    auto& mypc = WarpX::GetInstance().GetPartContainer().GetParticleContainerFromName(this->species_name);
+    auto pctmp_split = mypc.make_alike<amrex::DefaultAllocator>();
     RealVector psplit_x, psplit_y, psplit_z, psplit_w;
     RealVector psplit_ux, psplit_uy, psplit_uz;
     long np_split_to_add = 0;
@@ -2507,7 +2508,7 @@ PhysicalParticleContainer::SplitParticles (int lev)
     amrex::Vector<amrex::Vector<ParticleReal>> attr;
     attr.push_back(wp);
     const amrex::Vector<amrex::Vector<int>> attr_int;
-    pctmp_split.AddNParticles(lev,
+    pctmp_split.AddNParticles(lev,   // TODO
                               np_split_to_add,
                               xp,
                               yp,


### PR DESCRIPTION
There was an other temporary pc that makes refactoring init logic hard (e.g., #5015)

Follow-up to #5571

- [x] remove `pc_tmp`
- [x] finalize particle splitting (`AddNParticles`) cc @atmyers @EZoni 