### PR TITLE
Python: Remove PC Wrapper in Usage

### DIFF
--- a/Examples/Physics_applications/capacitive_discharge/inputs_base_1d_picmi.py
+++ b/Examples/Physics_applications/capacitive_discharge/inputs_base_1d_picmi.py
@@ -11,7 +11,7 @@ import numpy as np
 from scipy.sparse import csc_matrix
 from scipy.sparse import linalg as sla
 
-from pywarpx import callbacks, libwarpx, particle_containers, picmi
+from pywarpx import callbacks, libwarpx, picmi
 from pywarpx.LoadThirdParty import load_cupy
 
 constants = picmi.constants
@@ -410,13 +410,11 @@ class CapacitiveDischargeExample(object):
             return
 
         if not hasattr(self, "neutral_cont"):
-            self.neutral_cont = particle_containers.ParticleContainerWrapper(
-                self.neutrals.name
-            )
+            self.neutral_particles = self.sim.particles.get(self.neutrals.name)
 
-        ux_arrays = self.neutral_cont.uxp
-        uy_arrays = self.neutral_cont.uyp
-        uz_arrays = self.neutral_cont.uzp
+        ux_arrays = self.neutral_particles.uxp
+        uy_arrays = self.neutral_particles.uyp
+        uz_arrays = self.neutral_particles.uzp
 
         xp, _ = load_cupy()
 
@@ -429,8 +427,8 @@ class CapacitiveDischargeExample(object):
 
     def _get_rho_ions(self):
         # deposit the ion density in rho_fp
-        he_ions_wrapper = particle_containers.ParticleContainerWrapper("he_ions")
-        he_ions_wrapper.deposit_charge_density(level=0)
+        he_ions = self.sim.particles.get("he_ions")
+        he_ions.deposit_charge_density(level=0)
 
         rho_data = self.rho_wrapper[...]
         self.ion_density_array += rho_data / constants.q_e / self.diag_steps
@@ -453,9 +451,9 @@ class CapacitiveDischargeExample(object):
         # query the particle z-coordinates if this is run during CI testing
         # to cover that functionality
         if self.test:
-            he_ions_wrapper = particle_containers.ParticleContainerWrapper("he_ions")
-            nparts = he_ions_wrapper.get_particle_count(local=True)
-            z_coords = np.concatenate(he_ions_wrapper.zp)
+            he_ions = self.sim.particles.get("he_ions")
+            nparts = he_ions.get_particle_count(local=True)
+            z_coords = np.concatenate(he_ions.zp)
             assert len(z_coords) == nparts
             assert np.all(z_coords >= 0.0) and np.all(z_coords <= self.gap)
 

--- a/Examples/Physics_applications/capacitive_discharge/inputs_base_1d_picmi.py
+++ b/Examples/Physics_applications/capacitive_discharge/inputs_base_1d_picmi.py
@@ -409,7 +409,7 @@ class CapacitiveDischargeExample(object):
         if step % 1000 != 10:
             return
 
-        if not hasattr(self, "neutral_cont"):
+        if not hasattr(self, "neutral_particles"):
             self.neutral_particles = self.sim.particles.get(self.neutrals.name)
 
         ux_arrays = self.neutral_particles.uxp

--- a/Examples/Physics_applications/capacitive_discharge/inputs_base_1d_picmi.py
+++ b/Examples/Physics_applications/capacitive_discharge/inputs_base_1d_picmi.py
@@ -412,31 +412,29 @@ class CapacitiveDischargeExample(object):
         if not hasattr(self, "neutral_particles"):
             self.neutral_particles = self.sim.particles.get(self.neutrals.name)
 
-        ux_arrays = self.neutral_particles.uxp
-        uy_arrays = self.neutral_particles.uyp
-        uz_arrays = self.neutral_particles.uzp
-
         xp, _ = load_cupy()
 
         vel_std = np.sqrt(constants.kb * self.gas_temp / self.m_ion)
-        for ii in range(len(ux_arrays)):
-            nps = len(ux_arrays[ii])
-            ux_arrays[ii][:] = xp.array(vel_std * self.rng.normal(size=nps))
-            uy_arrays[ii][:] = xp.array(vel_std * self.rng.normal(size=nps))
-            uz_arrays[ii][:] = xp.array(vel_std * self.rng.normal(size=nps))
+        for pti in self.neutral_particles.iterator(level=0):
+            nps = pti.size
+            pti["ux"][:] = xp.array(vel_std * self.rng.normal(size=nps))
+            pti["uy"][:] = xp.array(vel_std * self.rng.normal(size=nps))
+            pti["uz"][:] = xp.array(vel_std * self.rng.normal(size=nps))
 
     def _get_rho_ions(self):
         # deposit the ion density in rho_fp
