### PR TITLE
Python: Precision & SIMD in `Config`

### DIFF
--- a/Source/Python/WarpX.cpp
+++ b/Source/Python/WarpX.cpp
@@ -41,6 +41,7 @@
 #include <AMReX.H>
 #include <AMReX_ParmParse.H>
 #include <AMReX_ParallelDescriptor.H>
+#include <AMReX_SIMD.H>
 
 #if defined(AMREX_DEBUG) || defined(DEBUG)
 #   include <cstdio>
@@ -340,7 +341,21 @@ The physical fields in WarpX have the following naming:
 #else
                 return false;
 #endif
-            })
+        })
+        .def_property_readonly_static(
+            "have_simd",
+            [](py::object const &){
+#ifdef AMREX_USE_SIMD
+                return true;
+#else
+                return false;
+#endif
+        })
+        .def_property_readonly_static(
+            "simd_size",
+            [](py::object const &){
+                return amrex::simd::native_simd_size_particlereal;
+        })
         .def_property_readonly_static(
             "gpu_backend",
             [](py::object){
@@ -353,6 +368,24 @@ The physical fields in WarpX have the following naming:
 #else
                 return py::none();
 #endif
-            })
+        })
+        .def_property_readonly_static(
+            "precision",
+            [](py::object){
+#ifdef AMREX_SINGLE_PRECISION
+                return "SINGLE";
+#else
+                return "DOUBLE";
+#endif
+        })
+        .def_property_readonly_static(
+            "precision_particles",
+            [](py::object){
+#ifdef AMREX_SINGLE_PRECISION_PARTICLES
+                return "SINGLE";
+#else
+                return "DOUBLE";
+#endif
+        })
         ;
 }


### PR DESCRIPTION
Extend our `Config` Python object:  Add particle precision properties in the Python API, similar to what we do in pyAMReX. This is useful for users to quickly find out what features are supported.

Also add details on SIMD status and size of SIMD lanes/registers.

Note: SIMD is not yet used in WarpX, but we will soon use it more (e.g., for the ES solver, Green's function).