### PR TITLE
fix collisions.correct_energy_momentum crash for implicit.

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -514,10 +514,12 @@ public:
                 std::vector<std::string> const & real_names1 = species_1.GetRealSoANames();
                 auto const pos1 = std::find(real_names1.begin(), real_names1.end(), "ux_n");
                 if (pos1 != real_names1.end()) {
+                    int const n_builtin_real = PIdx::nattribs;
                     auto const u1x_ni = static_cast<int>(std::distance(real_names1.begin(), pos1));
-                    u1x_before_ptr = soa_1.m_runtime_rdata[u1x_ni];
-                    u1y_before_ptr = soa_1.m_runtime_rdata[u1x_ni + 1];
-                    u1z_before_ptr = soa_1.m_runtime_rdata[u1x_ni + 2];
+                    int const u1x_runtime_ni = u1x_ni - n_builtin_real;
+                    u1x_before_ptr = soa_1.m_runtime_rdata[u1x_runtime_ni];
+                    u1y_before_ptr = soa_1.m_runtime_rdata[u1x_runtime_ni + 1];
+                    u1z_before_ptr = soa_1.m_runtime_rdata[u1x_runtime_ni + 2];
                 } else {
                     u1x_before.resize(np1);
                     u1y_before.resize(np1);
@@ -996,10 +998,12 @@ public:
                 std::vector<std::string> const & real_names1 = species_1.GetRealSoANames();
                 auto const pos1 = std::find(real_names1.begin(), real_names1.end(), "ux_n");
                 if (pos1 != real_names1.end()) {
+                    int const n_builtin_real = PIdx::nattribs;
                     auto const u1x_ni = static_cast<int>(std::distance(real_names1.begin(), pos1));
-                    u1x_before_ptr = soa_1.m_runtime_rdata[u1x_ni];
-                    u1y_before_ptr = soa_1.m_runtime_rdata[u1x_ni + 1];
-                    u1z_before_ptr = soa_1.m_runtime_rdata[u1x_ni + 2];
+                    int const u1x_runtime_ni = u1x_ni - n_builtin_real;
+                    u1x_before_ptr = soa_1.m_runtime_rdata[u1x_runtime_ni];
+                    u1y_before_ptr = soa_1.m_runtime_rdata[u1x_runtime_ni + 1];
+                    u1z_before_ptr = soa_1.m_runtime_rdata[u1x_runtime_ni + 2];
                 } else {
                     u1x_before.resize(np1);
                     u1y_before.resize(np1);
@@ -1021,10 +1025,12 @@ public:
                 std::vector<std::string> const & real_names2 = species_2.GetRealSoANames();
                 auto const pos2 = std::find(real_names2.begin(), real_names2.end(), "ux_n");
                 if (pos2 != real_names2.end()) {
+                    int const n_builtin_real = PIdx::nattribs;
                     auto const u2x_ni = static_cast<int>(std::distance(real_names2.begin(), pos2));
-                    u2x_before_ptr = soa_2.m_runtime_rdata[u2x_ni];
-                    u2y_before_ptr = soa_2.m_runtime_rdata[u2x_ni + 1];
-                    u2z_before_ptr = soa_2.m_runtime_rdata[u2x_ni + 2];
+                    int const u2x_runtime_ni = u2x_ni - n_builtin_real;
+                    u2x_before_ptr = soa_2.m_runtime_rdata[u2x_runtime_ni];
+                    u2y_before_ptr = soa_2.m_runtime_rdata[u2x_runtime_ni + 1];
+                    u2z_before_ptr = soa_2.m_runtime_rdata[u2x_runtime_ni + 2];
                 } else {
                     u2x_before.resize(np2);
                     u2y_before.resize(np2);


### PR DESCRIPTION
This PR fixes a runtime crash in the binary collision moment-correction algorithm (`collisions.correct_energy_momentum = true`) when using the implicit solvers.