+        self.rho.set_val(0.0)
         he_ions = self.sim.particles.get("he_ions")
-        he_ions.deposit_charge_density(level=0)
+        he_ions.deposit_charge(self.rho, lev=0)
+        libwarpx.warpx.sync_rho()
 
-        rho_data = self.rho_wrapper[...]
+        rho_data = self.rho[...]
         self.ion_density_array += rho_data / constants.q_e / self.diag_steps
 
     def run_sim(self):
         self.sim.step(self.max_steps - self.diag_steps)
 
-        self.rho_wrapper = self.sim.fields.get("rho_fp", level=0)
+        self.rho = self.sim.fields.get("rho_fp", level=0)
         callbacks.installafterstep(self._get_rho_ions)
 
         self.sim.step(self.diag_steps)
@@ -452,8 +450,10 @@ class CapacitiveDischargeExample(object):
         # to cover that functionality
         if self.test:
             he_ions = self.sim.particles.get("he_ions")
-            nparts = he_ions.get_particle_count(local=True)
-            z_coords = np.concatenate(he_ions.zp)
+            nparts = he_ions.number_of_particles(only_local=True)
+            z_coords = np.concatenate(
+                list(pti["z"] for pti in he_ions.iterator(level=0))
+            )
             assert len(z_coords) == nparts
             assert np.all(z_coords >= 0.0) and np.all(z_coords <= self.gap)
 

