### PR TITLE
`PlasmaInjector.H`: Hide `openPMD.hpp`

### DIFF
--- a/Source/Initialization/PlasmaInjector.H
+++ b/Source/Initialization/PlasmaInjector.H
@@ -25,10 +25,7 @@
 
 #include <AMReX_BaseFwd.H>
 
-#ifdef WARPX_USE_OPENPMD
-#   include <openPMD/openPMD.hpp>
-#endif
-
+#include <any>
 #include <limits>
 #include <memory>
 #include <string>
@@ -119,7 +116,7 @@ public:
     amrex::Real z_shift = 0.0; //! additional z offset for particle positions
 #ifdef WARPX_USE_OPENPMD
     //! openPMD::Series to load from in external_file injection
-    std::unique_ptr<openPMD::Series> m_openpmd_input_series;
+    std::any m_openpmd_input_series;
 #endif
 
     amrex::Real surface_flux_pos; // surface location

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -35,6 +35,10 @@
 #include <AMReX_RandomEngine.H>
 #include <AMReX_REAL.H>
 
+#ifdef WARPX_USE_OPENPMD
+#   include <openPMD/openPMD.hpp>
+#endif
+
 #include <algorithm>
 #include <cctype>
 #include <map>
@@ -469,13 +473,13 @@ void PlasmaInjector::setupExternalFile (amrex::ParmParse const& pp_species)
     const bool species_is_specified = pp_species.contains("species_type");
 
     if (amrex::ParallelDescriptor::IOProcessor()) {
-        m_openpmd_input_series = std::make_unique<openPMD::Series>(
+        auto series = openPMD::Series(
             str_injection_file, openPMD::Access::READ_ONLY);
 
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-            m_openpmd_input_series->iterations.size() == 1u,
+            series.iterations.size() == 1u,
             "External file should contain only 1 iteration\n");
-        openPMD::Iteration it = m_openpmd_input_series->iterations.begin()->second;
+        openPMD::Iteration it = series.iterations.begin()->second;
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             it.particles.size() == 1u,
             "External file should contain only 1 species\n");
@@ -502,7 +506,7 @@ void PlasmaInjector::setupExternalFile (amrex::ParmParse const& pp_species)
                 // TODO: Add ASSERT_WITH_MESSAGE to test if charge is a constant record
                 auto p_q_ptr =
                     ps["charge"][openPMD::RecordComponent::SCALAR].loadChunk<amrex::ParticleReal>();
-                m_openpmd_input_series->flush();
+                series.flush();
                 amrex::ParticleReal const p_q = p_q_ptr.get()[0];
                 auto const charge_unit = static_cast<amrex::Real>(ps["charge"][openPMD::RecordComponent::SCALAR].unitSI());
                 charge = p_q * charge_unit;
@@ -525,12 +529,13 @@ void PlasmaInjector::setupExternalFile (amrex::ParmParse const& pp_species)
                 // TODO: Add ASSERT_WITH_MESSAGE to test if mass is a constant record
                 auto p_m_ptr =
                     ps["mass"][openPMD::RecordComponent::SCALAR].loadChunk<amrex::ParticleReal>();
-                m_openpmd_input_series->flush();
+                series.flush();
                 amrex::ParticleReal const p_m = p_m_ptr.get()[0];
                 auto const mass_unit = static_cast<amrex::Real>(ps["mass"][openPMD::RecordComponent::SCALAR].unitSI());
                 mass = p_m * mass_unit;
             }
         }
+        m_openpmd_input_series = series;
     } // IOProcessor
 
     // Broadcast charge and mass to non-IO processors if read in from the file

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -1155,7 +1155,7 @@ void MultiParticleContainer::InitQuantumSync ()
     // qs_minimum_chi_part is the minimum chi parameter to be
     // considered for Synchrotron emission. If a lepton has chi < chi_min,
     // the optical depth is not evolved and photon generation is ignored
-    amrex::Real qs_minimum_chi_part;
+    amrex::Real qs_minimum_chi_part = 0;
     utils::parser::getWithParser(pp_qed_qs, "chi_min", qs_minimum_chi_part);
 
 
@@ -1277,7 +1277,7 @@ MultiParticleContainer::QuantumSyncGenerateTable ()
     // qs_minimum_chi_part is the minimum chi parameter to be
     // considered for Synchrotron emission. If a lepton has chi < chi_min,
     // the optical depth is not evolved and photon generation is ignored
-    amrex::Real qs_minimum_chi_part;
+    amrex::Real qs_minimum_chi_part = 0;
     utils::parser::getWithParser(pp_qed_qs, "chi_min", qs_minimum_chi_part);
 
     if(ParallelDescriptor::IOProcessor()){
@@ -1367,7 +1367,7 @@ MultiParticleContainer::BreitWheelerGenerateTable ()
     // bw_minimum_chi_phot is the minimum chi parameter to be
     // considered for pair production. If a photon has chi < chi_min,
     // the optical depth is not evolved and photon generation is ignored
-    amrex::Real bw_minimum_chi_part;
+    amrex::Real bw_minimum_chi_part = 0;
     utils::parser::getWithParser(pp_qed_bw, "chi_min", bw_minimum_chi_part);
 
     if(ParallelDescriptor::IOProcessor()){

--- a/Source/Particles/ParticleCreation/AddParticles.cpp
+++ b/Source/Particles/ParticleCreation/AddParticles.cpp
@@ -76,6 +76,7 @@
 #   include <openPMD/openPMD.hpp>
 #endif
 
+#include <any>
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -564,10 +565,10 @@ PhysicalParticleContainer::AddPlasmaFromFile(PlasmaInjector & plasma_injector,
     //TODO: Make changes for read/write in multiple MPI ranks
     if (ParallelDescriptor::IOProcessor()) {
         // take ownership of the series and close it when done
-        auto series = std::move(plasma_injector.m_openpmd_input_series);
+        auto series = std::any_cast<openPMD::Series>(std::move(plasma_injector.m_openpmd_input_series));
 
         // assumption asserts: see PlasmaInjector
-        openPMD::Iteration it = series->iterations.begin()->second;
+        openPMD::Iteration it = series.iterations.begin()->second;
         const ParmParse pp_species_name(species_name);
         pp_species_name.query("impose_t_lab_from_file", impose_t_lab_from_file);
         double t_lab = 0._prt;
@@ -610,7 +611,7 @@ PhysicalParticleContainer::AddPlasmaFromFile(PlasmaInjector & plasma_injector,
             ptr_uy = ps["momentum"]["y"].loadChunk<ParticleReal>();
             momentum_unit_y = static_cast<ParticleReal>(ps["momentum"]["y"].unitSI());
         }
-        series->flush();  // shared_ptr data can be read now
+        series.flush();  // shared_ptr data can be read now
 
         if (q_tot != 0.0) {
             std::stringstream warnMsg;


### PR DESCRIPTION
Avoid the `openPMD/openPMD.hpp` include in `PlasmaInjector.H`, because the latter file is included in tons of translation units, and the former is an "expensive" (~1.5sec) include, in terms of compile-time #5984.

Use a PIMPL-like idom with `std::any` to still store the series as a member variable, but only pull in the type in the two specific translation units, `AddParticles.cpp` and `PlasmaInjector.cpp` that access the member.

All other openPMD includes look good and TU local.