### PR TITLE
Doc: Perlmutter Python Batch Script

### DIFF
--- a/Docs/source/install/hpc/perlmutter.rst
+++ b/Docs/source/install/hpc/perlmutter.rst
@@ -233,8 +233,11 @@ Running
    .. tab-item:: A100 (40GB) GPUs
 
       The batch script below can be used to run a WarpX simulation on multiple nodes (change ``-N`` accordingly) on the supercomputer Perlmutter at NERSC.
-      This partition as up to `1536 nodes <https://docs.nersc.gov/systems/perlmutter/architecture/>`__.
+      This partition has up to `1536 nodes <https://docs.nersc.gov/systems/perlmutter/architecture/>`__.
 
+      The batch script is set up for Python (PICMI) by default (``EXE=python3``, ``INPUTS=run_script.py``).
+      To use the WarpX executable instead, edit the script and comment the Python lines and uncomment the ``EXE``/``INPUTS`` lines.
+      Source your ``perlmutter_gpu_warpx.profile`` before submitting (the script will try to source it if you forgot).
       Replace descriptions between chevrons ``<>`` by relevant values, for instance ``<input file>`` could be ``plasma_mirror_inputs``.
       Note that we run one MPI rank per GPU.
 
@@ -259,7 +262,8 @@ Running
 
    .. tab-item:: CPU Nodes
 
-      The Perlmutter CPU partition as up to `3072 nodes <https://docs.nersc.gov/systems/perlmutter/architecture/>`__, each with 2x AMD EPYC 7763 CPUs.
+      The Perlmutter CPU partition has up to `3072 nodes <https://docs.nersc.gov/systems/perlmutter/architecture/>`__, each with 2x AMD EPYC 7763 CPUs.
+      The batch script is set up for Python (PICMI) by default; to use the executable instead, edit ``EXE``/``INPUTS``. Source your ``perlmutter_cpu_warpx.profile`` before submitting (the script will try to source it if you forgot).
 
       .. literalinclude:: ../../../../Tools/machines/perlmutter-nersc/perlmutter_cpu.sbatch
          :language: bash

--- a/Tools/machines/perlmutter-nersc/perlmutter_cpu.sbatch
+++ b/Tools/machines/perlmutter-nersc/perlmutter_cpu.sbatch
@@ -20,9 +20,21 @@
 #SBATCH -o WarpX.o%j
 #SBATCH -e WarpX.e%j
 
-# executable & inputs file or python interpreter & PICMI script here
-EXE=./warpx
-INPUTS=inputs_small
+# python interpreter & script here
+EXE=python3
+INPUTS=run_script.py
+# or executable & inputs file
+#EXE=./warpx
+#INPUTS=inputs_small
+
+# environment setup
+if [[ -z "${MY_PROFILE}" ]]; then
+    echo "WARNING: FORGOT TO"
+    echo "   source $HOME/perlmutter_cpu_warpx.profile"
+    echo "before submission. Doing that now."
+
+    source $HOME/perlmutter_cpu_warpx.profile
+fi
 
 # each CPU node on Perlmutter (NERSC) has 64 hardware cores with
 # 2x Hyperthreading/SMP

--- a/Tools/machines/perlmutter-nersc/perlmutter_gpu.sbatch
+++ b/Tools/machines/perlmutter-nersc/perlmutter_gpu.sbatch
@@ -25,9 +25,21 @@
 #SBATCH -o WarpX.o%j
 #SBATCH -e WarpX.e%j
 
-# executable & inputs file or python interpreter & PICMI script here
-EXE=./warpx
-INPUTS=inputs
+# python interpreter & script here
+EXE=python3
+INPUTS=run_script.py
+# or executable & inputs file
+#EXE=./warpx
+#INPUTS=inputs
+
+# environment setup
+if [[ -z "${MY_PROFILE}" ]]; then
+    echo "WARNING: FORGOT TO"
+    echo "   source $HOME/perlmutter_gpu_warpx.profile"
+    echo "before submission. Doing that now."
+
+    source $HOME/perlmutter_gpu_warpx.profile
+fi
 
 # pin to closest NIC to GPU
 export MPICH_OFI_NIC_POLICY=GPU
@@ -37,11 +49,11 @@ export MPICH_OFI_NIC_POLICY=GPU
 export OMP_NUM_THREADS=16
 
 # GPU-aware MPI optimizations
-GPU_AWARE_MPI="amrex.use_gpu_aware_mpi=1"
+export AMREX_DEFAULT_INIT="amrex.use_gpu_aware_mpi=1"
 
 # CUDA visible devices are ordered inverse to local task IDs
 #   Reference: nvidia-smi topo -m
 srun --cpu-bind=cores bash -c "
     export CUDA_VISIBLE_DEVICES=\$((3-SLURM_LOCALID));
-    ${EXE} ${INPUTS} ${GPU_AWARE_MPI}" \
+    ${EXE} ${INPUTS}" \
   > output.txt


### PR DESCRIPTION
Perlmutter (NERSC): Make HPC batch templates portable to Python & executable usage alike.
Put Python first as in the rest of the docs.
Add fallback if a user forgot to source their profile.

### Background

Just developed and merged in ImpactX: https://github.com/BLAST-ImpactX/impactx/pull/1301

See also improved AMReX docs in https://github.com/AMReX-Codes/amrex/pull/4974