### PR TITLE
Pip Install: Skip `diags/`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,3 +9,9 @@ recursive-include Python *
 # see .gitignore
 prune cmake-build*
 prune .spack-env*
+
+# exclude diagnostics output directories (see .gitignore)
+prune diags
+prune diags.*
+prune **/diags
+prune **/diags.*

--- a/setup.py
+++ b/setup.py
@@ -44,10 +44,14 @@ class CopyPreBuild(build):
                 "PYWARPX_LIB_DIR='{}'".format(PYWARPX_LIB_DIR)
             )
 
-        # copy external libs into collection of files in a temporary build dir
+        # copy Python module artifacts and sources
         dst_path = os.path.join(self.build_lib, "pywarpx")
-        for lib_path in libs_found:
-            shutil.copy(lib_path, dst_path)
+        shutil.copytree(
+            PYWARPX_LIB_DIR,
+            dst_path,
+            dirs_exist_ok=True,
+            ignore=shutil.ignore_patterns("diags", "diags.*"),
+        )
 
 
 class CMakeExtension(Extension):


### PR DESCRIPTION
## Summary

- Exclude diagnostics output directories (`diags/`) from pip wheels (`--target pip_install`)  and source distributions (`sdist`), so they are not accidentally bundled into pip packages.

See https://github.com/BLAST-ImpactX/impactx/issues/1294
See https://github.com/BLAST-ImpactX/impactx/pull/1296

Made with [Cursor](https://cursor.com) based on the ImpactX PR of the same kind.