### PR TITLE
[WIP] Fix EB geometry lookup failure with anisotropic MR refinement ratio

### DIFF
--- a/Source/EmbeddedBoundary/WarpXInitEB.cpp
+++ b/Source/EmbeddedBoundary/WarpXInitEB.cpp
@@ -97,6 +97,12 @@ WarpX::InitEB ()
          // number (e.g., maxLevel()+20) for multigrid solvers.  Because the coarse
          // level has only 1/8 of the cells on the fine level, the memory usage should
          // not be an issue.
+        // Pass all AMR-level geometries explicitly so that AMReX registers the
+        // exact domain box for each level. Without this, AMReX derives coarse
+        // domains by coarsening Geom(maxLevel()) uniformly by 2 in every direction,
+        // which does not match the actual AMR geometry when ref_ratio_vect is
+        // anisotropic (e.g. 2 2 1), causing a "Geometry not found" abort in
+        // EB2::IndexSpace::getLevel.
         amrex::Vector<amrex::Geometry> geoms;
         for (int lev = 0; lev <= maxLevel(); lev++) { geoms.push_back(Geom(lev)); }
         amrex::EB2::Build(gshop, geoms);

--- a/Source/EmbeddedBoundary/WarpXInitEB.cpp
+++ b/Source/EmbeddedBoundary/WarpXInitEB.cpp
@@ -97,7 +97,7 @@ WarpX::InitEB ()
          // number (e.g., maxLevel()+20) for multigrid solvers.  Because the coarse
          // level has only 1/8 of the cells on the fine level, the memory usage should
          // not be an issue.
-        amrex::EB2::Build(gshop, Geom(maxLevel()), maxLevel(), maxLevel()+20);
+        amrex::EB2::Build(gshop, Geom(maxLevel()), maxLevel(), maxLevel()+20, 4, false);
     } else {
         amrex::ParmParse pp_eb2("eb2");
         if (!pp_eb2.contains("geom_type")) {

--- a/Source/EmbeddedBoundary/WarpXInitEB.cpp
+++ b/Source/EmbeddedBoundary/WarpXInitEB.cpp
@@ -105,7 +105,7 @@ WarpX::InitEB ()
             pp_eb2.add("geom_type", geom_type); // use all_regular by default
         }
         // See the comment above on amrex::EB2::Build for the hard-wired number 20.
-        amrex::EB2::Build(Geom(maxLevel()), maxLevel(), maxLevel()+20);
+        amrex::EB2::Build(Geom(maxLevel()), maxLevel(), maxLevel()+20, 4, false);
     }
 #endif
 }

--- a/Source/EmbeddedBoundary/WarpXInitEB.cpp
+++ b/Source/EmbeddedBoundary/WarpXInitEB.cpp
@@ -97,7 +97,9 @@ WarpX::InitEB ()
          // number (e.g., maxLevel()+20) for multigrid solvers.  Because the coarse
          // level has only 1/8 of the cells on the fine level, the memory usage should
          // not be an issue.
-        amrex::EB2::Build(gshop, Geom(maxLevel()), maxLevel(), maxLevel()+20, 4, false);
+        amrex::Vector<amrex::Geometry> geoms;
+        for (int lev = 0; lev <= maxLevel(); lev++) { geoms.push_back(Geom(lev)); }
+        amrex::EB2::Build(gshop, geoms);
     } else {
         amrex::ParmParse pp_eb2("eb2");
         if (!pp_eb2.contains("geom_type")) {


### PR DESCRIPTION
## Problem

When using embedded boundaries (EB) with mesh refinement and an anisotropic refinement ratio (e.g. `amr.ref_ratio_vect = 2 2 1`), WarpX crashes with:

```
IndexSpaceImp::getLevel: Geometry not found !!!
```

### Root cause

When `amrex::EB2::Build` is called with a single `Geometry` (the finest level) and a `required_coarsening_level`, AMReX internally derives coarse-level domain boxes by coarsening the fine domain uniformly by 2 in every direction. Those derived domains are registered in `EB2::IndexSpace::m_domain`. Later, `getLevel(Geom(lev))` searches for the exact domain box of each AMR level. With an anisotropic refinement ratio (e.g. `2 2 1`), the actual coarse-level domain is only coarsened in x and y (not z), so it never matches the uniformly-coarsened entries in `m_domain`, causing the crash.

### Relation to PR #6845

PR #6845 introduced `build_coarse_level_by_coarsening = false` for the STL/`geom_type` path and (in a follow-up commit) for the `eb_implicit_function` path. However, `build_coarse_level_by_coarsening` only controls **how** the EB is built at coarse levels (coarsening the fine EB vs. rebuilding from the gshop) — it does **not** change what domain boxes are registered. Coarse domains are always derived by uniform coarsening of the fine geometry, regardless of that flag. The `false` flag addresses a different failure mode ("Failed to build required coarse EB level"), not the geometry-not-found crash seen with anisotropic refinement.

## Fix

Use the `amrex::EB2::Build(gshop, Vector<Geometry>)` overload, passing all AMR-level geometries explicitly. This registers the exact domain box for each level, matching whatever refinement ratio is used.

This fix applies to the `warpx.eb_implicit_function` path. No equivalent `Vector<Geometry>` overload exists for the `geom_type`/STL path, which may still be affected by this issue.

## Action items
- [ ] Verify CI passes
- [ ] Investigate and fix the STL/`geom_type` path for anisotropic refinement