### PR TITLE
[WIP] Diagnostics: guard rho coarse dump against single-component rho_cp

### DIFF
--- a/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatPlotfile.cpp
@@ -705,9 +705,13 @@ FlushFormatPlotfile::WriteAllRawFields(
             }
             if (warpx.m_fields.has(FieldType::rho_fp, lev) && warpx.m_fields.has(FieldType::rho_cp, lev))
             {
-                // Use the component 1 of `rho_cp`, i.e. rho_new for time synchronization
+                // Use the last component of rho_cp (rho_new) for time synchronization.
+                // When rho has old and new components (nComp >= 2*ncomps), component ncomps
+                // is rho_new; otherwise fall back to component 0.
+                const int rho_cp_ncomp = warpx.m_fields.get(FieldType::rho_cp, lev)->nComp();
+                const int rho_icomp = (rho_cp_ncomp >= 2 * WarpX::ncomps) ? WarpX::ncomps : 0;
                 WriteCoarseScalar("rho", warpx.m_fields.get(FieldType::rho_cp, lev), warpx.m_fields.get(FieldType::rho_fp, lev),
-                    dm, raw_pltname, default_level_prefix, lev, plot_raw_fields_guards, 1);
+                    dm, raw_pltname, default_level_prefix, lev, plot_raw_fields_guards, rho_icomp);
             }
         }
     }


### PR DESCRIPTION
## Summary
`WriteAllRawFields` hard-coded `icomp=1` when calling `WriteCoarseScalar` for `rho_cp`. That index only exists when `rho_cp` stores both old and new charge densities (`nComp >= 2*ncomps`). For electrostatic and HybridPIC solvers, `rho_cp` holds a single set of components, so aliasing component 1 triggers an AMReX out-of-bounds assertion.

## Fix
Compute the component index at runtime: use `WarpX::ncomps` (rho_new) when `rho_cp` has two sets of components, otherwise fall back to component 0.

Fixes #6648

## Test plan
- [ ] Raw plotfile dumps work for electrostatic and HybridPIC solvers with AMR
- [ ] Existing PSATD/FDTD with dive-cleaning still writes rho_new as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)