### PR TITLE
[WIP] Parallelization: honour m_safe_guard_cells in FillBoundaryAux

### DIFF
--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -1124,12 +1124,16 @@ WarpX::FillBoundaryAux (int lev, IntVect ng)
     ablastr::fields::MultiLevelVectorField Bfield_aux = m_fields.get_mr_levels_alldirs(FieldType::Bfield_aux, finest_level);
 
     const amrex::Periodicity& period = Geom(lev).periodicity();
-    ablastr::utils::communication::FillBoundary(*Efield_aux[lev][0], ng, WarpX::do_single_precision_comms, period);
-    ablastr::utils::communication::FillBoundary(*Efield_aux[lev][1], ng, WarpX::do_single_precision_comms, period);
-    ablastr::utils::communication::FillBoundary(*Efield_aux[lev][2], ng, WarpX::do_single_precision_comms, period);
-    ablastr::utils::communication::FillBoundary(*Bfield_aux[lev][0], ng, WarpX::do_single_precision_comms, period);
-    ablastr::utils::communication::FillBoundary(*Bfield_aux[lev][1], ng, WarpX::do_single_precision_comms, period);
-    ablastr::utils::communication::FillBoundary(*Bfield_aux[lev][2], ng, WarpX::do_single_precision_comms, period);
+    for (int i = 0; i < 3; ++i)
+    {
+        const amrex::IntVect nghost = (m_safe_guard_cells) ? Efield_aux[lev][i]->nGrowVect() : ng;
+        ablastr::utils::communication::FillBoundary(*Efield_aux[lev][i], nghost, WarpX::do_single_precision_comms, period);
+    }
+    for (int i = 0; i < 3; ++i)
+    {
+        const amrex::IntVect nghost = (m_safe_guard_cells) ? Bfield_aux[lev][i]->nGrowVect() : ng;
+        ablastr::utils::communication::FillBoundary(*Bfield_aux[lev][i], nghost, WarpX::do_single_precision_comms, period);
+    }
 }
 
 void


### PR DESCRIPTION
## Summary
`FillBoundaryAux(int lev, IntVect ng)` always forwarded the caller-supplied `ng` to `FillBoundary`, ignoring `m_safe_guard_cells`. Every other `FillBoundary*` helper in `WarpXComm.cpp` upgrades `ng` to `nGrowVect()` when safe-guard mode is active, ensuring all allocated guard cells stay synchronised during debugging. The omission meant that enabling `warpx.safe_guard_cells=1` left `Efield_aux`/`Bfield_aux` guard regions partially stale.

## Fix
Apply the same `m_safe_guard_cells` pattern used by all other helpers, looping over directions for clarity.

Fixes #6659

## Test plan
- [ ] Runs with `warpx.safe_guard_cells=1` now fully synchronise aux field guard cells

🤖 Generated with [Claude Code](https://claude.com/claude-code)