--- a/Examples/Physics_applications/laser_acceleration/inputs_test_3d_laser_acceleration_python.py
+++ b/Examples/Physics_applications/laser_acceleration/inputs_test_3d_laser_acceleration_python.py
@@ -18,12 +18,10 @@ def my_simple_callback():
     and
     https://warpx.readthedocs.io/en/latest/usage/workflows/python_extend.html#fields
     """
-    from pywarpx import particle_containers
-
     print("  my_simple_callback")
 
     # electrons: access (and potentially manipulate)
-    electrons = particle_containers.ParticleContainerWrapper("electrons")
+    electrons = sim.particles.get("electrons")
     print(f"    {electrons}")
 
     # electric field: access (and potentially manipulate)
@@ -46,10 +44,10 @@ def my_advanced_callback():
     warpx = sim.extension.warpx
 
     # electrons: access (and potentially manipulate)
-    electrons_pc = warpx.multi_particle_container().get_particle_container_from_name(
+    electrons = warpx.multi_particle_container().get_particle_container_from_name(
         "electrons"
     )
-    print(f"    {electrons_pc}")
+    print(f"    {electrons}")
 
     # electric field: access (and potentially manipulate)
     Ex_mf = sim.fields.get("Efield_fp", dir="x", level=0)

--- a/Examples/Physics_applications/laser_acceleration/inputs_test_3d_laser_acceleration_python.py
+++ b/Examples/Physics_applications/laser_acceleration/inputs_test_3d_laser_acceleration_python.py
@@ -40,13 +40,8 @@ def my_advanced_callback():
     amr = sim.extension.amr
     amr.Print(f"    {amr.ParallelDescriptor.NProcs()} MPI process(es) active")
 
-    # the active simulation
-    warpx = sim.extension.warpx
-
     # electrons: access (and potentially manipulate)
-    electrons = warpx.multi_particle_container().get_particle_container_from_name(
-        "electrons"
-    )
+    electrons = sim.particles.get("electrons")
     print(f"    {electrons}")
 
     # electric field: access (and potentially manipulate)

--- a/Examples/Tests/ohm_solver_ion_Landau_damping/inputs_test_2d_ohm_solver_landau_damping_picmi.py
+++ b/Examples/Tests/ohm_solver_ion_Landau_damping/inputs_test_2d_ohm_solver_landau_damping_picmi.py
@@ -14,7 +14,7 @@ import dill
 import numpy as np
 from mpi4py import MPI as mpi
 
-from pywarpx import callbacks, libwarpx, particle_containers, picmi
+from pywarpx import callbacks, libwarpx, picmi
 
 constants = picmi.constants
 
@@ -254,7 +254,7 @@ class IonLandauDamping(object):
         simulation.initialize_warpx()
 
         # get ion particle container wrapper
-        self.ion_part_container = particle_containers.ParticleContainerWrapper("ions")
+        self.ions = simulation.particles.get("ions")
 
     def text_diag(self):
         """Diagnostic function to print out timing data and particle numbers."""
@@ -269,7 +269,7 @@ class IonLandauDamping(object):
 
         status_dict = {
             "step": step,
-            "nplive ions": self.ion_part_container.nps,
+            "nplive ions": self.ions.size,
             "wall_time": wall_time,
             "step_rate": step_rate,
             "diag_steps": self.diag_steps,

--- a/Examples/Tests/ohm_solver_ion_beam_instability/inputs_test_1d_ohm_solver_ion_beam_picmi.py
+++ b/Examples/Tests/ohm_solver_ion_beam_instability/inputs_test_1d_ohm_solver_ion_beam_picmi.py
@@ -343,8 +343,8 @@ class HybridPICBeamInstability(object):
 
         status_dict = {
             "step": step,
-            "nplive beam ions": self.ion_container.size,
-            "nplive ions": self.beam_ion_container.size,
+            "nplive ions": self.ion_container.size,
+            "nplive beam ions": self.beam_ion_container.size,
             "wall_time": wall_time,
             "step_rate": step_rate,
             "diag_steps": self.diag_steps,

--- a/Examples/Tests/ohm_solver_ion_beam_instability/inputs_test_1d_ohm_solver_ion_beam_picmi.py
+++ b/Examples/Tests/ohm_solver_ion_beam_instability/inputs_test_1d_ohm_solver_ion_beam_picmi.py
@@ -15,7 +15,7 @@ import dill
 import numpy as np
 from mpi4py import MPI as mpi
 
-from pywarpx import callbacks, libwarpx, particle_containers, picmi
+from pywarpx import callbacks, libwarpx, picmi
 
 constants = picmi.constants
 
@@ -315,12 +315,8 @@ class HybridPICBeamInstability(object):
 
         # create particle container wrapper for the ion species to access
         # particle data
-        self.ion_container_wrapper = particle_containers.ParticleContainerWrapper(
-            self.ions.name
-        )
-        self.beam_ion_container_wrapper = particle_containers.ParticleContainerWrapper(
-            self.beam_ions.name
-        )
+        self.ion_container = self.sim.particles.get(self.ions.name)
+        self.beam_ion_container = self.sim.particles.get(self.beam_ions.name)
 
     def _create_data_arrays(self):
         self.prev_time = time.time()
@@ -347,8 +343,8 @@ class HybridPICBeamInstability(object):
 
         status_dict = {
             "step": step,
-            "nplive beam ions": self.ion_container_wrapper.nps,
-            "nplive ions": self.beam_ion_container_wrapper.nps,
+            "nplive beam ions": self.ion_container.size,
+            "nplive ions": self.beam_ion_container.size,
             "wall_time": wall_time,
             "step_rate": step_rate,
             "diag_steps": self.diag_steps,
@@ -383,8 +379,8 @@ class HybridPICBeamInstability(object):
             self._create_data_arrays()
 
         # get the simulation energies
-        Ec_par, Ec_perp = self._get_kinetic_energy(self.ion_container_wrapper)
-        Eb_par, Eb_perp = self._get_kinetic_energy(self.beam_ion_container_wrapper)
+        Ec_par, Ec_perp = self._get_kinetic_energy(self.ion_container)
+        Eb_par, Eb_perp = self._get_kinetic_energy(self.beam_ion_container)
 
         if libwarpx.amr.ParallelDescriptor.MyProc() != 0:
             return

--- a/Examples/Tests/ohm_solver_ion_beam_instability/inputs_test_1d_ohm_solver_ion_beam_picmi.py
+++ b/Examples/Tests/ohm_solver_ion_beam_instability/inputs_test_1d_ohm_solver_ion_beam_picmi.py
@@ -315,8 +315,8 @@ class HybridPICBeamInstability(object):
 
         # create particle container wrapper for the ion species to access
         # particle data
-        self.ion_container = self.sim.particles.get(self.ions.name)
-        self.beam_ion_container = self.sim.particles.get(self.beam_ions.name)
+        self.ion_container = simulation.particles.get(self.ions.name)
+        self.beam_ion_container = simulation.particles.get(self.beam_ions.name)
 
     def _create_data_arrays(self):
         self.prev_time = time.time()
@@ -396,18 +396,17 @@ class HybridPICBeamInstability(object):
     def _get_kinetic_energy(self, container_wrapper):
         """Utility function to retrieve the total kinetic energy in the
         simulation."""
-        try:
-            ux = np.concatenate(container_wrapper.get_particle_ux())
-            uy = np.concatenate(container_wrapper.get_particle_uy())
-            uz = np.concatenate(container_wrapper.get_particle_uz())
-            w = np.concatenate(container_wrapper.get_particle_weight())
-        except ValueError:
-            return 0.0, 0.0
+        my_E_perp = 0
+        my_E_par = 0
+        for pti in container_wrapper.iterator(level=0):
+            ux = pti["ux"]
+            uy = pti["uy"]
+            uz = pti["uz"]
+            w = pti["w"]
+            my_E_perp += 0.5 * self.M * np.sum(w * (ux**2 + uy**2))
+            my_E_par += 0.5 * self.M * np.sum(w * uz**2)
 
-        my_E_perp = 0.5 * self.M * np.sum(w * (ux**2 + uy**2))
         E_perp = comm.allreduce(my_E_perp, op=mpi.SUM)
-
-        my_E_par = 0.5 * self.M * np.sum(w * uz**2)
         E_par = comm.allreduce(my_E_par, op=mpi.SUM)
 
         return E_par, E_perp

--- a/Examples/Tests/particle_boundary_interaction/inputs_test_rz_particle_boundary_interaction_picmi.py
+++ b/Examples/Tests/particle_boundary_interaction/inputs_test_rz_particle_boundary_interaction_picmi.py
@@ -148,16 +148,14 @@ def mirror_reflection():
     nz = concat(buffer.get_particle_scraped_this_step("electrons", "eb", "nz", lev))
 
     # STEP 2: use these parameters to inject particle from the same position in the plasma
-    elect_pc = particle_containers.ParticleContainerWrapper(
-        "electrons"
-    )  # general particle container
+    electrons = sim.particles.get("electrons")  # general particle container
 
     ####this part is specific to the case of simple reflection.
     un = ux * nx + uy * ny + uz * nz
     ux_reflect = -2 * un * nx + ux  # for a "mirror reflection" u(sym)=-2(u.n)n+u
     uy_reflect = -2 * un * ny + uy
     uz_reflect = -2 * un * nz + uz
-    elect_pc.add_particles(
+    electrons.add_particles(
         x=x + (dt - delta_t) * ux_reflect,
         y=y + (dt - delta_t) * uy_reflect,
         z=z + (dt - delta_t) * uz_reflect,

--- a/Examples/Tests/particle_data_python/inputs_test_2d_particle_attr_access_picmi.py
+++ b/Examples/Tests/particle_data_python/inputs_test_2d_particle_attr_access_picmi.py
@@ -4,7 +4,7 @@ import sys
 
 import numpy as np
 
-from pywarpx import callbacks, libwarpx, particle_containers, picmi
+from pywarpx import callbacks, libwarpx, picmi
 
 # Create the parser and add the argument
 parser = argparse.ArgumentParser()
@@ -106,8 +106,8 @@ sim.initialize_warpx()
 # below will be reproducible from run to run
 np.random.seed(30025025)
 
-elec_wrapper = particle_containers.ParticleContainerWrapper("electrons")
-elec_wrapper.add_real_comp("newPid")
+electrons = sim.particles.get("electrons")
+electrons.add_real_comp("newPid")
 
 my_id = libwarpx.amr.ParallelDescriptor.MyProc()
 
@@ -123,7 +123,7 @@ def add_particles():
     w = np.ones(nps) * 2.0
     newPid = 5.0
 
-    elec_wrapper.add_particles(
+    electrons.add_particles(
         x=x,
         y=y,
         z=z,
@@ -149,12 +149,12 @@ sim.step(max_steps - 1)
 # are properly set
 ##########################
 
-assert elec_wrapper.nps == 270 / (2 - args.unique)
-assert elec_wrapper.particle_container.get_real_comp_index("w") == 2
-assert elec_wrapper.particle_container.get_real_comp_index("newPid") == 6
+assert electrons.size == 270 / (2 - args.unique)
+assert electrons.get_real_comp_index("w") == 2
+assert electrons.get_real_comp_index("newPid") == 6
 
-new_pid_vals = elec_wrapper.get_particle_real_arrays("newPid", 0)
-for vals in new_pid_vals:
+for pti in electrons.iterator(level=0):
+    vals = pti["newPid"]
     assert np.allclose(vals, 5)
 
 ##########################

--- a/Examples/Tests/particle_data_python/inputs_test_2d_prev_positions_picmi.py
+++ b/Examples/Tests/particle_data_python/inputs_test_2d_prev_positions_picmi.py
@@ -4,7 +4,7 @@
 
 import numpy as np
 
-from pywarpx import particle_containers, picmi
+from pywarpx import picmi
 
 constants = picmi.constants
 
@@ -107,23 +107,21 @@ sim.step(max_steps - 1)
 # exist
 ##########################
 
-elec_wrapper = particle_containers.ParticleContainerWrapper("electrons")
-elec_count = elec_wrapper.nps
+electrons = sim.particles.get("electrons")
 
 # check that the runtime attributes have the right indices
-assert elec_wrapper.particle_container.get_real_comp_index("prev_x") == 6
-assert elec_wrapper.particle_container.get_real_comp_index("prev_z") == 7
+assert electrons.get_real_comp_index("prev_x") == 6
+assert electrons.get_real_comp_index("prev_z") == 7
 
 # sanity check that the prev_z values are reasonable and
 # that the correct number of values are returned
-prev_z_vals = elec_wrapper.get_particle_real_arrays("prev_z", 0)
 running_count = 0
-
-for z_vals in prev_z_vals:
+for pti in electrons.iterator(level=0):
+    z_vals = pti["prev_z"]
     running_count += len(z_vals)
     assert np.all(z_vals < zmax)
 
-assert running_count == elec_wrapper.get_particle_count(True)
+assert running_count == electrons.number_of_particles(only_local=True)
 
 ##########################
 # take the final sim step

--- a/Examples/Tests/restart/inputs_test_2d_id_cpu_read_picmi.py
+++ b/Examples/Tests/restart/inputs_test_2d_id_cpu_read_picmi.py
@@ -7,7 +7,7 @@ import sys
 
 import numpy as np
 
-from pywarpx import callbacks, particle_containers, picmi
+from pywarpx import callbacks, libwarpx, picmi
 
 ##########################
 # physics parameters
@@ -112,8 +112,8 @@ sim.initialize_warpx()
 np.random.seed(30025025)
 
 # wrap the electrons particle container
-electron_wrapper = particle_containers.ParticleContainerWrapper("electrons")
-electron_wrapper.add_real_comp("newPid")
+electrons = sim.particles.get("electrons")
+electrons.add_real_comp("newPid")
 
 
 def add_particles():
@@ -127,9 +127,7 @@ def add_particles():
     w = np.ones(nps) * 2.0
     newPid = 5.0
 
-    electron_wrapper.add_particles(
-        x=x, y=y, z=z, ux=ux, uy=uy, uz=uz, w=w, newPid=newPid
-    )
+    electrons.add_particles(x=x, y=y, z=z, ux=ux, uy=uy, uz=uz, w=w, newPid=newPid)
 
 
 callbacks.installbeforestep(add_particles)
@@ -145,5 +143,15 @@ sim.step(max_steps)
 # check that the ids and cpus are read properly
 ###############################################
 
-assert np.sum(np.concatenate(electron_wrapper.get_particle_id())) == 5050
-assert np.sum(np.concatenate(electron_wrapper.get_particle_cpu())) == 0
+ids_sum = 0
+cpu_sum = 0
+for pti in electrons.iterator(level=0):
+    idcpu = pti["idcpu"]
+    ids = libwarpx.amr.unpack_ids(idcpu)
+    cpu = libwarpx.amr.unpack_cpus(idcpu)
+
+    ids_sum += np.sum(ids)
+    cpu_sum += np.sum(cpu)
+
+assert ids_sum == 5050
+assert cpu_sum == 0

--- a/Examples/Tests/restart/inputs_test_2d_runtime_components_picmi.py
+++ b/Examples/Tests/restart/inputs_test_2d_runtime_components_picmi.py
@@ -8,7 +8,7 @@ import sys
 
 import numpy as np
 
-from pywarpx import callbacks, particle_containers, picmi
+from pywarpx import callbacks, picmi
 
 ##########################
 # physics parameters
@@ -106,9 +106,9 @@ sim.initialize_warpx()
 # below will be reproducible from run to run
 np.random.seed(30025025)
 
-electron_wrapper = particle_containers.ParticleContainerWrapper("electrons")
+electrons = sim.particles.get("electrons")
 if not sim.amr_restart:
-    electron_wrapper.add_real_comp("newPid")
+    electrons.add_real_comp("newPid")
 
 
 def add_particles():
@@ -122,9 +122,7 @@ def add_particles():
     w = np.ones(nps) * 2.0
     newPid = 5.0
 
-    electron_wrapper.add_particles(
-        x=x, y=y, z=z, ux=ux, uy=uy, uz=uz, w=w, newPid=newPid
-    )
+    electrons.add_particles(x=x, y=y, z=z, ux=ux, uy=uy, uz=uz, w=w, newPid=newPid)
 
 
 callbacks.installbeforestep(add_particles)
@@ -140,12 +138,12 @@ sim.step(max_steps - 1 - step_number)
 # check that the new PIDs are properly set
 ##########################
 
-assert electron_wrapper.nps == 90
-assert electron_wrapper.particle_container.get_real_comp_index("w") == 2
-assert electron_wrapper.particle_container.get_real_comp_index("newPid") == 6
+assert electrons.size == 90
+assert electrons.get_real_comp_index("w") == 2
+assert electrons.get_real_comp_index("newPid") == 6
 
-new_pid_vals = electron_wrapper.get_particle_real_arrays("newPid", 0)
-for vals in new_pid_vals:
+for pti in electrons.iterator(level=0):
+    vals = pti["newPid"]
     assert np.allclose(vals, 5)
 
 ##########################

--- a/Examples/Tests/secondary_ion_emission/inputs_test_rz_secondary_ion_emission_picmi.py
+++ b/Examples/Tests/secondary_ion_emission/inputs_test_rz_secondary_ion_emission_picmi.py
@@ -185,7 +185,7 @@ def secondary_emission():
     # STEP 1: extract the different parameters of the boundary buffer (normal, time, position)
     lev = 0  # level 0 (no mesh refinement here)
     n = buffer.get_particle_boundary_buffer_size("ions", "eb")
-    elect_pc = particle_containers.ParticleContainerWrapper("electrons")
+    electrons = sim.particles.get("electrons")
 
     if n != 0:
         r = concat(buffer.get_particle_scraped_this_step("ions", "eb", "r", lev))
@@ -252,7 +252,7 @@ def secondary_emission():
                 we = np.append(we, w[i])
                 delta_te = np.append(delta_te, delta_t[i])
 
-                elect_pc.add_particles(
+                electrons.add_particles(
                     x=xe + (dt - delta_te) * uxe,
                     y=ye + (dt - delta_te) * uye,
                     z=ze + (dt - delta_te) * uze,

--- a/Python/pywarpx/WarpX.py
+++ b/Python/pywarpx/WarpX.py
@@ -164,6 +164,10 @@ class WarpX(Bucket):
     def fields(self):
         return libwarpx.warpx.multifab_register()
 
+    @property
+    def particles(self):
+        return libwarpx.warpx.multi_particle_container()
+
     def evolve(self, nsteps=-1):
         libwarpx.warpx.evolve(nsteps)
 

--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -134,12 +134,16 @@ class LibWarpX:
         from .extensions.MultiFabRegister import (
             register_warpx_MultiFabRegister_extension,
         )
+        from .extensions.MultiParticleContainer import (
+            register_warpx_MultiParticleContainer_extension,
+        )
         from .extensions.WarpXParticleContainer import (
             register_warpx_WarpXParticleContainer_extension,
         )
 
         register_warpx_MultiFab_extension(self.amr)
         register_warpx_MultiFabRegister_extension(self.libwarpx_so)
+        register_warpx_MultiParticleContainer_extension(self.libwarpx_so)
         register_warpx_WarpXParticleContainer_extension(self.libwarpx_so)
 
     def amrex_init(self, argv, mpi_comm=None):

--- a/Python/pywarpx/extensions/MultiParticleContainer.py
+++ b/Python/pywarpx/extensions/MultiParticleContainer.py
@@ -1,0 +1,29 @@
+"""
+This file is part of WarpX
+
+Copyright 2024 WarpX community
+Authors: Axel Huebl, David Grote
+License: BSD-3-Clause-LBNL
+"""
+
+
+def get_particle_container_from_name(self, name):
+    """Deprecated alias for get"""
+    import warnings
+
+    warnings.warn(
+        "get_particle_container_from_name is deprecated. Use get instead.",
+        UserWarning,
+        stacklevel=2,
+    )
+
+    return self.get(name)
+
+
+def register_warpx_MultiParticleContainer_extension(libwarpx_so):
+    """MultiParticleContainer helper methods"""
+
+    # Register additional methods
+    libwarpx_so.WarpXParticleContainer.get_particle_container_from_name = (
+        get_particle_container_from_name
+    )

--- a/Python/pywarpx/particle_containers.py
+++ b/Python/pywarpx/particle_containers.py
@@ -25,6 +25,15 @@ class ParticleContainerWrapper(object):
         self.name = species_name
         self._particle_container = None
 
+        import warnings
+
+        warnings.warn(
+            f'ParticleContainerWrapper("{species_name}") is deprecated. '
+            f'Use sim.particles.get("{species_name}") instead.',
+            UserWarning,
+            stacklevel=2,
+        )
+
     @property
     def particle_container(self):
         if self._particle_container is None:

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -3420,6 +3420,14 @@ class Simulation(picmistandard.PICMI_Simulation):
         """
         return self.extension.warpx.multifab_register()
 
