### PR TITLE
[WIP] Deduplicate Moving Window Logic

### DIFF
--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -529,15 +529,41 @@ Diagnostics::InitBaseData ()
     m_all_field_functors.resize( nmax_lev );
 
     // For restart, move the m_lo and m_hi of the diag consistent with the
-    // current moving_window location
-    if (WarpX::do_moving_window) {
+    // current moving_window location. Account for start_moving_window_step and
+    // end_moving_window_step to only shift based on steps where the window was active.
+    if (WarpX::do_moving_window && warpx.getistep(0) > 0) {
         const int moving_dir = WarpX::moving_window_dir;
-        const amrex::Real displacement =
-            warpx.getmoving_window_x() - warpx.Geom(0).ProbLo(moving_dir);
-        const int shift_num_base = static_cast<int>
-            (displacement / warpx.Geom(0).CellSize(moving_dir));
-        m_lo[moving_dir] += shift_num_base * warpx.Geom(0).CellSize(moving_dir);
-        m_hi[moving_dir] += shift_num_base * warpx.Geom(0).CellSize(moving_dir);
+        const int current_step = warpx.getistep(0);
+
+        // Calculate how many steps the moving window has been active up to current_step
+        // This accounts for start_moving_window_step and end_moving_window_step
+        int active_steps = 0;
+        const int start_step = WarpX::start_moving_window_step;
+        const int end_step = (WarpX::end_moving_window_step < 0) ?
+            current_step : std::min(WarpX::end_moving_window_step, current_step);
+
+        if (end_step >= start_step && current_step >= start_step) {
+            // Count steps from start_step to min(end_step, current_step - 1)
+            // Note: current_step is the checkpoint step, but the replay loop goes from 0 to current_step - 1
+            // So we need to count steps up to current_step - 1, not current_step
+            const int last_replayed_step = current_step - 1;
+            const int effective_end_step = std::min(end_step, last_replayed_step);
+            if (effective_end_step >= start_step) {
+                active_steps = effective_end_step - start_step + 1;
+            }
+        }
+
+        if (active_steps > 0) {
+            // Calculate the shift based on the number of active steps
+            const amrex::Real shift_per_step = (WarpX::moving_window_v - WarpX::beta_boost * PhysConst::c)
+                                             / (1._rt - WarpX::moving_window_v * WarpX::beta_boost / PhysConst::c)
+                                             * warpx.getdt(0);
+            const amrex::Real total_shift = active_steps * shift_per_step;
+            const int shift_num_base = static_cast<int>
+                (total_shift / warpx.Geom(0).CellSize(moving_dir));
+            m_lo[moving_dir] += shift_num_base * warpx.Geom(0).CellSize(moving_dir);
+            m_hi[moving_dir] += shift_num_base * warpx.Geom(0).CellSize(moving_dir);
+        }
     }
     // Construct Flush class.
     if        (m_format == "plotfile"){

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -541,10 +541,11 @@ Diagnostics::InitBaseData ()
         const amrex::Real total_shift = WarpX::CalculateMovingWindowShift(0, last_replayed_step, warpx.getdt(0));
 
         if (total_shift > 0.0_rt) {
-            const int shift_num_base = static_cast<int>
-                (total_shift / warpx.Geom(0).CellSize(moving_dir));
-            m_lo[moving_dir] += shift_num_base * warpx.Geom(0).CellSize(moving_dir);
-            m_hi[moving_dir] += shift_num_base * warpx.Geom(0).CellSize(moving_dir);
+            // Use the unified helper function to calculate physical shift aligned to cell boundaries
+            const amrex::Real physical_shift = WarpX::CalculateMovingWindowAlignedShift(
+                total_shift, warpx.Geom(0).CellSize(moving_dir));
+            m_lo[moving_dir] += physical_shift;
+            m_hi[moving_dir] += physical_shift;
         }
     }
     // Construct Flush class.

--- a/Source/Diagnostics/Diagnostics.cpp
+++ b/Source/Diagnostics/Diagnostics.cpp
@@ -535,30 +535,12 @@ Diagnostics::InitBaseData ()
         const int moving_dir = WarpX::moving_window_dir;
         const int current_step = warpx.getistep(0);
 
-        // Calculate how many steps the moving window has been active up to current_step
-        // This accounts for start_moving_window_step and end_moving_window_step
-        int active_steps = 0;
-        const int start_step = WarpX::start_moving_window_step;
-        const int end_step = (WarpX::end_moving_window_step < 0) ?
-            current_step : std::min(WarpX::end_moving_window_step, current_step);
+        // Note: current_step is the checkpoint step, but the replay loop goes from 0 to current_step - 1
+        // So we need to calculate the shift for steps 0 to current_step - 1
+        const int last_replayed_step = current_step - 1;
+        const amrex::Real total_shift = WarpX::CalculateMovingWindowShift(0, last_replayed_step, warpx.getdt(0));
 
-        if (end_step >= start_step && current_step >= start_step) {
-            // Count steps from start_step to min(end_step, current_step - 1)
-            // Note: current_step is the checkpoint step, but the replay loop goes from 0 to current_step - 1
-            // So we need to count steps up to current_step - 1, not current_step
-            const int last_replayed_step = current_step - 1;
-            const int effective_end_step = std::min(end_step, last_replayed_step);
-            if (effective_end_step >= start_step) {
-                active_steps = effective_end_step - start_step + 1;
-            }
-        }
-
-        if (active_steps > 0) {
-            // Calculate the shift based on the number of active steps
-            const amrex::Real shift_per_step = (WarpX::moving_window_v - WarpX::beta_boost * PhysConst::c)
-                                             / (1._rt - WarpX::moving_window_v * WarpX::beta_boost / PhysConst::c)
-                                             * warpx.getdt(0);
-            const amrex::Real total_shift = active_steps * shift_per_step;
+        if (total_shift > 0.0_rt) {
             const int shift_num_base = static_cast<int>
                 (total_shift / warpx.Geom(0).CellSize(moving_dir));
             m_lo[moving_dir] += shift_num_base * warpx.Geom(0).CellSize(moving_dir);

--- a/Source/Diagnostics/FullDiagnostics.cpp
+++ b/Source/Diagnostics/FullDiagnostics.cpp
@@ -1004,16 +1004,17 @@ FullDiagnostics::MovingWindowAndGalileanDomainShift (int step)
         const amrex::Real* cur_lo = m_geom_output[0][0].ProbLo();
         const amrex::Real* cur_hi = m_geom_output[0][0].ProbHi();
         const amrex::Real* geom_dx = m_geom_output[0][0].CellSize();
-        const auto num_shift_base = static_cast<int>((moving_window_x - cur_lo[moving_dir])
-                                              / geom_dx[moving_dir]);
+        // Use the unified helper function to calculate physical shift aligned to cell boundaries
+        const amrex::Real physical_shift_raw = moving_window_x - cur_lo[moving_dir];
+        const amrex::Real physical_shift = WarpX::CalculateMovingWindowAlignedShift(physical_shift_raw, geom_dx[moving_dir]);
         // Update the diagnostic geom domain. Note that this is done only for the
         // base level 0 because m_geom_output[0][lev] share the same static RealBox
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             new_lo[idim] = cur_lo[idim];
             new_hi[idim] = cur_hi[idim];
         }
-        new_lo[moving_dir] = cur_lo[moving_dir] + num_shift_base*geom_dx[moving_dir];
-        new_hi[moving_dir] = cur_hi[moving_dir] + num_shift_base*geom_dx[moving_dir];
+        new_lo[moving_dir] = cur_lo[moving_dir] + physical_shift;
+        new_hi[moving_dir] = cur_hi[moving_dir] + physical_shift;
         // Update RealBox of geometry with shifted domain geometry for moving-window
         for (int lev = 0; lev < nmax_lev; ++lev) {
             // Note that Full diagnostics has only one snapshot, m_num_buffers = 1

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -353,6 +353,46 @@ namespace
 
 }
 
+amrex::Real
+WarpX::CalculateMovingWindowShiftPerStep (amrex::Real dt)
+{
+    // Calculate the shift per step (same formula as used in MoveWindow)
+    return (moving_window_v - beta_boost * PhysConst::c)
+         / (1._rt - moving_window_v * beta_boost / PhysConst::c)
+         * dt;
+}
+
+amrex::Real
+WarpX::CalculateMovingWindowShift (int start_step, int end_step, amrex::Real dt)
+{
+    if (!do_moving_window || start_step > end_step) {
+        return 0.0_rt;
+    }
+
+    // Calculate how many steps the moving window was active between start_step and end_step
+    int active_steps = 0;
+    const int window_start = start_moving_window_step;
+    const int window_end = (end_moving_window_step < 0) ?
+        end_step : std::min(end_moving_window_step, end_step);
+
+    if (window_end >= window_start && end_step >= window_start) {
+        // Count steps from max(window_start, start_step) to min(window_end, end_step)
+        const int effective_start = std::max(window_start, start_step);
+        const int effective_end = std::min(window_end, end_step);
+        if (effective_end >= effective_start) {
+            active_steps = effective_end - effective_start + 1;
+        }
+    }
+
+    if (active_steps > 0) {
+        // Use the unified shift-per-step calculation
+        const amrex::Real shift_per_step = CalculateMovingWindowShiftPerStep(dt);
+        return active_steps * shift_per_step;
+    }
+
+    return 0.0_rt;
+}
+
 int
 WarpX::MoveWindow (const int step, bool move_j)
 {
@@ -363,17 +403,24 @@ WarpX::MoveWindow (const int step, bool move_j)
 
     bool const skip_lev0_coarse_patch = true;
 
+    // All logic for determining if the moving window should be active is centralized here.
+    // This includes checking start_moving_window_step, end_moving_window_step, and do_moving_window.
+    // Callers should not need to check these externally - just call MoveWindow and it will
+    // return 0 if the window is not active for this step.
+    if (!moving_window_active(step)) { return 0; }
+
+    // Print messages when starting/stopping the moving window
     if (step == start_moving_window_step) {
         amrex::Print() << Utils::TextMsg::Info("Starting moving window");
     }
     if (step == end_moving_window_step) {
         amrex::Print() << Utils::TextMsg::Info("Stopping moving window");
     }
-    if (!moving_window_active(step)) { return 0; }
 
     // Update the continuous position of the moving window,
     // and of the plasma injection
-    moving_window_x += (moving_window_v - WarpX::beta_boost * PhysConst::c)/(1 - moving_window_v * WarpX::beta_boost / PhysConst::c) * dt[0];
+    // Use the unified shift-per-step calculation
+    moving_window_x += CalculateMovingWindowShiftPerStep(dt[0]);
     const int dir = moving_window_dir;
 
     // Update current injection position for all containers

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -363,6 +363,15 @@ WarpX::CalculateMovingWindowShiftPerStep (amrex::Real dt)
 }
 
 amrex::Real
+WarpX::CalculateMovingWindowAlignedShift (amrex::Real total_shift, amrex::Real cell_size)
+{
+    // Convert physical shift to cell-based shift, then back to physical units
+    // This ensures the result is aligned to cell boundaries
+    const int cell_shift = static_cast<int>(total_shift / cell_size);
+    return cell_shift * cell_size;
+}
+
+amrex::Real
 WarpX::CalculateMovingWindowShift (int start_step, int end_step, amrex::Real dt)
 {
     if (!do_moving_window || start_step > end_step) {
@@ -436,9 +445,14 @@ WarpX::MoveWindow (const int step, bool move_j)
     const amrex::Real* current_lo = geom[0].ProbLo();
     const amrex::Real* current_hi = geom[0].ProbHi();
     const amrex::Real* cdx = geom[0].CellSize();
-    const int num_shift_base = static_cast<int>((moving_window_x - current_lo[dir]) / cdx[dir]);
+    // Use the unified helper function to calculate physical shift aligned to cell boundaries
+    const amrex::Real physical_shift_raw = moving_window_x - current_lo[dir];
+    const amrex::Real physical_shift = CalculateMovingWindowAlignedShift(physical_shift_raw, cdx[dir]);
 
-    if (num_shift_base == 0) { return 0; }
+    if (physical_shift == 0.0_rt) { return 0; }
+
+    // Calculate the cell-based shift for mesh field operations
+    const int num_shift_base = static_cast<int>(physical_shift_raw / cdx[dir]);
 
     // update the problem domain. Note the we only do this on the base level because
     // amrex::Geometry objects share the same, static RealBox.
@@ -446,8 +460,8 @@ WarpX::MoveWindow (const int step, bool move_j)
         new_lo[i] = current_lo[i];
         new_hi[i] = current_hi[i];
     }
-    new_lo[dir] = current_lo[dir] + num_shift_base * cdx[dir];
-    new_hi[dir] = current_hi[dir] + num_shift_base * cdx[dir];
+    new_lo[dir] = current_lo[dir] + physical_shift;
+    new_hi[dir] = current_hi[dir] + physical_shift;
 
     ResetProbDomain(amrex::RealBox(new_lo, new_hi));
 
@@ -463,10 +477,11 @@ WarpX::MoveWindow (const int step, bool move_j)
             new_slice_lo[i] = current_slice_lo[i];
             new_slice_hi[i] = current_slice_hi[i];
         }
-        const int num_shift_base_slice = static_cast<int> ((moving_window_x -
-                                   current_slice_lo[dir]) / cdx[dir]);
-        new_slice_lo[dir] = current_slice_lo[dir] + num_shift_base_slice*cdx[dir];
-        new_slice_hi[dir] = current_slice_hi[dir] + num_shift_base_slice*cdx[dir];
+        // Use the unified helper function to calculate physical shift aligned to cell boundaries
+        const amrex::Real physical_shift_slice_raw = moving_window_x - current_slice_lo[dir];
+        const amrex::Real physical_shift_slice = CalculateMovingWindowAlignedShift(physical_shift_slice_raw, cdx[dir]);
+        new_slice_lo[dir] = current_slice_lo[dir] + physical_shift_slice;
+        new_slice_hi[dir] = current_slice_hi[dir] + physical_shift_slice;
         slice_realbox.setLo(new_slice_lo);
         slice_realbox.setHi(new_slice_hi);
     }

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -766,6 +766,18 @@ public:
      */
     static amrex::Real CalculateMovingWindowShiftPerStep (amrex::Real dt);
 
+    /** Calculate physical shift aligned to cell boundaries for the moving window direction
+     *
+     * This function takes a total physical shift and returns the physical shift amount
+     * aligned to cell boundaries. It converts the shift to cell-based units and back
+     * to physical units, ensuring the result is aligned to cell boundaries.
+     *
+     * @param total_shift Total shift amount in physical units
+     * @param cell_size Cell size in the moving window direction
+     * @return Physical shift amount aligned to cell boundaries
+     */
+    static amrex::Real CalculateMovingWindowAlignedShift (amrex::Real total_shift, amrex::Real cell_size);
+
     /** Calculate the total shift for the moving window based on active steps
      *
      * This function calculates how many steps the moving window was active

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -756,6 +756,29 @@ public:
         bool const step_after_start = (step >= start_moving_window_step);
         return do_moving_window && step_before_end && step_after_start;
     }
+    /** Calculate the shift per step for the moving window
+     *
+     * This function calculates how much the moving window shifts in one timestep.
+     * This is the same calculation used in MoveWindow.
+     *
+     * @param dt Timestep size
+     * @return Shift per step in physical units
+     */
+    static amrex::Real CalculateMovingWindowShiftPerStep (amrex::Real dt);
+
+    /** Calculate the total shift for the moving window based on active steps
+     *
+     * This function calculates how many steps the moving window was active
+     * between start_step (inclusive) and end_step (inclusive), accounting for
+     * start_moving_window_step and end_moving_window_step, and returns the
+     * total shift that would occur over those active steps.
+     *
+     * @param start_step First step to consider (inclusive)
+     * @param end_step Last step to consider (inclusive)
+     * @param dt Timestep size
+     * @return Total shift in physical units
+     */
+    static amrex::Real CalculateMovingWindowShift (int start_step, int end_step, amrex::Real dt);
     static int moving_window_dir;
     static amrex::Real moving_window_v;
     static bool fft_do_time_averaging;


### PR DESCRIPTION
The math of a variable-window and variable-start/stop moving window is duplicated partly over the code base. This caused bugs. Refactoring to avoid bugs in the future.

- [x] vibe refactor
- [ ] rebase after #6399
- [ ] clean up