### PR TITLE
Initial Box Splitting (Profile): NRandomPerCell

### DIFF
--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -88,6 +88,62 @@ using namespace amrex;
 
 namespace
 {
+    /** Return the number of particles per cell as specified by the user
+     *
+     * This provides the user input parameters for particles per cell to
+     * initialize, before applying profile functions for individual cells
+     * (which might set the real nppc of a cell to zero).
+     *
+     * TODO: this does not yet support multiple injection sources from
+     *       <species_name>.injection_sources
+     * \see PlasmaInjector::PlasmaInjector
+     */
+    amrex::Real
+    get_nppc (ParmParse & pp_spec)
+    {
+        amrex::Real nppc = 0;
+
+        std::string injection_style = "none";
+        pp_spec.query("injection_style", injection_style);
+        std::transform(injection_style.begin(),
+                       injection_style.end(),
+                       injection_style.begin(),
+                       ::tolower);
+
+        if (injection_style == "singleparticle") {
+            nppc = 1;
+        } else if (injection_style == "multipleparticles") {
+            std::vector<int> multiple_particles_pos_x;
+            utils::parser::getArrWithParser(pp_spec, "multiple_particles_pos_x", multiple_particles_pos_x);
+            nppc = multiple_particles_pos_x.size();
+        } else if (injection_style == "gaussian_beam") {
+            // TODO: hard to estimate well
+            // Possible way: take the npart parameter, normalize by rms scale to nppc via cell size on level 0.
+            nppc = 1;
+        } else if (injection_style == "nrandompercell") {
+            amrex::Real num_particles_per_cell = 0;
+            utils::parser::getWithParser(pp_spec, "num_particles_per_cell", num_particles_per_cell);
+            nppc = num_particles_per_cell;
+        } else if (injection_style == "nfluxpercell") {
+            amrex::Real num_particles_per_cell = 0;
+            utils::parser::getWithParser(pp_spec, "num_particles_per_cell", num_particles_per_cell);
+            nppc = num_particles_per_cell;
+        } else if (injection_style == "nuniformpercell") {
+            std::vector<int> nppc_v(3,1);
+            utils::parser::getArrWithParser(pp_spec, "num_particles_per_cell_each_dim", nppc_v);
+            nppc = AMREX_D_TERM(Real(nppc_v[0]),*Real(nppc_v[1]),*Real(nppc_v[2]));
+        } else if (injection_style == "external_file") {
+            // TODO
+        } else if (injection_style != "none") {
+            nppc = 0;
+        }
+
+        // TODO: <species_name>.read_from_file
+        // https://github.com/BLAST-WarpX/warpx/issues/6157
+
+        return nppc;
+    }
+
 
     /** Print dt and dx,dy,dz */
     void PrintDtDxDyDz (
@@ -340,9 +396,7 @@ WarpX::PostProcessBaseGrids (BoxArray& ba0) const
             {
                 split_using_this_species = true;
                 utils::parser::queryWithParser(pp_spec, "density_min", density_min);
-                std::vector<int> nppc_v(3,1);
-                utils::parser::getArrWithParser(pp_spec, "num_particles_per_cell_each_dim", nppc_v);
-                nppc = AMREX_D_TERM(Real(nppc_v[0]),*Real(nppc_v[1]),*Real(nppc_v[2]));
+                nppc = get_nppc(pp_spec);
             }
 
             // If this species is not initialized by parse_density_function,


### PR DESCRIPTION
Add support for `NRandomPerCell` injection style for initial box splitting based on a density profile. Before this, only `NUniformPerCell` was supported.

Follow-up to #5812