### PR TITLE
WarpX Remake: Keep MultiFab Pointers for EBs

### DIFF
--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -183,7 +183,7 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
         const IntVect& ng = mf->nGrowVect();
         auto pmf = std::remove_reference_t<decltype(mf)>{};
         AllocInitMultiFab(pmf, mf->boxArray(), dm, mf->nComp(), ng, lev, mf->tags()[0]);
-        std::swap(mf, pmf);
+        *mf = std::move(*pmf);
     };
 
     bool const eb_enabled = EB::enabled();

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -183,7 +183,7 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
         const IntVect& ng = mf->nGrowVect();
         auto pmf = std::remove_reference_t<decltype(mf)>{};
         AllocInitMultiFab(pmf, mf->boxArray(), dm, mf->nComp(), ng, lev, mf->tags()[0]);
-        mf = std::move(pmf);
+        std::swap(mf, pmf);
     };
 
     bool const eb_enabled = EB::enabled();

--- a/Source/ablastr/fields/MultiFabRegister.cpp
+++ b/Source/ablastr/fields/MultiFabRegister.cpp
@@ -273,7 +273,7 @@ namespace ablastr::fields
                 }
 
                 // replace old MultiFab with new one, deallocate old one
-                std::swap(mf_owner.m_mf, new_mf);
+                mf_owner.m_mf = std::move(new_mf);
             }
         }
 

--- a/Source/ablastr/fields/MultiFabRegister.cpp
+++ b/Source/ablastr/fields/MultiFabRegister.cpp
@@ -273,7 +273,7 @@ namespace ablastr::fields
                 }
 
                 // replace old MultiFab with new one, deallocate old one
-                mf_owner.m_mf = std::move(new_mf);
+                std::swap(mf_owner.m_mf, new_mf);
             }
         }
 


### PR DESCRIPTION
We want to keep the `MultiFab` pointers the same during load balancing (`WarpX::RemakeLevel`).

In interactive usage, users might store a reference/handle to our `MultiFab` classes directly between simulation steps. We want to make sure these references stay valid.

Using `std::swap` and `std::move` helps us to move the new data underneath the existing pointer to `MultiFab` instead of replacing it with a new pointer altogether during load balancing, where we recreate `MultiFab` instances.

This fixes the load balancing of EB fields to stay stable, too. With this fix (and the already working handles handed out by `MutliFabRegister` for most of our fields), we can avoid our high level field wrapper and transparently forward all AMReX methods and properties to users, without another level of indirection.