### PR TITLE
fix volume element in binary collisions for non-planar geometries.

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -318,13 +318,15 @@ public:
         amrex::Geometry const& geom_lev = WarpX::GetInstance().Geom(lev);
         // dV is level-specific: cell volume at this refinement level (smaller on fine levels).
         amrex::ParticleReal const dV = AMREX_D_TERM(geom_lev.CellSize(0), *geom_lev.CellSize(1), *geom_lev.CellSize(2));
-#if defined(WARPX_DIM_RZ)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
         amrex::Box const& cbx = mfi.tilebox(amrex::IntVect::TheZeroVector()); //Cell-centered box
+#if defined(WARPX_DIM_RZ)
         auto const lo = lbound(cbx);
         auto const hi = ubound(cbx);
         int const nz = hi.y - lo.y + 1;
 #endif
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+        amrex::XDim3 const xyzmin = WarpX::LowerCorner(cbx, lev, 0._rt);
+        amrex::Real const rmin = xyzmin.x;
         auto const dr = geom_lev.CellSize(0);
 #endif
 
@@ -333,18 +335,18 @@ public:
             // Return the radial factor for the volume element, dV
             int const ri = (i_cell - i_cell%nz)/nz;
             // rr is radius at the cell center
-            amrex::ParticleReal const rr = (ri + 0.5_prt)*dr;
+            amrex::ParticleReal const rr = rmin + (ri + 0.5_prt)*dr;
             return 2.0_prt*static_cast<amrex::ParticleReal>(MathConst::pi)*rr;
 #elif defined(WARPX_DIM_RCYLINDER)
             int const ri = i_cell;
             // rr is radius at the cell center
-            amrex::ParticleReal const rr = (ri + 0.5_prt)*dr;
+            amrex::ParticleReal const rr = rmin + (ri + 0.5_prt)*dr;
             return 2.0_prt*static_cast<amrex::ParticleReal>(MathConst::pi)*rr;
 #elif defined(WARPX_DIM_RSPHERE)
             // This needs double checking
             int const ri = i_cell;
             // rr is radius at the cell center
-            amrex::ParticleReal const rr = (ri + 0.5_prt)*dr;
+            amrex::ParticleReal const rr = rmin + (ri + 0.5_prt)*dr;
             return 4.0_prt*static_cast<amrex::ParticleReal>(MathConst::pi)*rr*rr;
 #else
             // No factor is needed for Cartesian

--- a/Source/Particles/Collision/BinaryCollision/Bremsstrahlung/BremsstrahlungFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/Bremsstrahlung/BremsstrahlungFunc.H
@@ -118,7 +118,7 @@ public:
 
             index_type pair_index = cell_start_pair + coll_idx;
 
-#if (defined WARPX_DIM_RZ)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
             amrex::ParticleReal * const AMREX_RESTRICT theta1 = soa_1.m_rdata[PIdx::theta];
             amrex::ParticleReal * const AMREX_RESTRICT theta2 = soa_2.m_rdata[PIdx::theta];
 #endif
