### PR TITLE
Refactor moment correction method for weighted particle collisions

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3108,6 +3108,13 @@ Details about the collision models can be found in the :ref:`theory section <mul
     particle momentum so that the energy and momentum are exactly conserved in each cell.
     This uses the algorithm described in https://doi.org/10.1016/j.jcp.2025.113927.
 
+.. pp:param:: collisions.np_warning_threshold
+    :type: ``int``
+    :default: 20.
+    :optional:
+
+    Only for ``pairwisecoulomb`` collisions, with :pp:param:`collisions.correct_energy_momentum` set, this parameter controls the minimum number of particles per cell for producing warning messages when the moment-correction method fails.
+
 .. pp:param:: collisions.energy_fraction
     :type: ``float``
     :default: 0.05

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3115,18 +3115,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
 
     Only for ``pairwisecoulomb`` collisions, with :pp:param:`collisions.correct_energy_momentum` set, the energy correction is applied to pairs of particles in their center of momentum frame.
     This can be set for each collision using :pp:param:`<collision_name>.energy_fraction`.
-    This parameter is the fraction of the relative energy in the COM frame that is used in the correction.
-
-.. pp:param:: collisions.energy_fraction_max
-    :type: ``float``
-    :default: 0.5
-    :optional:
-
-    Only for ``pairwisecoulomb`` collisions, with :pp:param:`collisions.correct_energy_momentum` set, the energy correction is applied to pairs of particles in their center of momentum frame.
-    This can be set for each collision using :pp:param:`<collision_name>.energy_fraction_max`.
-    This parameter sets the maximum allowed value for :pp:param:`collisions.energy_fraction`.
-    If residual energy error remains after a pass over all particle pairs in a cell, the algorithm increases the effective correction fraction for the next pass based on an estimate of the remaining error.
-    If this computed value exceeds the limit imposed by this parameter, the correction is deemed to have failed and particle velocities in the cell are restored to their pre-collision values.
+    This parameter is the fraction of the relative energy in the COM frame that is used in the correction. If residual energy error remains after 10 passes over all particle pairs in a cell, the correction is deemed to have failed and particle velocities in the cell are restored to their pre-collision values.
 
 .. pp:param:: collisions.beta_weight_exponent
     :type: ``float``

--- a/Examples/Tests/collision/inputs_test_1d_collision_z_correct_conservation
+++ b/Examples/Tests/collision/inputs_test_1d_collision_z_correct_conservation
@@ -86,6 +86,7 @@ ionsB.uz_th = sqrt(TB*q_e/m_c12)/clight
 #################################
 collisions.collision_names = collision1 collisionA collisionB
 collisions.correct_energy_momentum = 1
+collisions.energy_correction_sort_by_weight = true
 collision1.species = ionsA ionsB
 collision1.CoulombLog = 10.0
 collisionA.species = ionsA ionsA

--- a/Regression/Checksum/benchmarks_json/test_1d_collision_z_correct_conservation.json
+++ b/Regression/Checksum/benchmarks_json/test_1d_collision_z_correct_conservation.json
@@ -11,17 +11,17 @@
     "jz": 0.0
   },
   "ionsA": {
-    "particle_momentum_x": 3.942947005793911e-19,
-    "particle_momentum_y": 3.889773426818635e-19,
-    "particle_momentum_z": 4.127421991047703e-18,
-    "particle_position_x": 0.07121501561350166,
+    "particle_momentum_x": 3.9141737477497895e-19,
+    "particle_momentum_y": 3.917175706013383e-19,
+    "particle_momentum_z": 4.127283540935136e-18,
+    "particle_position_x": 0.07121501334563603,
     "particle_weight": 4.4444444444444443e+21
   },
   "ionsB": {
-    "particle_momentum_x": 3.242605550385425e-19,
-    "particle_momentum_y": 3.5319018528484435e-19,
-    "particle_momentum_z": 3.173399986508819e-19,
-    "particle_position_x": 0.07111066030814499,
+    "particle_momentum_x": 3.243634893627769e-19,
+    "particle_momentum_y": 3.557422796408759e-19,
+    "particle_momentum_z": 3.167939289837553e-19,
+    "particle_position_x": 0.07111066006940242,
     "particle_weight": 4.444444444444445e+22
   }
 }

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -116,14 +116,12 @@ public:
             pp_collisions.query("energy_correction_sort_by_weight", m_energy_correction_sort_by_weight);
             pp_collisions.query("beta_weight_exponent", m_beta_weight_exponent);
             pp_collisions.query("energy_fraction", m_energy_fraction);
-            pp_collisions.query("energy_fraction_max", m_energy_fraction_max);
 
             // Input parameter set for this collision
             pp_collision_name.query("correct_energy_momentum", m_correct_energy_momentum);
             pp_collision_name.query("energy_correction_sort_by_weight", m_energy_correction_sort_by_weight);
             pp_collision_name.query("beta_weight_exponent", m_beta_weight_exponent);
             pp_collision_name.query("energy_fraction", m_energy_fraction);
-            pp_collision_name.query("energy_fraction_max", m_energy_fraction_max);
         }
 
         // If DSMC the colliding species are also product species.
@@ -557,7 +555,7 @@ public:
 
                             // Compute the local energy and momentum.
                             amrex::ParticleReal const w1_scaled = std::pow(w1[ip], beta_weight_exponent);
-                            amrex::Gpu::Atomic::AddNoRet(&ww_weighted_sum_in_each_cell[i_cell], w1_scaled);
+                            amrex::Gpu::Atomic::AddNoRet(&ww_weighted_sum_in_each_cell[i_cell], w1_scaled*m1);
                             amrex::Gpu::Atomic::AddNoRet(&px_in_each_cell[i_cell], w1[ip]*u1x[ip]*m1);
                             amrex::Gpu::Atomic::AddNoRet(&py_in_each_cell[i_cell], w1[ip]*u1y[ip]*m1);
                             amrex::Gpu::Atomic::AddNoRet(&pz_in_each_cell[i_cell], w1[ip]*u1z[ip]*m1);
@@ -714,7 +712,6 @@ public:
             if (m_correct_energy_momentum) {
                 // Loop over cells and calculate the change in energy and momentum.
                 amrex::ParticleReal const energy_fraction = m_energy_fraction;
-                amrex::ParticleReal const energy_fraction_max = m_energy_fraction_max;
 
                 ABLASTR_PROFILE_VAR("BinaryCollision::doCollisionsWithinTile::correctEnergyMomentum", prof_correctEnergyMomentum);
                 amrex::ParallelFor( np1,
@@ -741,7 +738,7 @@ public:
                         const int i_cell = bins_1_ptr[i1];
 
                         amrex::ParticleReal const ww_weighted_sum = ww_weighted_sum_in_each_cell[i_cell];
-                        amrex::ParticleReal const w_factor = std::pow(w1[i1], beta_weight_exponent - 1._prt)/m1;
+                        amrex::ParticleReal const w_factor = std::pow(w1[i1], beta_weight_exponent - 1._prt);
                         u1x[i1] += w_factor*px_in_each_cell[i_cell]/ww_weighted_sum;
                         u1y[i1] += w_factor*py_in_each_cell[i_cell]/ww_weighted_sum;
                         u1z[i1] += w_factor*pz_in_each_cell[i_cell]/ww_weighted_sum;
@@ -752,9 +749,7 @@ public:
                 );
 
                 amrex::Gpu::Buffer<amrex::Long> failed_corrections({0});
-                amrex::Gpu::Buffer<amrex::ParticleReal> remaining_energy({0.});
                 amrex::Long* failed_corrections_ptr = failed_corrections.data();
-                amrex::ParticleReal* remaining_energy_ptr = remaining_energy.data();
 
                 // The particles are sorted by weight in decreasing order. This gives more of the correction
                 // to the heavier particles, having a smallar effect on their momenta, and typically
@@ -790,7 +785,7 @@ public:
                             const bool correction_failed =
                                  ParticleUtils::ModifyEnergyPairwise(u1x, u1y, u1z, w1, indices_1,
                                                                      cell_start_1, cell_stop_1, m1,
-                                                                     energy_fraction, energy_fraction_max, deltaEp1);
+                                                                     energy_fraction, deltaEp1);
                             if (correction_failed) {
                                 // If the correction failed, give up on the collision and restore the
                                 // momentum to what it was beforehand.
@@ -799,8 +794,10 @@ public:
                                     u1y[ indices_1[i1] ] = u1y_before_ptr[ indices_1[i1] ];
                                     u1z[ indices_1[i1] ] = u1z_before_ptr[ indices_1[i1] ];
                                 }
-                                amrex::Gpu::Atomic::Add(failed_corrections_ptr, amrex::Long(1));
-                                amrex::Gpu::Atomic::Add(remaining_energy_ptr, deltaEp1);
+                                int const numCell1 = (cell_stop_1 - cell_start_1);
+                                if (numCell1 > 10) { // limit here is to reduce warning messages
+                                    amrex::Gpu::Atomic::Add(failed_corrections_ptr, amrex::Long(1));
+                                }
                             }
                         }
 
@@ -808,12 +805,10 @@ public:
                 );
 
                 amrex::Long const num_failed_corrections = *(failed_corrections.copyToHost());
-                amrex::ParticleReal const total_remaining_energy = *(remaining_energy.copyToHost());
                 if (num_failed_corrections > 0) {
                     ablastr::warn_manager::WMRecordWarning("BinaryCollision::doCollisionsWithinTile",
                         "The energy correction failed for " + std::to_string(num_failed_corrections) + " cells " +
                         "for Coulomb collisions for species " + m_species_names[0] + ". " +
-                        "The remaining energy is " + std::to_string(total_remaining_energy/PhysConst::q_e) + " eV. " +
                         "The collisions in those cells was cancelled.");
                 }
 
@@ -1091,7 +1086,7 @@ public:
 
                                 // Compute the local energy and momentum.
                                 amrex::ParticleReal const w1_scaled = std::pow(w1[i1], beta_weight_exponent);
-                                amrex::Gpu::Atomic::AddNoRet(&ww_weighted_sum_in_each_cell[i_cell], w1_scaled);
+                                amrex::Gpu::Atomic::AddNoRet(&ww_weighted_sum_in_each_cell[i_cell], w1_scaled*m1);
                                 amrex::Gpu::Atomic::AddNoRet(&px_in_each_cell[i_cell], w1[i1]*u1x[i1]*m1);
                                 amrex::Gpu::Atomic::AddNoRet(&py_in_each_cell[i_cell], w1[i1]*u1y[i1]*m1);
                                 amrex::Gpu::Atomic::AddNoRet(&pz_in_each_cell[i_cell], w1[i1]*u1z[i1]*m1);
@@ -1110,7 +1105,7 @@ public:
 
                                 // Compute the local energy and momentum.
                                 amrex::ParticleReal const w2_scaled = std::pow(w2[i2], beta_weight_exponent);
-                                amrex::Gpu::Atomic::AddNoRet(&ww_weighted_sum_in_each_cell[i_cell], w2_scaled);
+                                amrex::Gpu::Atomic::AddNoRet(&ww_weighted_sum_in_each_cell[i_cell], w2_scaled*m2);
                                 amrex::Gpu::Atomic::AddNoRet(&px_in_each_cell[i_cell], w2[i2]*u2x[i2]*m2);
                                 amrex::Gpu::Atomic::AddNoRet(&py_in_each_cell[i_cell], w2[i2]*u2y[i2]*m2);
                                 amrex::Gpu::Atomic::AddNoRet(&pz_in_each_cell[i_cell], w2[i2]*u2z[i2]*m2);
@@ -1322,7 +1317,6 @@ public:
             if (m_correct_energy_momentum) {
                 // Loop over cells and calculate the change in energy and momentum.
                 amrex::ParticleReal const energy_fraction = m_energy_fraction;
-                amrex::ParticleReal const energy_fraction_max = m_energy_fraction_max;
 
                 ABLASTR_PROFILE_VAR("BinaryCollision::doCollisionsWithinTile::correctEnergyMomentum", prof_correctEnergyMomentum);
                 amrex::ParallelFor( std::max(np1, np2),
@@ -1367,7 +1361,7 @@ public:
                             const int i_cell = bins_1_ptr[i1];
 
                             amrex::ParticleReal const ww_weighted_sum = ww_weighted_sum_in_each_cell[i_cell];
-                            amrex::ParticleReal const w_factor = std::pow(w1[i1], beta_weight_exponent - 1._prt)/m1;
+                            amrex::ParticleReal const w_factor = std::pow(w1[i1], beta_weight_exponent - 1._prt);
                             u1x[i1] += w_factor*px_in_each_cell[i_cell]/ww_weighted_sum;
                             u1y[i1] += w_factor*py_in_each_cell[i_cell]/ww_weighted_sum;
                             u1z[i1] += w_factor*pz_in_each_cell[i_cell]/ww_weighted_sum;
@@ -1378,7 +1372,7 @@ public:
                             const int i_cell = bins_2_ptr[i2];
 
                             amrex::ParticleReal const ww_weighted_sum = ww_weighted_sum_in_each_cell[i_cell];
-                            amrex::ParticleReal const w_factor = std::pow(w2[i2], beta_weight_exponent - 1._prt)/m2;
+                            amrex::ParticleReal const w_factor = std::pow(w2[i2], beta_weight_exponent - 1._prt);
                             u2x[i2] += w_factor*px_in_each_cell[i_cell]/ww_weighted_sum;
                             u2y[i2] += w_factor*py_in_each_cell[i_cell]/ww_weighted_sum;
                             u2z[i2] += w_factor*pz_in_each_cell[i_cell]/ww_weighted_sum;
@@ -1387,9 +1381,7 @@ public:
                 );
 
                 amrex::Gpu::Buffer<amrex::Long> failed_corrections({0});
-                amrex::Gpu::Buffer<amrex::ParticleReal> remaining_energy({0.});
                 amrex::Long* failed_corrections_ptr = failed_corrections.data();
-                amrex::ParticleReal* remaining_energy_ptr = remaining_energy.data();
 
                 // The particles are sorted by weight in decreasing order. This gives more of the correction
                 // to the heavier particles, having a smallar effect on their momenta, and typically
@@ -1466,7 +1458,7 @@ public:
                                 correction1_failed =
                                      ParticleUtils::ModifyEnergyPairwise(u1x, u1y, u1z, w1, indices_1,
                                                                          cell_start_1, cell_stop_1, m1,
-                                                                         energy_fraction, energy_fraction_max, deltaEp1);
+                                                                         energy_fraction, deltaEp1);
                             }
 
                             if (deltaEp2 != 0. && numCell2 > 1) {
@@ -1477,7 +1469,7 @@ public:
                                 correction2_failed =
                                      ParticleUtils::ModifyEnergyPairwise(u2x, u2y, u2z, w2, indices_2,
                                                                          cell_start_2, cell_stop_2, m2,
-                                                                         energy_fraction, energy_fraction_max, deltaEp2);
+                                                                         energy_fraction, deltaEp2);
                             }
 
                             if (correction1_failed || correction2_failed ||
@@ -1495,8 +1487,9 @@ public:
                                     u2y[ indices_2[i2] ] = u2y_before_ptr[ indices_2[i2] ];
                                     u2z[ indices_2[i2] ] = u2z_before_ptr[ indices_2[i2] ];
                                 }
-                                amrex::Gpu::Atomic::Add(failed_corrections_ptr, amrex::Long(1));
-                                amrex::Gpu::Atomic::Add(remaining_energy_ptr, deltaEp1 + deltaEp2);
+                                if ((numCell1 > 10 && correction1_failed) || (numCell2 > 10 && correction2_failed)) {
+                                    amrex::Gpu::Atomic::Add(failed_corrections_ptr, amrex::Long(1));
+                                }
                             }
 
                         }
@@ -1504,12 +1497,10 @@ public:
                 );
 
                 amrex::Long const num_failed_corrections = *(failed_corrections.copyToHost());
-                amrex::ParticleReal const total_remaining_energy = *(remaining_energy.copyToHost());
                 if (num_failed_corrections > 0) {
                     ablastr::warn_manager::WMRecordWarning("BinaryCollision::doCollisionsWithinTile",
                         "The energy correction failed for " + std::to_string(num_failed_corrections) + " cells " +
                         "for Coulomb collisions between species " + m_species_names[0] + " and " + m_species_names[1] + ". " +
-                        "The remaining energy is " + std::to_string(total_remaining_energy/PhysConst::q_e) + " eV. " +
                         "The collisions in those cells was cancelled.");
                 }
 
@@ -1529,7 +1520,6 @@ private:
     bool m_energy_correction_sort_by_weight = false;
     amrex::ParticleReal m_beta_weight_exponent = 1.;
     amrex::ParticleReal m_energy_fraction = 0.05;
-    amrex::ParticleReal m_energy_fraction_max = 0.5;
 
     enum energy_correction_sort_by_weight_flags : int { no_sort, sort };
 

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -794,16 +794,16 @@ public:
                                     u1y[ indices_1[i1] ] = u1y_before_ptr[ indices_1[i1] ];
                                     u1z[ indices_1[i1] ] = u1z_before_ptr[ indices_1[i1] ];
                                 }
-                                int const numCell1 = (cell_stop_1 - cell_start_1);
-                                if (numCell1 > 10) { // limit here is to reduce warning messages
-                                    amrex::Gpu::Atomic::Add(failed_corrections_ptr, amrex::Long(1));
-                                }
+#if defined(AMREX_DEBUG) || defined(DEBUG)
+                                amrex::Gpu::Atomic::Add(failed_corrections_ptr, amrex::Long(1));
+#endif
                             }
                         }
 
                     }
                 );
 
+#if defined(AMREX_DEBUG) || defined(DEBUG)
                 amrex::Long const num_failed_corrections = *(failed_corrections.copyToHost());
                 if (num_failed_corrections > 0) {
                     ablastr::warn_manager::WMRecordWarning("BinaryCollision::doCollisionsWithinTile",
@@ -811,6 +811,7 @@ public:
                         "for Coulomb collisions for species " + m_species_names[0] + ". " +
                         "The collisions in those cells was cancelled.");
                 }
+#endif
 
                 ABLASTR_PROFILE_VAR_STOP(prof_correctEnergyMomentum);
             }
@@ -1487,15 +1488,18 @@ public:
                                     u2y[ indices_2[i2] ] = u2y_before_ptr[ indices_2[i2] ];
                                     u2z[ indices_2[i2] ] = u2z_before_ptr[ indices_2[i2] ];
                                 }
-                                if ((numCell1 > 10 && correction1_failed) || (numCell2 > 10 && correction2_failed)) {
+#if defined(AMREX_DEBUG) || defined(DEBUG)
+                                if (correction1_failed || correction2_failed) {
                                     amrex::Gpu::Atomic::Add(failed_corrections_ptr, amrex::Long(1));
                                 }
+#endif
                             }
 
                         }
                     }
                 );
 
+#if defined(AMREX_DEBUG) || defined(DEBUG)
                 amrex::Long const num_failed_corrections = *(failed_corrections.copyToHost());
                 if (num_failed_corrections > 0) {
                     ablastr::warn_manager::WMRecordWarning("BinaryCollision::doCollisionsWithinTile",
@@ -1503,6 +1507,7 @@ public:
                         "for Coulomb collisions between species " + m_species_names[0] + " and " + m_species_names[1] + ". " +
                         "The collisions in those cells was cancelled.");
                 }
+#endif
 
                 ABLASTR_PROFILE_VAR_STOP(prof_correctEnergyMomentum);
             }

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -1490,7 +1490,7 @@ public:
                                     u2z[ indices_2[i2] ] = u2z_before_ptr[ indices_2[i2] ];
                                 }
                                 if ((correction1_failed && numCell1 > np_warning_thresh) ||
-                                    (correction2_failed && numCell2 > np_warning_thresh) {
+                                    (correction2_failed && numCell2 > np_warning_thresh)) {
                                     amrex::Gpu::Atomic::Add(failed_corrections_ptr, amrex::Long(1));
                                 }
                             }

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -750,6 +750,11 @@ public:
 
                 amrex::Gpu::Buffer<amrex::Long> failed_corrections({0});
                 amrex::Long* failed_corrections_ptr = failed_corrections.data();
+#if defined(AMREX_DEBUG) || defined(DEBUG)
+                const int np_warning_thresh = 1;
+#else
+                const int np_warning_thresh = 20;
+#endif
 
                 // The particles are sorted by weight in decreasing order. This gives more of the correction
                 // to the heavier particles, having a smallar effect on their momenta, and typically
@@ -794,16 +799,16 @@ public:
                                     u1y[ indices_1[i1] ] = u1y_before_ptr[ indices_1[i1] ];
                                     u1z[ indices_1[i1] ] = u1z_before_ptr[ indices_1[i1] ];
                                 }
-#if defined(AMREX_DEBUG) || defined(DEBUG)
-                                amrex::Gpu::Atomic::Add(failed_corrections_ptr, amrex::Long(1));
-#endif
+                                int const numCell1 = (cell_stop_1 - cell_start_1);
+                                if (numCell1 > np_warning_thresh) {
+                                    amrex::Gpu::Atomic::Add(failed_corrections_ptr, amrex::Long(1));
+                                }
                             }
                         }
 
                     }
                 );
 
-#if defined(AMREX_DEBUG) || defined(DEBUG)
                 amrex::Long const num_failed_corrections = *(failed_corrections.copyToHost());
                 if (num_failed_corrections > 0) {
                     ablastr::warn_manager::WMRecordWarning("BinaryCollision::doCollisionsWithinTile",
@@ -811,7 +816,6 @@ public:
                         "for Coulomb collisions for species " + m_species_names[0] + ". " +
                         "The collisions in those cells was cancelled.");
                 }
-#endif
 
                 ABLASTR_PROFILE_VAR_STOP(prof_correctEnergyMomentum);
             }
@@ -1488,18 +1492,16 @@ public:
                                     u2y[ indices_2[i2] ] = u2y_before_ptr[ indices_2[i2] ];
                                     u2z[ indices_2[i2] ] = u2z_before_ptr[ indices_2[i2] ];
                                 }
-#if defined(AMREX_DEBUG) || defined(DEBUG)
-                                if (correction1_failed || correction2_failed) {
+                                if ((correction1_failed && numCell1 > np_warning_thresh) ||
+                                    (correction2_failed && numCell2 > np_warning_thresh) {
                                     amrex::Gpu::Atomic::Add(failed_corrections_ptr, amrex::Long(1));
                                 }
-#endif
                             }
 
                         }
                     }
                 );
 
-#if defined(AMREX_DEBUG) || defined(DEBUG)
                 amrex::Long const num_failed_corrections = *(failed_corrections.copyToHost());
                 if (num_failed_corrections > 0) {
                     ablastr::warn_manager::WMRecordWarning("BinaryCollision::doCollisionsWithinTile",
@@ -1507,7 +1509,6 @@ public:
                         "for Coulomb collisions between species " + m_species_names[0] + " and " + m_species_names[1] + ". " +
                         "The collisions in those cells was cancelled.");
                 }
-#endif
 
                 ABLASTR_PROFILE_VAR_STOP(prof_correctEnergyMomentum);
             }

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -750,11 +750,7 @@ public:
 
                 amrex::Gpu::Buffer<amrex::Long> failed_corrections({0});
                 amrex::Long* failed_corrections_ptr = failed_corrections.data();
-#if defined(AMREX_DEBUG) || defined(DEBUG)
-                const int np_warning_thresh = 1;
-#else
-                const int np_warning_thresh = 20;
-#endif
+                const int np_warning_thresh = m_np_warning_thresh;
 
                 // The particles are sorted by weight in decreasing order. This gives more of the correction
                 // to the heavier particles, having a smallar effect on their momenta, and typically
@@ -1387,11 +1383,7 @@ public:
 
                 amrex::Gpu::Buffer<amrex::Long> failed_corrections({0});
                 amrex::Long* failed_corrections_ptr = failed_corrections.data();
-#if defined(AMREX_DEBUG) || defined(DEBUG)
-                const int np_warning_thresh = 1;
-#else
-                const int np_warning_thresh = 20;
-#endif
+                const int np_warning_thresh = m_np_warning_thresh;
 
                 // The particles are sorted by weight in decreasing order. This gives more of the correction
                 // to the heavier particles, having a smallar effect on their momenta, and typically
@@ -1529,6 +1521,11 @@ private:
 
     bool m_correct_energy_momentum = false;
     bool m_energy_correction_sort_by_weight = false;
+#if defined(AMREX_DEBUG) || defined(DEBUG)
+    const int m_np_warning_thresh = 1;
+#else
+    const int m_np_warning_thresh = 20;
+#endif
     amrex::ParticleReal m_beta_weight_exponent = 1.;
     amrex::ParticleReal m_energy_fraction = 0.05;
 

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -1522,9 +1522,9 @@ private:
     bool m_correct_energy_momentum = false;
     bool m_energy_correction_sort_by_weight = false;
 #if defined(AMREX_DEBUG) || defined(DEBUG)
-    const int m_np_warning_thresh = 1;
+    static constexpr int m_np_warning_thresh = 1;
 #else
-    const int m_np_warning_thresh = 20;
+    static constexpr int m_np_warning_thresh = 20;
 #endif
     amrex::ParticleReal m_beta_weight_exponent = 1.;
     amrex::ParticleReal m_energy_fraction = 0.05;

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -114,12 +114,14 @@ public:
             const amrex::ParmParse pp_collisions("collisions");
             pp_collisions.query("correct_energy_momentum", m_correct_energy_momentum);
             pp_collisions.query("energy_correction_sort_by_weight", m_energy_correction_sort_by_weight);
+            pp_collisions.query("np_warning_threshold", m_np_warning_threshold);
             pp_collisions.query("beta_weight_exponent", m_beta_weight_exponent);
             pp_collisions.query("energy_fraction", m_energy_fraction);
 
             // Input parameter set for this collision
             pp_collision_name.query("correct_energy_momentum", m_correct_energy_momentum);
             pp_collision_name.query("energy_correction_sort_by_weight", m_energy_correction_sort_by_weight);
+            pp_collision_name.query("np_warning_threshold", m_np_warning_threshold);
             pp_collision_name.query("beta_weight_exponent", m_beta_weight_exponent);
             pp_collision_name.query("energy_fraction", m_energy_fraction);
         }
@@ -750,7 +752,7 @@ public:
 
                 amrex::Gpu::Buffer<amrex::Long> failed_corrections({0});
                 amrex::Long* failed_corrections_ptr = failed_corrections.data();
-                const int np_warning_thresh = m_np_warning_thresh;
+                const int np_warning_threshold = m_np_warning_threshold;
 
                 // The particles are sorted by weight in decreasing order. This gives more of the correction
                 // to the heavier particles, having a smallar effect on their momenta, and typically
@@ -796,7 +798,7 @@ public:
                                     u1z[ indices_1[i1] ] = u1z_before_ptr[ indices_1[i1] ];
                                 }
                                 int const numCell1 = (cell_stop_1 - cell_start_1);
-                                if (numCell1 > np_warning_thresh) {
+                                if (numCell1 > np_warning_threshold) {
                                     amrex::Gpu::Atomic::Add(failed_corrections_ptr, amrex::Long(1));
                                 }
                             }
@@ -1383,7 +1385,7 @@ public:
 
                 amrex::Gpu::Buffer<amrex::Long> failed_corrections({0});
                 amrex::Long* failed_corrections_ptr = failed_corrections.data();
-                const int np_warning_thresh = m_np_warning_thresh;
+                const int np_warning_threshold = m_np_warning_threshold;
 
                 // The particles are sorted by weight in decreasing order. This gives more of the correction
                 // to the heavier particles, having a smallar effect on their momenta, and typically
@@ -1489,8 +1491,8 @@ public:
                                     u2y[ indices_2[i2] ] = u2y_before_ptr[ indices_2[i2] ];
                                     u2z[ indices_2[i2] ] = u2z_before_ptr[ indices_2[i2] ];
                                 }
-                                if ((correction1_failed && numCell1 > np_warning_thresh) ||
-                                    (correction2_failed && numCell2 > np_warning_thresh)) {
+                                if ((correction1_failed && numCell1 > np_warning_threshold) ||
+                                    (correction2_failed && numCell2 > np_warning_threshold)) {
                                     amrex::Gpu::Atomic::Add(failed_corrections_ptr, amrex::Long(1));
                                 }
                             }
@@ -1521,11 +1523,8 @@ private:
 
     bool m_correct_energy_momentum = false;
     bool m_energy_correction_sort_by_weight = false;
-#if defined(AMREX_DEBUG) || defined(DEBUG)
-    static constexpr int m_np_warning_thresh = 1;
-#else
-    static constexpr int m_np_warning_thresh = 20;
-#endif
+    int m_np_warning_threshold = 20;
+
     amrex::ParticleReal m_beta_weight_exponent = 1.;
     amrex::ParticleReal m_energy_fraction = 0.05;
 

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -1387,6 +1387,11 @@ public:
 
                 amrex::Gpu::Buffer<amrex::Long> failed_corrections({0});
                 amrex::Long* failed_corrections_ptr = failed_corrections.data();
+#if defined(AMREX_DEBUG) || defined(DEBUG)
+                const int np_warning_thresh = 1;
+#else
+                const int np_warning_thresh = 20;
+#endif
 
                 // The particles are sorted by weight in decreasing order. This gives more of the correction
                 // to the heavier particles, having a smallar effect on their momenta, and typically

--- a/Source/Utils/ParticleUtils.H
+++ b/Source/Utils/ParticleUtils.H
@@ -421,7 +421,7 @@ namespace ParticleUtils {
                 i2 = cell_start;
             }
 
-            int const sign = (deltaE < 0.0 ? -1 : 1);
+            int const sign = (deltaE < 0.0_prt ? -1 : 1);
 
             const amrex::ParticleReal ux1 = uxp[ indices[i1] ];
             const amrex::ParticleReal uy1 = uyp[ indices[i1] ];
@@ -469,8 +469,8 @@ namespace ParticleUtils {
 
                 const amrex::ParticleReal A = Etot - deltaEpair;
                 const amrex::ParticleReal D = A*A + E2*E2 - E1*E1;
-                const auto p2dotu = static_cast<amrex::ParticleReal>(wpmp2*(ux2*ux + uy2*uy + uz2*uz));
-                const amrex::ParticleReal ptdotu = (pxtot*ux + pytot*uy + pztot*uz);
+                const amrex::ParticleReal p2dotu = wpmp2*(ux2*ux + uy2*uy + uz2*uz);
+                const amrex::ParticleReal ptdotu = pxtot*ux + pytot*uy + pztot*uz;
 
                 // Compute coefficients for quadratic equation for alpha.
                 const amrex::ParticleReal a = A*A*dbetasq - ptdotu*ptdotu;

--- a/Source/Utils/ParticleUtils.H
+++ b/Source/Utils/ParticleUtils.H
@@ -17,8 +17,6 @@
 
 #include <AMReX_BaseFwd.H>
 
-#include <limits>
-
 namespace ParticleUtils {
 
     // Define shortcuts for frequently-used type names
@@ -481,7 +479,7 @@ namespace ParticleUtils {
                 const amrex::ParticleReal c = A*A*E2*E2 - D*D/4.0_prt;
 
                 const amrex::ParticleReal root = b*b - 4.0_prt*a*c;
-                if (root >= 0.0_prt && amrex::Math::abs(a) > std::numeric_limits<amrex::ParticleReal>::epsilon()) {
+                if (root >= 0.0_prt && amrex::Math::abs(a) > 0.0_prt) {
 
                     // Update particle velocities.
                     const amrex::ParticleReal alpha = (-b + std::sqrt(root))/(2.0_prt*a);

--- a/Source/Utils/ParticleUtils.H
+++ b/Source/Utils/ParticleUtils.H
@@ -13,8 +13,11 @@
 #include <AMReX_DenseBins.H>
 #include <AMReX_Geometry.H>
 #include <AMReX_Particles.H>
+#include <AMReX_Math.H>
 
 #include <AMReX_BaseFwd.H>
+
+#include <limits>
 
 namespace ParticleUtils {
 
@@ -478,7 +481,7 @@ namespace ParticleUtils {
                 const amrex::ParticleReal c = A*A*E2*E2 - D*D/4.0_prt;
 
                 const amrex::ParticleReal root = b*b - 4.0_prt*a*c;
-                if (root >= 0.0_prt && a != 0.0_prt) {
+                if (root >= 0.0_prt && amrex::Math::abs(a) > std::numeric_limits<amrex::ParticleReal>::epsilon()) {
 
                     // Update particle velocities.
                     const amrex::ParticleReal alpha = (-b + std::sqrt(root))/(2.0_prt*a);

--- a/Source/Utils/ParticleUtils.H
+++ b/Source/Utils/ParticleUtils.H
@@ -377,7 +377,6 @@ namespace ParticleUtils {
      * \param[in] cell_stop start index of particles in the next cell
      * \param[in] mass mass of the particles
      * \param[in] energy_fraction fraction of pair's relative energy to change
-     * \param[in] energy_fraction_max max fracton of total relative energy that can be changed
      * \param[in/out] deltaE amount of energy to be distributed in this species
      */
     template <typename T_index>
@@ -391,7 +390,6 @@ namespace ParticleUtils {
                                T_index const cell_stop,
                                amrex::ParticleReal const mass,
                                amrex::ParticleReal const energy_fraction,
-                               amrex::ParticleReal const energy_fraction_max,
                                amrex::ParticleReal & deltaE )
     {
         using namespace amrex::literals;
@@ -400,25 +398,22 @@ namespace ParticleUtils {
 
         int const numCell = (cell_stop - cell_start);
 
+        if (numCell < 2) {
+            return true;
+        }
+
         // Adjust particle's momentum to absorb deltaE.
         // This loops over the particles, two at a time, distributing
         // the energy until all of it has been distributed or failing if not.
-        // If deltaE < 0, it should never fail since energy can always be added
-        // to the particles.
-        // if deltaE > 0, it will sometimes fail because energy cannot always be
-        // removed from the particles without changing the momentum.
         // The loop is setup to switch between even first and odd first pairs
         // each loop over the particles.
         int loop_count = 0;
         int const max_loop_count = 10;
-        amrex::ParticleReal Erel_cumm = 0.0_prt;
-        amrex::ParticleReal fmult_fact = 1.0_prt;
-        amrex::ParticleReal energy_frac_eff = 0.0_prt;
-        T_index i1 = cell_start;
+        int pair_offset = 0;
+        T_index i1 = cell_start + pair_offset;
         bool correction_failed = false;
         bool deltaE_is_zero = false;
-        int Erel_negative_count = 0;
-        while (!deltaE_is_zero && !correction_failed && loop_count <= max_loop_count) {
+        while (!deltaE_is_zero) {
 
             T_index i2 = i1 + 1;
             if (i2 == cell_stop) {
@@ -460,92 +455,68 @@ namespace ParticleUtils {
             const amrex::ParticleReal pztot = wpmp1*uz1 + wpmp2*uz2;
             const amrex::ParticleReal Ecm = std::sqrt(Etot*Etot - (pxtot*pxtot + pytot*pytot + pztot*pztot)*c2);
             const amrex::ParticleReal Erel = Ecm - wpmp1*c2 - wpmp2*c2;
-            if (Erel <= 0.0) {
-                // This checks for the unlikely case where the Erel is negative for all
-                // pairs of particles
-                Erel_negative_count++;
-                if (Erel_negative_count >= numCell) {
-                    correction_failed = true;
-                    break;
+
+            if (Erel > 0.0_prt) {
+
+                // Set the amount of energy change for this pair based on the
+                // relative energy in the center of momentum.
+                bool deltaE_finishes = false;
+                amrex::ParticleReal deltaEpair = static_cast<amrex::ParticleReal>(sign*energy_fraction)*Erel;
+                if (std::abs(deltaEpair) >= std::abs(deltaE)) {
+                    deltaEpair = deltaE;
+                    deltaE_finishes = true;
                 }
-                continue;
-            } else {
-                // Reset the counter since the next time through the loop
-                // might use difference pairs of particles
-                Erel_negative_count = 0;
+
+                const amrex::ParticleReal A = Etot - deltaEpair;
+                const amrex::ParticleReal D = A*A + E2*E2 - E1*E1;
+                const auto p2dotu = static_cast<amrex::ParticleReal>(wpmp2*(ux2*ux + uy2*uy + uz2*uz));
+                const amrex::ParticleReal ptdotu = (pxtot*ux + pytot*uy + pztot*uz);
+
+                // Compute coefficients for quadratic equation for alpha.
+                const amrex::ParticleReal a = A*A*dbetasq - ptdotu*ptdotu;
+                const amrex::ParticleReal b = D*ptdotu - 2.0_prt*A*A*p2dotu;
+                const amrex::ParticleReal c = A*A*E2*E2 - D*D/4.0_prt;
+
+                const amrex::ParticleReal root = b*b - 4.0_prt*a*c;
+                if (root >= 0.0_prt && a != 0.0_prt) {
+
+                    // Update particle velocities.
+                    const amrex::ParticleReal alpha = (-b + std::sqrt(root))/(2.0_prt*a);
+                    const amrex::ParticleReal ratio1 = alpha/(wpmp1*c2);
+                    const amrex::ParticleReal ratio2 = alpha/(wpmp2*c2);
+                    uxp[ indices[i1] ] += ratio1*ux;
+                    uyp[ indices[i1] ] += ratio1*uy;
+                    uzp[ indices[i1] ] += ratio1*uz;
+                    uxp[ indices[i2] ] -= ratio2*ux;
+                    uyp[ indices[i2] ] -= ratio2*uy;
+                    uzp[ indices[i2] ] -= ratio2*uz;
+
+                    // Update energy violation.
+                    if (deltaE_finishes) {
+                        deltaE = 0.0_prt;
+                        deltaE_is_zero = true;
+                    }
+                    else {
+                        deltaE -= deltaEpair;
+                    }
+
+                }
+
             }
 
-            // Set the amount of energy change for this pair based on the
-            // relative energy in the center of momentum.
-            // If deltaE > 0, no more that Erel can be removed from this pair.
-            // If deltaE < 0, limit the energy added by Erel at first, but
-            // after the first loop, add whatever is left (using the adjusted fmult_fact).
-            amrex::ParticleReal deltaEpair = static_cast<amrex::ParticleReal>(sign*energy_fraction*fmult_fact)*Erel;
-            if (std::abs(deltaEpair) >= std::abs(deltaE)) {
-                deltaEpair = deltaE;
-                deltaE = 0.0_prt;
-                deltaE_is_zero = true;
-            } else {
-                deltaE -= deltaEpair;
-            }
-
-            const amrex::ParticleReal A = Etot - deltaEpair;
-            const amrex::ParticleReal D = A*A + E2*E2 - E1*E1;
-            const auto p2dotu = static_cast<amrex::ParticleReal>(wpmp2*(ux2*ux + uy2*uy + uz2*uz));
-            const amrex::ParticleReal ptdotu = (pxtot*ux + pytot*uy + pztot*uz);
-
-            // Compute coefficients for quadratic equation for alpha.
-            const amrex::ParticleReal a = A*A*dbetasq - ptdotu*ptdotu;
-            const amrex::ParticleReal b = D*ptdotu - 2.0_prt*A*A*p2dotu;
-            const amrex::ParticleReal c = A*A*E2*E2 - D*D/4.0_prt;
-
-            const amrex::ParticleReal root = b*b - 4.0_prt*a*c;
-            if (root < 0.0 || a == 0.0) { continue; }
-            const amrex::ParticleReal alpha = (-b + std::sqrt(root))/(2.0_prt*a);
-
-            // Update particle velocities.
-            const amrex::ParticleReal ratio1 = alpha/(wpmp1*c2);
-            const amrex::ParticleReal ratio2 = alpha/(wpmp2*c2);
-            uxp[ indices[i1] ] += ratio1*ux;
-            uyp[ indices[i1] ] += ratio1*uy;
-            uzp[ indices[i1] ] += ratio1*uz;
-            uxp[ indices[i2] ] -= ratio2*ux;
-            uyp[ indices[i2] ] -= ratio2*uy;
-            uzp[ indices[i2] ] -= ratio2*uz;
-
-            Erel_cumm += Erel - deltaEpair;
-
+            // Update particle 1 index.
             if (i1 < cell_stop - 2) {
-                // If not done with the loop, increment to the next pair of particles
                 i1 = i2 + 1;
             } else {
                 loop_count++;
-                // On next time through the loop, use a different set of pairs.
-                // What index to start with depends on whether the number of particles
-                // is even or odd.
-                if (i1 == cell_stop - 2) {
-                    if ((numCell % 2) == 0) { i1 = cell_start + 1; }
-                    if ((numCell % 2) != 0) { i1 = cell_start; }
-                } else {
-                    if ((numCell % 2) == 0) { i1 = cell_start; }
-                    if ((numCell % 2) != 0) { i1 = cell_start + 1; }
-                }
-                // Compute the energy fraction to correct with one more loop.
-                // This is the remaining energy correction divided by the cummulated Erel,
-                // the amount of "free" energy available.
-                // If deltaE < 0, this check always passes since the amount of energy that
-                // can be added is unlimited.
-                energy_frac_eff = std::abs(deltaE)/Erel_cumm;
-                if (energy_frac_eff > energy_fraction_max || loop_count > max_loop_count) {
+                if (loop_count >= max_loop_count) {
                     correction_failed = true;
                     break;
-                } else if (deltaE < 0.) {
-                    // If after the first time around, there is energy left to distribute,
-                    // increase the multiplier to distribute the rest faster.
-                    fmult_fact = std::max(1._prt, energy_frac_eff/energy_fraction);
                 }
-            }
 
+                pair_offset = 1 - pair_offset; // 0, 1, 0, 1, ...
+                i1 = cell_start + pair_offset;
+            }
         }
 
         return correction_failed;


### PR DESCRIPTION
This PR refactors the post-scatter momentum and energy correction method for weighted-particle binary scattering. This PR fixes several implementation bugs, removes an input parameter, and limits the warnings messages that are produced when failures occur.

### Summary of changes
1. Remove `energy_fraction_max` input parameter.
2. Fix bug in momentum correction for inter-species scattering.
3. Limit warning message for failures to when the number of particles in a cell is larger than `np_warning_threshold`, which is a user input value.
4. Remove total remaining energy from warning message, as it was misleading.
5. Fix bugs in `ParticleUtils::ModifyEnergyPairwise()` associated with the usage of `continue;`