### PR TITLE
CMake: Fix Superbuilds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Parse WarpX version information
-file(READ "${CMAKE_SOURCE_DIR}/dependencies.json" dependencies_data)
+file(READ "${CMAKE_CURRENT_LIST_DIR}/dependencies.json" dependencies_data)
 string(JSON warpx_version GET "${dependencies_data}" version_warpx)
 
 # Preamble ####################################################################

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -298,7 +298,7 @@ set(WarpX_amrex_repo "https://github.com/AMReX-Codes/amrex.git"
     "Repository URI to pull and build AMReX from if(WarpX_amrex_internal)")
 
 # Parse AMReX version and commit information
-file(READ "${CMAKE_SOURCE_DIR}/dependencies.json" dependencies_data)
+file(READ "${WarpX_SOURCE_DIR}/dependencies.json" dependencies_data)
 string(JSON amrex_version GET "${dependencies_data}" version_amrex)
 string(JSON amrex_commit GET "${dependencies_data}" commit_amrex)
 

--- a/cmake/dependencies/PICSAR.cmake
+++ b/cmake/dependencies/PICSAR.cmake
@@ -111,7 +111,7 @@ if(WarpX_QED)
         "Repository URI to pull and build PICSAR from if(WarpX_picsar_internal)")
 
     # Parse PICSAR version and commit information
-    file(READ "${CMAKE_SOURCE_DIR}/dependencies.json" dependencies_data)
+    file(READ "${WarpX_SOURCE_DIR}/dependencies.json" dependencies_data)
     string(JSON picsar_version GET "${dependencies_data}" version_picsar)
     string(JSON picsar_commit GET "${dependencies_data}" commit_picsar)
 

--- a/cmake/dependencies/pyAMReX.cmake
+++ b/cmake/dependencies/pyAMReX.cmake
@@ -76,7 +76,7 @@ set(WarpX_pyamrex_repo "https://github.com/AMReX-Codes/pyamrex.git"
     "Repository URI to pull and build pyamrex from if(WarpX_pyamrex_internal)")
 
 # Parse pyAMReX version and commit information
-file(READ "${CMAKE_SOURCE_DIR}/dependencies.json" dependencies_data)
+file(READ "${WarpX_SOURCE_DIR}/dependencies.json" dependencies_data)
 string(JSON pyamrex_version GET "${dependencies_data}" version_pyamrex)
 string(JSON pyamrex_commit GET "${dependencies_data}" commit_pyamrex)
 


### PR DESCRIPTION
Use WarpX-specific and not CMake-superbuild-specific directory. Follow-up to #5965