@@ -132,8 +132,8 @@ public:
             for (index_type k = coll_idx; k < max_N; k += min_N)
             {
 
-#if (defined WARPX_DIM_RZ)
-                /* In RZ geometry, macroparticles can collide with other macroparticles
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
+                /* In RZ and RCYLINDER geometry, macroparticles can collide with other macroparticles
                  * in the same *cylindrical* cell. For this reason, collisions between macroparticles
                  * are actually not local in space. In this case, the underlying assumption is that
                  * particles within the same cylindrical cell represent a cylindrically-symmetry
@@ -155,7 +155,7 @@ public:
                     p_pair_reaction_weight, p_product_data,
                     engine);
 
-#if (defined WARPX_DIM_RZ)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
                 amrex::ParticleReal const u1xbuf_new = u1x[I1[i1]];
                 u1x[I1[i1]] = u1xbuf_new*std::cos(-theta) - u1y[I1[i1]]*std::sin(-theta);
                 u1y[I1[i1]] = u1xbuf_new*std::sin(-theta) + u1y[I1[i1]]*std::cos(-theta);

--- a/Source/Particles/Collision/BinaryCollision/Coulomb/ElasticCollisionPerez.H
+++ b/Source/Particles/Collision/BinaryCollision/Coulomb/ElasticCollisionPerez.H
@@ -12,7 +12,7 @@
 #include "Utils/WarpXConst.H"
 
 #include <AMReX_Random.H>
-
+#include <iostream>
 
 /** Prepare information for and call UpdateMomentumPerezElastic().
  *
@@ -91,7 +91,7 @@ void ElasticCollisionPerez (
     // set max cross section based on mfp = atomic spacing
     const T_PR sigma_max = T_PR(1.0) / (maxn * rmin);
 
-#if (defined WARPX_DIM_RZ)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
     T_PR * const AMREX_RESTRICT theta1 = soa_1.m_rdata[PIdx::theta];
     T_PR * const AMREX_RESTRICT theta2 = soa_2.m_rdata[PIdx::theta];
 #endif
@@ -105,7 +105,7 @@ void ElasticCollisionPerez (
       // stride (smaller set size) until we do all collisions (larger set size)
       for (T_index k = coll_idx; k < max_N; k += min_N)
       {
-#if (defined WARPX_DIM_RZ)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
           /* In RZ geometry, macroparticles can collide with other macroparticles
            * in the same *cylindrical* cell. For this reason, collisions between macroparticles
            * are actually not local in space. In this case, the underlying assumption is that
@@ -138,7 +138,7 @@ void ElasticCollisionPerez (
               q1, m1, w1[ I1[i1] ], q2, m2, w2[ I2[i2] ],
               n12, sigma_max, L, bmax, dt, engine );
 
-#if (defined WARPX_DIM_RZ)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
           T_PR const u1xbuf_new = u1x[I1[i1]];
           u1x[I1[i1]] = u1xbuf_new*std::cos(-theta) - u1y[I1[i1]]*std::sin(-theta);
           u1y[I1[i1]] = u1xbuf_new*std::sin(-theta) + u1y[I1[i1]]*std::cos(-theta);

--- a/Source/Particles/Collision/BinaryCollision/Coulomb/ElasticCollisionPerez.H
+++ b/Source/Particles/Collision/BinaryCollision/Coulomb/ElasticCollisionPerez.H
@@ -105,7 +105,7 @@ void ElasticCollisionPerez (
       for (T_index k = coll_idx; k < max_N; k += min_N)
       {
 #if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-          /* In RZ geometry, macroparticles can collide with other macroparticles
+          /* In RZ and RCYLINDER geometry, macroparticles can collide with other macroparticles
            * in the same *cylindrical* cell. For this reason, collisions between macroparticles
            * are actually not local in space. In this case, the underlying assumption is that
            * particles within the same cylindrical cell represent a cylindrically-symmetry

--- a/Source/Particles/Collision/BinaryCollision/Coulomb/ElasticCollisionPerez.H
+++ b/Source/Particles/Collision/BinaryCollision/Coulomb/ElasticCollisionPerez.H
@@ -12,7 +12,6 @@
 #include "Utils/WarpXConst.H"
 
 #include <AMReX_Random.H>
-#include <iostream>
 
 /** Prepare information for and call UpdateMomentumPerezElastic().
  *

--- a/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.H
@@ -132,7 +132,7 @@ public:
             const auto multiplier_ratio = static_cast<int>(
                 m_isSameSpecies ? min_N + max_N - 1 : min_N);
 
-#if (defined WARPX_DIM_RZ)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
             amrex::ParticleReal * const AMREX_RESTRICT theta1 = soa_1.m_rdata[PIdx::theta];
             amrex::ParticleReal * const AMREX_RESTRICT theta2 = soa_2.m_rdata[PIdx::theta];
 #endif
@@ -149,8 +149,8 @@ public:
                     p_mask[pair_index] = false;
                 } else {
 
-#if (defined WARPX_DIM_RZ)
-                    /* In RZ geometry, macroparticles can collide with other macroparticles
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
+                    /* In RZ and RCYLINDER geometry, macroparticles can collide with other macroparticles
                     * in the same *cylindrical* cell. For this reason, collisions between macroparticles
                     * are actually not local in space. In this case, the underlying assumption is that
                     * particles within the same cylindrical cell represent a cylindrically-symmetry
@@ -177,7 +177,7 @@ public:
                         p_pair_reaction_weight, multiplier_ratio,
                         m_process_count, m_scattering_processes_data, engine);
 
-#if (defined WARPX_DIM_RZ)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
                     /* Undo the earlier velocity rotation. */
                     amrex::ParticleReal const u1xbuf_new = u1x[I1[i1]];
                     u1x[I1[i1]] = u1xbuf_new*std::cos(-theta) - u1y[I1[i1]]*std::sin(-theta);

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -205,8 +205,8 @@ public:
                 auto& uy2 = soa_products_data[1].m_rdata[PIdx::uy][product2_index];
                 auto& uz2 = soa_products_data[1].m_rdata[PIdx::uz][product2_index];
 
-#if (defined WARPX_DIM_RZ)
-                /* In RZ geometry, macroparticles can collide with other macroparticles
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
+                /* In RZ and RCYLINDER geometry, macroparticles can collide with other macroparticles
                 * in the same *cylindrical* cell. For this reason, collisions between macroparticles
                 * are actually not local in space. In this case, the underlying assumption is that
                 * particles within the same cylindrical cell represent a cylindrically-symmetry
@@ -272,7 +272,7 @@ public:
                 uy2 += uCOM_y;
                 uz2 += uCOM_z;
 
-#if (defined WARPX_DIM_RZ)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
                 /* Undo the earlier velocity rotation. */
                 amrex::ParticleReal const ux1buf_new = ux1;
                 ux1 = ux1buf_new*std::cos(-theta) - uy1*std::sin(-theta);
@@ -359,8 +359,8 @@ public:
                 auto& uy_p2 = soa_products_data[3].m_rdata[PIdx::uy][product2_index];
                 auto& uz_p2 = soa_products_data[3].m_rdata[PIdx::uz][product2_index];
 
-#if (defined WARPX_DIM_RZ)
-                /* In RZ geometry, macroparticles can collide with other macroparticles
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
+                /* In RZ and RCYLINDER geometry, macroparticles can collide with other macroparticles
                 * in the same *cylindrical* cell. For this reason, collisions between macroparticles
                 * are actually not local in space. In this case, the underlying assumption is that
                 * particles within the same cylindrical cell represent a cylindrically-symmetry
@@ -495,7 +495,7 @@ public:
                 uy_p2 += uCOM_y;
                 uz_p2 += uCOM_z;
 
-#if (defined WARPX_DIM_RZ)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
                 /* Undo the earlier velocity rotation. */
                 amrex::ParticleReal const ux1buf_new = ux1;
                 ux1 = ux1buf_new*std::cos(-theta) - uy1*std::sin(-theta);

--- a/Source/Particles/Collision/BinaryCollision/LinearBreitWheeler/LinearBreitWheelerCollisionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/LinearBreitWheeler/LinearBreitWheelerCollisionFunc.H
@@ -177,7 +177,7 @@ public:
             const auto multiplier_ratio = static_cast<int>(
                 m_isSameSpecies ? min_N + max_N - 1 : min_N);
 
-#if (defined WARPX_DIM_RZ)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
             amrex::ParticleReal * const AMREX_RESTRICT theta1 = soa_1.m_rdata[PIdx::theta];
             amrex::ParticleReal * const AMREX_RESTRICT theta2 = soa_2.m_rdata[PIdx::theta];
 #endif
@@ -194,8 +194,8 @@ public:
                     p_mask[pair_index] = false;
                 }
                 else {
-#if (defined WARPX_DIM_RZ)
-                    /* In RZ geometry, macroparticles can collide with other macroparticles
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
+                    /* In RZ and RCYLINDER geometry, macroparticles can collide with other macroparticles
                      * in the same *cylindrical* cell. For this reason, collisions between macroparticles
                      * are actually not local in space. In this case, the underlying assumption is that
                      * particles within the same cylindrical cell represent a cylindrically-symmetry
@@ -217,7 +217,7 @@ public:
                         m_probability_threshold,
                         m_probability_target_value,
                         engine);
-#if (defined WARPX_DIM_RZ)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
                     amrex::ParticleReal const u1xbuf_new = u1x[I1[i1]];
                     u1x[I1[i1]] = u1xbuf_new*std::cos(-theta) - u1y[I1[i1]]*std::sin(-theta);
                     u1y[I1[i1]] = u1xbuf_new*std::sin(-theta) + u1y[I1[i1]]*std::cos(-theta);

--- a/Source/Particles/Collision/BinaryCollision/LinearCompton/LinearComptonCollisionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/LinearCompton/LinearComptonCollisionFunc.H
@@ -173,7 +173,7 @@ public:
             const auto multiplier_ratio = static_cast<int>(
                 m_isSameSpecies ? min_N + max_N - 1 : min_N);
 
-#if (defined WARPX_DIM_RZ)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
             amrex::ParticleReal * const AMREX_RESTRICT theta1 = soa_1.m_rdata[PIdx::theta];
             amrex::ParticleReal * const AMREX_RESTRICT theta2 = soa_2.m_rdata[PIdx::theta];
 #endif
@@ -190,8 +190,8 @@ public:
                     p_mask[pair_index] = false;
                 }
                 else {
-#if (defined WARPX_DIM_RZ)
-                    /* In RZ geometry, macroparticles can collide with other macroparticles
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
+                    /* In RZ and RCYLINDER geometry, macroparticles can collide with other macroparticles
                      * in the same *cylindrical* cell. For this reason, collisions between macroparticles
                      * are actually not local in space. In this case, the underlying assumption is that
                      * particles within the same cylindrical cell represent a cylindrically-symmetry
@@ -213,7 +213,7 @@ public:
                         m_probability_threshold,
                         m_probability_target_value,
                         engine);
-#if (defined WARPX_DIM_RZ)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
                     amrex::ParticleReal const u1xbuf_new = u1x[I1[i1]];
                     u1x[I1[i1]] = u1xbuf_new*std::cos(-theta) - u1y[I1[i1]]*std::sin(-theta);
                     u1y[I1[i1]] = u1xbuf_new*std::sin(-theta) + u1y[I1[i1]]*std::cos(-theta);

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/NuclearFusionFunc.H
@@ -166,7 +166,7 @@ public:
             const auto multiplier_ratio = static_cast<int>(
                 m_isSameSpecies ? min_N + max_N - 1 : min_N);
 
-#if (defined WARPX_DIM_RZ)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
             amrex::ParticleReal * const AMREX_RESTRICT theta1 = soa_1.m_rdata[PIdx::theta];
             amrex::ParticleReal * const AMREX_RESTRICT theta2 = soa_2.m_rdata[PIdx::theta];
 #endif
@@ -185,8 +185,8 @@ public:
                 }
                 else {
 
-#if (defined WARPX_DIM_RZ)
-                    /* In RZ geometry, macroparticles can collide with other macroparticles
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
+                    /* In RZ and RCYLINDER geometry, macroparticles can collide with other macroparticles
                      * in the same *cylindrical* cell. For this reason, collisions between macroparticles
                      * are actually not local in space. In this case, the underlying assumption is that
                      * particles within the same cylindrical cell represent a cylindrically-symmetry
@@ -210,7 +210,7 @@ public:
                         m_probability_target_value,
                         m_fusion_type, engine);
 
-#if (defined WARPX_DIM_RZ)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
                     amrex::ParticleReal const u1xbuf_new = u1x[I1[i1]];
                     u1x[I1[i1]] = u1xbuf_new*std::cos(-theta) - u1y[I1[i1]]*std::sin(-theta);
                     u1y[I1[i1]] = u1xbuf_new*std::sin(-theta) + u1y[I1[i1]]*std::cos(-theta);


### PR DESCRIPTION
This PR fixes a bug in the volume element used to compute the density for binary collisions in non-planar geometries (RZ, RCYLINDER, RSPHERE).

The volume element is computed using the radial cell index. The bug is that this index is relative to the box, not relative to the domain. This bug would not show up if running on a single processor. For more than one processor in the radial domain, this bug results in artificially high collisionality for ranks that do not include the origin.

This PR also add the rotation of colliding particles before and after the scattering for Coulomb collisions for RCYLINDER geometry. Previously this was done only for RZ. A rotation should also bee done for 1D spherical geometry, but I think that should be saved for a separate PR. Perhaps there is an easier way in that case to avoid placing the rotation in many files.

[DynamicPinch_WarpXBugFix.pdf](https://github.com/user-attachments/files/26255590/DynamicPinch_WarpXBugFix.pdf)
