### PR TITLE
Hybrid-PIC: set unused dimensions nodal for RCYLINDER and RSPHERE

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -244,7 +244,8 @@ void HybridPICModel::InitData (const ablastr::fields::MultiFabRegister& fields)
     // Below we set all the unused dimensions to have nodal values for J, B & E
     // since these values will be interpolated onto a nodal grid - if this is
     // not done the Interp function returns nonsense values.
-#if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ) || defined(WARPX_DIM_1D_Z)
+#if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ) || defined(WARPX_DIM_1D_Z) || \
+    defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
     Jx_IndexType[2]    = 1;
     Jy_IndexType[2]    = 1;
     Jz_IndexType[2]    = 1;
@@ -255,7 +256,7 @@ void HybridPICModel::InitData (const ablastr::fields::MultiFabRegister& fields)
     Ey_IndexType[2]    = 1;
     Ez_IndexType[2]    = 1;
 #endif
-#if defined(WARPX_DIM_1D_Z)
+#if defined(WARPX_DIM_1D_Z) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
     Jx_IndexType[1]    = 1;
     Jy_IndexType[1]    = 1;
     Jz_IndexType[1]    = 1;


### PR DESCRIPTION
## Overview

The hybrid-PIC (Ohm's law) solver aborts on the **first step** in `RCYLINDER`
geometry with a non-finite E-field, for *any* input — including a bare uniform
plasma with no current drive and no sources:

STEP 1 starts ...
Assertion `Efield_fp[lev][idim]->is_finite()' failed, file ".../WarpXPushFieldsHybridPIC.cpp", line 253
ERROR : Non-finite value detected in E-field; this indicates more substeps should be used ...


The failure is independent of `substeps` and of all physics inputs; the
"use more substeps" hint is a red herring. The same physics runs fine in `RZ`.

## Root cause

`HybridPICModel::InitData` sets the staggering index types of the **unused
(collapsed) dimensions** of J, B and E to nodal, so that the nodal `Interp`
used in `HybridPICSolveE` does not average across non-existent dimensions.
The comment there already warns:

> Below we set all the unused dimensions to have nodal values for J, B & E
> since these values will be interpolated onto a nodal grid - if this is not
> done the Interp function returns nonsense values.

The guards covered `XZ`/`RZ`/`1D_Z` (index `[2]`) and `1D_Z` (index `[1]`),
but omitted the 1D radial geometries `RCYLINDER` and `RSPHERE`. For those
`AMREX_SPACEDIM == 1`, so both `[1]` and `[2]` are unused and must be nodal.
Leaving them cell-centered makes the nodal `Interp` read uninitialized guard
cells along the collapsed dimensions, producing a non-finite
`enE = (J - J_i) x B` that propagates into E on the first step.

This is exactly why `RZ` (which *is* in the first guard) works and `RCYLINDER`
does not.

## Fix

Add `WARPX_DIM_RCYLINDER` and `WARPX_DIM_RSPHERE` to both guards, mirroring
the existing `1D_Z` handling (one file, +3 / -2 lines).

## Verification

- Minimal reproducer (uniform plasma only, RCYLINDER hybrid): crashed at
  STEP 1 before, runs after.
- Driven-pinch RCYLINDER hybrid deck (full physics, 200 steps): runs with
  finite fields.
- `RCYLINDER` was runtime-tested; `RSPHERE` shares the identical 1D staggering
  logic and is fixed by symmetry (not separately runtime-tested).

### How it was localized

- Step-0 fields/particles are finite; the non-finite value is created in the
  step-1 solve.
- Independent of `plasma_resistivity` (incl. 0), `n_floor`, `elec_temp=0`,
  boundary BC, `substeps` (20–1000), current deposition, field gathering,
  `grid_type`, `particle_shape`.
- Not an on-axis (1/r) issue: moving the domain off the axis
  (`geometry.prob_lo = 0.1`) still aborts.
- Not uninitialized-snan masking: `amrex.init_snan=0 fab.init_snan=0` does not
  help.
- Setting `hybrid_pic_model.holmstrom_vacuum_region = 1` with a high `n_floor`
  (which makes the E-solve skip the `enE/ρ` evaluation) makes it run, pinning
  the non-finite value to the `enE = (J - J_i) x B` / nodal-`Interp` term and
  hence to the staggering index types.

## Follow-up (not in this PR)

There is currently no `RCYLINDER`/`RSPHERE` hybrid-PIC example or regression
test (`Examples/Tests/ohm_solver_*`), which is why this path went untested.
Happy to add one if desired.