### PR TITLE
Ascent 0.9.3

### DIFF
--- a/.github/workflows/insitu.yml
+++ b/.github/workflows/insitu.yml
@@ -54,7 +54,7 @@ jobs:
       CMAKE_PREFIX_PATH: /ascent/install/lib/cmake/
       OMP_NUM_THREADS: 1
     container:
-      image: alpinedav/ascent:0.9.2
+      image: alpinedav/ascent:0.9.3
     steps:
     - uses: actions/checkout@v4
     - name: Configure


### PR DESCRIPTION
Update Ascent to the latest patch release of the 0.9.X line, primarily for a newer CMake in the image.

X-ref: https://github.com/AMReX-Codes/amrex/pull/4572#issuecomment-3120479463