+    @property
+    def particles(self):
+        """
+        This is a convenience property that returns the MultiParticleContainer, allowing
+        easy fetching of the WarpXParticleContainer instances.
+        """
+        return self.extension.warpx.multi_particle_container()
+
 
 # ----------------------------
 # Simulation frame diagnostics

--- a/Source/Python/Particles/MultiParticleContainer.cpp
+++ b/Source/Python/Particles/MultiParticleContainer.cpp
@@ -15,7 +15,7 @@
 void init_MultiParticleContainer (py::module& m)
 {
     py::class_<MultiParticleContainer>(m, "MultiParticleContainer")
-        .def("get_particle_container_from_name",
+        .def("get",
             &MultiParticleContainer::GetParticleContainerFromName,
             py::arg("name"),
             py::return_value_policy::reference_internal

--- a/Source/Python/Particles/WarpXParticleContainer.cpp
+++ b/Source/Python/Particles/WarpXParticleContainer.cpp
@@ -29,10 +29,6 @@ void init_WarpXParticleContainer (py::module& m)
         amrex::ParticleContainerPureSoA<PIdx::nattribs, 0>
     > wpc (m, "WarpXParticleContainer");
     wpc
-        .def("add_real_comp",
-            [](WarpXParticleContainer& pc, const std::string& name, bool comm) { pc.AddRealComp(name, comm); },
-            py::arg("name"), py::arg("comm")
-        )
         .def("add_n_particles",
             [](WarpXParticleContainer& pc, int lev,
                 int n, py::array_t<double> &x,
@@ -100,14 +96,6 @@ void init_WarpXParticleContainer (py::module& m)
                 return pc.GetIntCompIndex(comp_name);
             },
             py::arg("comp_name")
-        )
-        .def("num_local_tiles_at_level",
-            &WarpXParticleContainer::numLocalTilesAtLevel,
-            py::arg("level")
-        )
-        .def("total_number_of_particles",
-            &WarpXParticleContainer::TotalNumberOfParticles,
-            py::arg("valid_particles_only"), py::arg("local")
         )
         .def("sum_particle_weight",
             &WarpXParticleContainer::sumParticleWeight,

--- a/dependencies.json
+++ b/dependencies.json
@@ -4,6 +4,6 @@
     "version_pyamrex": "25.10",
     "version_picsar": "25.06",
     "commit_amrex": "3c1f1c78f60530e4ee17f766cf195c2c776f7b00",
-    "commit_pyamrex": "f56da4a68868bc2eabf28a611d76315526ffabee",
+    "commit_pyamrex": "49c917f552e19aa6fad690dfe53f41e42514f858",
     "commit_picsar": "0c329e66010267662a82219f7de7abbd231463f4"
 }


### PR DESCRIPTION
Modernize examples to use the new `sim.particles` access to `MultiParticleContainer` directly.