### PR TITLE
Add an opt-in system memory guard for WarpX time stepping

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -5586,6 +5586,29 @@ When developing, testing and :ref:`debugging WarpX <debugging_warpx>`, the follo
     It is mainly intended for debug purposes, and is best used with
     :pp:param:`warpx.always_warn_immediately = 1`.
 
+.. pp:param:: warpx.max_system_memory_fraction
+    :type: ``Real``
+    :default: ``0.0``
+
+    The default value ``0.0`` disables the guard and preserves the default
+    behavior. If set to a value in the range ``(0, 1)``, WarpX checks
+    host/node physical memory pressure and collectively aborts when used memory
+    exceeds this fraction of host/node physical memory. Negative, non-finite,
+    or values ``>= 1`` abort during startup (a fraction of ``1.0`` could never
+    trip, since used memory cannot exceed total).
+
+    This guard does not account for scheduler, cgroup, or container memory
+    limits in this PR. Those limits can be lower than host/node physical memory
+    and may be handled by a follow-up change.
+
+.. pp:param:: warpx.system_memory_check_interval
+    :type: positive integer
+    :default: ``1``
+
+    The number of time steps between checks of
+    :pp:param:`warpx.max_system_memory_fraction`. WarpX also checks once at the
+    start of each ``Evolve`` call when the guard is enabled.
+
 .. pp:param:: amrex.abort_on_unused_inputs
     :type: ``0`` or ``1``
     :default: ``0`` for false

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -31,6 +31,7 @@
 #include "Particles/ParticleBoundaryBuffer.H"
 #include "Python/callbacks.H"
 #include "Utils/TextMsg.H"
+#include "Utils/SystemMemoryGuard.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXUtil.H"
 #include "Utils/WarpXConst.H"
@@ -163,6 +164,8 @@ WarpX::Evolve (int numsteps)
     static Real evolve_time = 0;
 
     const int step_begin = istep[0];
+    warpx::utils::system_memory_guard::Check(step_begin);
+
     for (int step = istep[0]; step < numsteps_max && cur_time < stop_time; ++step)
     {
         ABLASTR_PROFILE("WarpX::Evolve::step");
@@ -170,6 +173,7 @@ WarpX::Evolve (int numsteps)
 
         // Check and clear signal flags and asynchronously broadcast them from process 0
         SignalHandling::CheckSignals();
+        warpx::utils::system_memory_guard::CheckIfDue(step + 1, step_begin);
 
         multi_diags->NewIteration();
 

--- a/Source/Utils/CMakeLists.txt
+++ b/Source/Utils/CMakeLists.txt
@@ -5,6 +5,7 @@ foreach(D IN LISTS WarpX_DIMS)
         Interpolate.cpp
         ParticleUtils.cpp
         SpeciesUtils.cpp
+        SystemMemoryGuard.cpp
         WarpXMovingWindow.cpp
         WarpXUtil.cpp
         WarpXVersion.cpp
@@ -13,3 +14,7 @@ endforeach()
 
 add_subdirectory(Logo)
 add_subdirectory(Parser)
+
+if(BUILD_TESTING)
+    add_subdirectory(Tests)
+endif()

--- a/Source/Utils/Make.package
+++ b/Source/Utils/Make.package
@@ -4,6 +4,7 @@ CEXE_sources += WarpXVersion.cpp
 CEXE_sources += Interpolate.cpp
 CEXE_sources += ParticleUtils.cpp
 CEXE_sources += SpeciesUtils.cpp
+CEXE_sources += SystemMemoryGuard.cpp
 
 include $(WARPX_HOME)/Source/Utils/Algorithms/Make.package
 include $(WARPX_HOME)/Source/Utils/Logo/Make.package

--- a/Source/Utils/SystemMemoryGuard.H
+++ b/Source/Utils/SystemMemoryGuard.H
@@ -1,0 +1,45 @@
+/* Copyright 2026 The WarpX Community
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#ifndef WARPX_SYSTEM_MEMORY_GUARD_H_
+#define WARPX_SYSTEM_MEMORY_GUARD_H_
+
+#include <AMReX_ParmParse.H>
+
+#include <string>
+
+namespace warpx::utils::system_memory_guard
+{
+
+struct Config
+{
+    double max_fraction = 0.0;
+    int check_interval = 1;
+
+    [[nodiscard]] bool enabled () const noexcept { return max_fraction > 0.0; }
+};
+
+Config ReadConfig (amrex::ParmParse const& pp_warpx);
+
+std::string ValidateConfig (
+    Config const& config,
+    bool memory_query_supported);
+
+bool ShouldCheck (
+    Config const& config,
+    int step,
+    int step_begin) noexcept;
+
+void ReadParameters ();
+
+void Check (int step);
+
+void CheckIfDue (int step, int step_begin);
+
+} // namespace warpx::utils::system_memory_guard
+
+#endif // WARPX_SYSTEM_MEMORY_GUARD_H_

--- a/Source/Utils/SystemMemoryGuard.cpp
+++ b/Source/Utils/SystemMemoryGuard.cpp
@@ -1,0 +1,182 @@
+/* Copyright 2026 The WarpX Community
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#include "SystemMemoryGuard.H"
+
+#include "Utils/TextMsg.H"
+
+#include <ablastr/utils/SystemMemory.H>
+
+#include <AMReX_ParallelDescriptor.H>
+
+#include <cmath>
+#include <iomanip>
+#include <sstream>
+#include <string>
+
+namespace
+{
+    warpx::utils::system_memory_guard::Config& guard_config ()
+    {
+        static auto config = warpx::utils::system_memory_guard::Config{};
+        return config;
+    }
+
+    std::string format_memory_guard_message (
+        warpx::utils::system_memory_guard::Config const& config,
+        ablastr::utils::SystemMemoryInfo const& info,
+        int step,
+        bool local_over_threshold,
+        double max_observed_fraction)
+    {
+        auto os = std::ostringstream{};
+        os << std::setprecision(6);
+
+        if (!info.supported) {
+            os << "warpx.max_system_memory_fraction is enabled, but system "
+               << "memory query is unsupported on this platform at step "
+               << step << ". ";
+        } else {
+            auto const local_fraction =
+                ablastr::utils::UsedSystemMemoryFraction(info);
+            os << "System memory guard triggered by "
+                << "warpx.max_system_memory_fraction at step " << step
+                << " on one or more MPI ranks/nodes. This rank "
+                << (local_over_threshold ? "exceeded" : "did not exceed")
+                << " the threshold. Local rank memory: "
+                << "used=" << info.used_bytes << " bytes, "
+                << "total=" << info.total_bytes << " bytes, "
+                << "available=" << info.available_bytes << " bytes, "
+                << "fraction=" << local_fraction
+                << ", max_fraction_across_ranks=" << max_observed_fraction
+                << ", threshold=" << config.max_fraction << ". ";
+        }
+
+        os << "lower problem size or raise warpx.max_system_memory_fraction";
+        return os.str();
+    }
+} // namespace
+
+namespace warpx::utils::system_memory_guard
+{
+
+Config ReadConfig (amrex::ParmParse const& pp_warpx)
+{
+    auto config = Config{};
+    pp_warpx.query("max_system_memory_fraction", config.max_fraction);
+    pp_warpx.query("system_memory_check_interval", config.check_interval);
+    return config;
+}
+
+std::string ValidateConfig (
+    Config const& config,
+    bool memory_query_supported)
+{
+    if (config.check_interval < 1) {
+        return "warpx.system_memory_check_interval must be >= 1";
+    }
+
+    if (!std::isfinite(config.max_fraction)) {
+        return "warpx.max_system_memory_fraction must be finite and either "
+               "0.0 to disable or in the valid range (0, 1)";
+    }
+
+    if (config.max_fraction == 0.0) {
+        return {};
+    }
+
+    // The guard trips when the used fraction strictly exceeds max_fraction, so a
+    // value of 1.0 could never trip (used memory cannot exceed total). Require a
+    // fraction strictly below 1.0 so the guard can fire before exhaustion.
+    if (config.max_fraction < 0.0 || config.max_fraction >= 1.0) {
+        return "warpx.max_system_memory_fraction must be 0.0 to disable or "
+               "in the valid range (0, 1)";
+    }
+
+    if (!memory_query_supported) {
+        return "warpx.max_system_memory_fraction is enabled, but system memory "
+               "query is unsupported on this platform";
+    }
+
+    return {};
+}
+
+bool ShouldCheck (
+    Config const& config,
+    int step,
+    int step_begin) noexcept
+{
+    if (!config.enabled()) {
+        return false;
+    }
+
+    if (step <= step_begin) {
+        return true;
+    }
+
+    return ((step - step_begin) % config.check_interval) == 0;
+}
+
+void ReadParameters ()
+{
+    auto const pp_warpx = amrex::ParmParse{"warpx"};
+    auto config = ReadConfig(pp_warpx);
+
+    auto const memory_info = config.enabled()
+        ? ablastr::utils::QuerySystemMemory()
+        : ablastr::utils::SystemMemoryInfo{};
+
+    auto const error = ValidateConfig(
+        config,
+        !config.enabled() || memory_info.supported);
+    if (!error.empty()) {
+        WARPX_ABORT_WITH_MESSAGE(error);
+    }
+
+    guard_config() = config;
+}
+
+void Check (int step)
+{
+    auto const config = guard_config();
+    if (!config.enabled()) {
+        return;
+    }
+
+    auto const memory_info = ablastr::utils::QuerySystemMemory();
+    auto max_observed_fraction =
+        ablastr::utils::UsedSystemMemoryFraction(memory_info);
+    amrex::ParallelDescriptor::ReduceRealMax(max_observed_fraction);
+
+    auto const local_over_threshold =
+        ablastr::utils::ExceedsSystemMemoryFraction(
+            memory_info, config.max_fraction);
+    auto const local_guard_failure =
+        !memory_info.supported || local_over_threshold;
+
+    auto any_rank_guard_failure = local_guard_failure;
+    amrex::ParallelDescriptor::ReduceBoolOr(any_rank_guard_failure);
+
+    if (any_rank_guard_failure) {
+        WARPX_ABORT_WITH_MESSAGE(
+            format_memory_guard_message(
+                config,
+                memory_info,
+                step,
+                local_over_threshold,
+                max_observed_fraction));
+    }
+}
+
+void CheckIfDue (int step, int step_begin)
+{
+    if (ShouldCheck(guard_config(), step, step_begin)) {
+        Check(step);
+    }
+}
+
+} // namespace warpx::utils::system_memory_guard

--- a/Source/Utils/Tests/CMakeLists.txt
+++ b/Source/Utils/Tests/CMakeLists.txt
@@ -1,0 +1,35 @@
+set(_system_memory_test_dim ${WarpX_DIMS_LAST})
+
+add_executable(WarpXSystemMemoryInfoTest
+    SystemMemoryInfoTest.cpp
+)
+target_link_libraries(WarpXSystemMemoryInfoTest
+    PRIVATE
+        ablastr_${_system_memory_test_dim}
+)
+add_test(NAME WarpXSystemMemoryInfoTest COMMAND WarpXSystemMemoryInfoTest)
+
+add_executable(WarpXSystemMemoryGuardTest
+    SystemMemoryGuardTest.cpp
+    ../SystemMemoryGuard.cpp
+)
+target_link_libraries(WarpXSystemMemoryGuardTest
+    PRIVATE
+        ablastr_${_system_memory_test_dim}
+)
+add_test(NAME WarpXSystemMemoryGuardTest COMMAND WarpXSystemMemoryGuardTest)
+
+# These standalone test executables are not part of WarpX's _ALL_TARGETS list, so
+# the global CUDA setup in the top-level CMakeLists does not reach them. Apply the
+# same AMReX CUDA compilation properties here so their AMReX-including sources are
+# compiled as CUDA (not handed to the host compiler) in a CUDA build.
+if(WarpX_COMPUTE STREQUAL CUDA)
+    foreach(_system_memory_test_tgt IN ITEMS WarpXSystemMemoryInfoTest WarpXSystemMemoryGuardTest)
+        setup_target_for_cuda_compilation(${_system_memory_test_tgt})
+        target_compile_features(${_system_memory_test_tgt} PUBLIC cuda_std_20)
+        set_target_properties(${_system_memory_test_tgt} PROPERTIES
+            CUDA_EXTENSIONS OFF
+            CUDA_STANDARD_REQUIRED ON
+        )
+    endforeach()
+endif()

--- a/Source/Utils/Tests/SystemMemoryGuardTest.cpp
+++ b/Source/Utils/Tests/SystemMemoryGuardTest.cpp
@@ -1,0 +1,82 @@
+/* Copyright 2026 The WarpX Community
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#include "Utils/SystemMemoryGuard.H"
+
+#include <AMReX.H>
+#include <AMReX_ParmParse.H>
+
+#include <AMReX_BLassert.H>
+#include <limits>
+#include <string>
+
+int main (int argc, char* argv[])
+{
+    amrex::Initialize(argc, argv);
+
+    {
+        auto pp_warpx = amrex::ParmParse{"warpx"};
+        pp_warpx.remove("max_system_memory_fraction");
+        pp_warpx.remove("system_memory_check_interval");
+
+        auto config = warpx::utils::system_memory_guard::ReadConfig(pp_warpx);
+        AMREX_ALWAYS_ASSERT(!config.enabled());
+        AMREX_ALWAYS_ASSERT(config.max_fraction == 0.0);
+        AMREX_ALWAYS_ASSERT(config.check_interval == 1);
+        AMREX_ALWAYS_ASSERT(warpx::utils::system_memory_guard::ValidateConfig(config, false).empty());
+        AMREX_ALWAYS_ASSERT(!warpx::utils::system_memory_guard::ShouldCheck(config, 0, 0));
+
+        pp_warpx.add("max_system_memory_fraction", 0.5);
+        pp_warpx.add("system_memory_check_interval", 3);
+
+        config = warpx::utils::system_memory_guard::ReadConfig(pp_warpx);
+        AMREX_ALWAYS_ASSERT(config.enabled());
+        AMREX_ALWAYS_ASSERT(config.max_fraction == 0.5);
+        AMREX_ALWAYS_ASSERT(config.check_interval == 3);
+        AMREX_ALWAYS_ASSERT(warpx::utils::system_memory_guard::ValidateConfig(config, true).empty());
+        AMREX_ALWAYS_ASSERT(warpx::utils::system_memory_guard::ShouldCheck(config, 10, 10));
+        AMREX_ALWAYS_ASSERT(!warpx::utils::system_memory_guard::ShouldCheck(config, 11, 10));
+        AMREX_ALWAYS_ASSERT(warpx::utils::system_memory_guard::ShouldCheck(config, 13, 10));
+
+        config.max_fraction = -0.1;
+        auto error = warpx::utils::system_memory_guard::ValidateConfig(config, true);
+        AMREX_ALWAYS_ASSERT(error.find("warpx.max_system_memory_fraction") != std::string::npos);
+        AMREX_ALWAYS_ASSERT(error.find("(0, 1)") != std::string::npos);
+
+        config.max_fraction = 1.01;
+        error = warpx::utils::system_memory_guard::ValidateConfig(config, true);
+        AMREX_ALWAYS_ASSERT(error.find("warpx.max_system_memory_fraction") != std::string::npos);
+        AMREX_ALWAYS_ASSERT(error.find("(0, 1)") != std::string::npos);
+
+        // A fraction of exactly 1.0 can never trip (used cannot exceed total),
+        // so it must be rejected rather than silently accepted as a dead config.
+        config.max_fraction = 1.0;
+        error = warpx::utils::system_memory_guard::ValidateConfig(config, true);
+        AMREX_ALWAYS_ASSERT(error.find("warpx.max_system_memory_fraction") != std::string::npos);
+        AMREX_ALWAYS_ASSERT(error.find("(0, 1)") != std::string::npos);
+
+        config.max_fraction = std::numeric_limits<double>::quiet_NaN();
+        error = warpx::utils::system_memory_guard::ValidateConfig(config, true);
+        AMREX_ALWAYS_ASSERT(error.find("warpx.max_system_memory_fraction") != std::string::npos);
+        AMREX_ALWAYS_ASSERT(error.find("finite") != std::string::npos);
+
+        config.max_fraction = 0.5;
+        config.check_interval = 0;
+        error = warpx::utils::system_memory_guard::ValidateConfig(config, true);
+        AMREX_ALWAYS_ASSERT(error.find("warpx.system_memory_check_interval") != std::string::npos);
+
+        config.check_interval = 1;
+        error = warpx::utils::system_memory_guard::ValidateConfig(config, false);
+        AMREX_ALWAYS_ASSERT(error.find("unsupported") != std::string::npos);
+
+        pp_warpx.remove("max_system_memory_fraction");
+        pp_warpx.remove("system_memory_check_interval");
+    }
+
+    amrex::Finalize();
+    return 0;
+}

--- a/Source/Utils/Tests/SystemMemoryInfoTest.cpp
+++ b/Source/Utils/Tests/SystemMemoryInfoTest.cpp
@@ -1,0 +1,46 @@
+/* Copyright 2026 The WarpX Community
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#include <ablastr/utils/SystemMemory.H>
+
+#include <AMReX_BLassert.H>
+
+int main ()
+{
+    using ablastr::utils::ExceedsSystemMemoryFraction;
+    using ablastr::utils::MakeSystemMemoryInfo;
+    using ablastr::utils::QuerySystemMemory;
+    using ablastr::utils::UsedSystemMemoryFraction;
+
+    auto const mocked = MakeSystemMemoryInfo(100, 25, true);
+    AMREX_ALWAYS_ASSERT(mocked.supported);
+    AMREX_ALWAYS_ASSERT(mocked.total_bytes == 100);
+    AMREX_ALWAYS_ASSERT(mocked.available_bytes == 25);
+    AMREX_ALWAYS_ASSERT(mocked.used_bytes == 75);
+    AMREX_ALWAYS_ASSERT(UsedSystemMemoryFraction(mocked) == 0.75);
+    AMREX_ALWAYS_ASSERT(ExceedsSystemMemoryFraction(mocked, 0.70));
+    AMREX_ALWAYS_ASSERT(!ExceedsSystemMemoryFraction(mocked, 0.75));
+
+    auto const capped = MakeSystemMemoryInfo(100, 125, true);
+    AMREX_ALWAYS_ASSERT(capped.available_bytes == 100);
+    AMREX_ALWAYS_ASSERT(capped.used_bytes == 0);
+
+    auto const unsupported = MakeSystemMemoryInfo(100, 25, false);
+    AMREX_ALWAYS_ASSERT(!unsupported.supported);
+    AMREX_ALWAYS_ASSERT(unsupported.total_bytes == 0);
+    AMREX_ALWAYS_ASSERT(UsedSystemMemoryFraction(unsupported) == 0.0);
+    AMREX_ALWAYS_ASSERT(!ExceedsSystemMemoryFraction(unsupported, 0.70));
+
+    auto const live = QuerySystemMemory();
+    if (live.supported) {
+        AMREX_ALWAYS_ASSERT(live.total_bytes > 0);
+        AMREX_ALWAYS_ASSERT(live.available_bytes <= live.total_bytes);
+        AMREX_ALWAYS_ASSERT(live.used_bytes <= live.total_bytes);
+    }
+
+    return 0;
+}

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -45,6 +45,7 @@
 #include "Particles/ParticleBoundaryBuffer.H"
 #include "AcceleratorLattice/AcceleratorLattice.H"
 #include "Utils/TextMsg.H"
+#include "Utils/SystemMemoryGuard.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 #include "Utils/WarpXConst.H"
 #include "Utils/WarpXUtil.H"
@@ -325,6 +326,7 @@ WarpX::WarpX ()
                        // indirectly used in WarpX constructor.
 
     warpx::initialization::initialize_warning_manager();
+    warpx::utils::system_memory_guard::ReadParameters();
 
     ReadParameters();
 

--- a/Source/ablastr/utils/CMakeLists.txt
+++ b/Source/ablastr/utils/CMakeLists.txt
@@ -5,6 +5,7 @@ foreach(D IN LISTS WarpX_DIMS)
         Communication.cpp
         RelativeCellPosition.cpp
         SignalHandling.cpp
+        SystemMemory.cpp
         TextMsg.cpp
         UsedInputsFile.cpp
     )

--- a/Source/ablastr/utils/Make.package
+++ b/Source/ablastr/utils/Make.package
@@ -1,6 +1,7 @@
 CEXE_sources += Communication.cpp
 CEXE_sources += RelativeCellPosition.cpp
 CEXE_sources += SignalHandling.cpp
+CEXE_sources += SystemMemory.cpp
 CEXE_sources += TextMsg.cpp
 CEXE_sources += UsedInputsFile.cpp
 

--- a/Source/ablastr/utils/SystemMemory.H
+++ b/Source/ablastr/utils/SystemMemory.H
@@ -1,0 +1,39 @@
+/* Copyright 2026 The WarpX Community
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#ifndef ABLASTR_UTILS_SYSTEM_MEMORY_H_
+#define ABLASTR_UTILS_SYSTEM_MEMORY_H_
+
+#include <cstdint>
+
+namespace ablastr::utils
+{
+
+struct SystemMemoryInfo
+{
+    std::uint64_t total_bytes = 0;
+    std::uint64_t available_bytes = 0;
+    std::uint64_t used_bytes = 0;
+    bool supported = false;
+};
+
+SystemMemoryInfo MakeSystemMemoryInfo (
+    std::uint64_t total_bytes,
+    std::uint64_t available_bytes,
+    bool supported) noexcept;
+
+SystemMemoryInfo QuerySystemMemory () noexcept;
+
+double UsedSystemMemoryFraction (SystemMemoryInfo const& info) noexcept;
+
+bool ExceedsSystemMemoryFraction (
+    SystemMemoryInfo const& info,
+    double max_fraction) noexcept;
+
+} // namespace ablastr::utils
+
+#endif // ABLASTR_UTILS_SYSTEM_MEMORY_H_

--- a/Source/ablastr/utils/SystemMemory.cpp
+++ b/Source/ablastr/utils/SystemMemory.cpp
@@ -1,0 +1,193 @@
+/* Copyright 2026 The WarpX Community
+ *
+ * This file is part of WarpX.
+ *
+ * License: BSD-3-Clause-LBNL
+ */
+
+#include "SystemMemory.H"
+
+#if defined(__linux__)
+#include <sys/sysinfo.h>
+#elif defined(__APPLE__) && defined(__MACH__)
+#include <mach/mach.h>
+#include <sys/sysctl.h>
+#endif
+
+#include <algorithm>
+#include <cstdint>
+#include <fstream>
+#include <limits>
+#include <string>
+#include <unordered_map>
+
+namespace
+{
+    std::uint64_t saturating_add (std::uint64_t lhs, std::uint64_t rhs) noexcept
+    {
+        constexpr auto max_value = std::numeric_limits<std::uint64_t>::max();
+        if (max_value - lhs < rhs) {
+            return max_value;
+        }
+        return lhs + rhs;
+    }
+
+    std::uint64_t saturating_multiply (std::uint64_t lhs, std::uint64_t rhs) noexcept
+    {
+        constexpr auto max_value = std::numeric_limits<std::uint64_t>::max();
+        if (lhs != 0 && max_value / lhs < rhs) {
+            return max_value;
+        }
+        return lhs * rhs;
+    }
+
+#if defined(__linux__)
+    std::unordered_map<std::string, std::uint64_t> read_meminfo_kb ()
+    {
+        auto values = std::unordered_map<std::string, std::uint64_t>{};
+
+        auto file = std::ifstream{"/proc/meminfo"};
+        auto key = std::string{};
+        auto unit = std::string{};
+        auto value = std::uint64_t{};
+
+        while (file >> key >> value >> unit) {
+            if (!key.empty() && key.back() == ':') {
+                key.pop_back();
+            }
+            values[key] = value;
+        }
+
+        return values;
+    }
+#endif
+} // namespace
+
+namespace ablastr::utils
+{
+
+SystemMemoryInfo MakeSystemMemoryInfo (
+    std::uint64_t total_bytes,
+    std::uint64_t available_bytes,
+    bool supported) noexcept
+{
+    if (!supported || total_bytes == 0) {
+        return {};
+    }
+
+    available_bytes = std::min(available_bytes, total_bytes);
+
+    return SystemMemoryInfo{
+        total_bytes,
+        available_bytes,
+        total_bytes - available_bytes,
+        true};
+}
+
+SystemMemoryInfo QuerySystemMemory () noexcept
+{
+#if defined(__linux__)
+    auto const meminfo = read_meminfo_kb();
+    auto const total_it = meminfo.find("MemTotal");
+    if (total_it != meminfo.end()) {
+        auto const available_it = meminfo.find("MemAvailable");
+        std::uint64_t available_kb = 0;
+
+        if (available_it != meminfo.end()) {
+            available_kb = available_it->second;
+        } else {
+            for (auto const* key : {"MemFree", "Buffers", "Cached", "SReclaimable"}) {
+                auto const it = meminfo.find(key);
+                if (it != meminfo.end()) {
+                    available_kb = saturating_add(available_kb, it->second);
+                }
+            }
+            auto const shmem_it = meminfo.find("Shmem");
+            if (shmem_it != meminfo.end()) {
+                // Subtract shared memory, saturating at zero: when Shmem is at
+                // least the accumulated total, treat available as zero rather
+                // than leaving it overstated.
+                available_kb = (available_kb > shmem_it->second)
+                    ? available_kb - shmem_it->second
+                    : std::uint64_t{0};
+            }
+        }
+
+        return MakeSystemMemoryInfo(
+            saturating_multiply(total_it->second, 1024),
+            saturating_multiply(available_kb, 1024),
+            true);
+    }
+
+    struct sysinfo info{};
+    if (sysinfo(&info) == 0) {
+        auto const mem_unit = static_cast<std::uint64_t>(info.mem_unit);
+        auto const total_bytes = saturating_multiply(
+            static_cast<std::uint64_t>(info.totalram), mem_unit);
+        auto const available_pages = saturating_add(
+            static_cast<std::uint64_t>(info.freeram),
+            static_cast<std::uint64_t>(info.bufferram));
+        return MakeSystemMemoryInfo(
+            total_bytes,
+            saturating_multiply(available_pages, mem_unit),
+            true);
+    }
+#elif defined(__APPLE__) && defined(__MACH__)
+    std::uint64_t total_bytes = 0;
+    auto total_size = sizeof(total_bytes);
+    if (sysctlbyname("hw.memsize", &total_bytes, &total_size, nullptr, 0) != 0) {
+        return {};
+    }
+
+    auto page_size = vm_size_t{};
+    if (host_page_size(mach_host_self(), &page_size) != KERN_SUCCESS) {
+        return {};
+    }
+
+    auto vm_stats = vm_statistics64_data_t{};
+    auto count = static_cast<mach_msg_type_number_t>(HOST_VM_INFO64_COUNT);
+    if (host_statistics64(
+            mach_host_self(),
+            HOST_VM_INFO64,
+            reinterpret_cast<host_info64_t>(&vm_stats),
+            &count) != KERN_SUCCESS)
+    {
+        return {};
+    }
+
+    // On macOS, "available" is defined here as pages the kernel can reuse
+    // without swapping: free, inactive, and speculative pages.
+    auto const available_pages = saturating_add(
+        saturating_add(
+            static_cast<std::uint64_t>(vm_stats.free_count),
+            static_cast<std::uint64_t>(vm_stats.inactive_count)),
+        static_cast<std::uint64_t>(vm_stats.speculative_count));
+
+    return MakeSystemMemoryInfo(
+        total_bytes,
+        saturating_multiply(available_pages, static_cast<std::uint64_t>(page_size)),
+        true);
+#endif
+
+    return {};
+}
+
+double UsedSystemMemoryFraction (SystemMemoryInfo const& info) noexcept
+{
+    if (!info.supported || info.total_bytes == 0) {
+        return 0.0;
+    }
+
+    return static_cast<double>(info.used_bytes) / static_cast<double>(info.total_bytes);
+}
+
+bool ExceedsSystemMemoryFraction (
+    SystemMemoryInfo const& info,
+    double max_fraction) noexcept
+{
+    return info.supported &&
+        info.total_bytes != 0 &&
+        UsedSystemMemoryFraction(info) > max_fraction;
+}
+
+} // namespace ablastr::utils


### PR DESCRIPTION

## Motivation

Long-running simulations can become unresponsive when host/node physical memory pressure grows until the operating system intervenes. This adds an opt-in guard that lets users ask WarpX to abort cleanly before a node reaches host physical-memory exhaustion.

This PR does not detect scheduler, cgroup, or container memory limits. Those limits can be lower than host/node physical memory and are a possible follow-up.

The guard is disabled by default, so existing inputs preserve current behavior.

## Design

This PR adds two WarpX inputs:

- `warpx.max_system_memory_fraction`, default `0.0`. Exactly `0.0` disables the guard. Values in `(0, 1]` enable it. Negative, non-finite, and greater-than-one values abort early.
- `warpx.system_memory_check_interval`, default `1`. This is the number of time steps between checks and must be at least `1`.

The settings are parsed during WarpX startup and invalid values abort early with `WARPX_ABORT_WITH_MESSAGE`. If a user enables the guard on an unsupported host/node-memory telemetry platform, WarpX also aborts at startup with a clear parameter-specific error.

The runtime hook is deterministic: `WarpX::Evolve` checks once at the start of each `Evolve` call and then checks at the configured step interval after signal handling and before iteration work. This PR intentionally does not add a daemon thread or process watchdog.

## Portability

The portable memory query is isolated in `ablastr::utils`:

- Linux reads host/node physical memory from `/proc/meminfo`, using `MemTotal` and `MemAvailable` when present. If `MemAvailable` is missing, it falls back to reclaimable fields from `/proc/meminfo`, then to `sysinfo`.
- macOS uses `sysctlbyname("hw.memsize")` for physical memory and `host_statistics64(HOST_VM_INFO64)` for VM page counters. In this implementation, available memory is defined as free plus inactive plus speculative pages.
- Unsupported operating systems report `supported=false`. The guard remains a no-op when disabled and aborts at startup if explicitly enabled.

The helper is kept local to WarpX/ablastr in this first PR, but it is deliberately small and could move to AMReX later if maintainers prefer a shared host/node-memory telemetry primitive. Scheduler/cgroup/container limit detection is intentionally out of scope for this PR.

## MPI semantics

The threshold is based on host/node physical memory pressure, not summed per-rank RSS and not scheduler/cgroup limits. Each rank samples the host memory visible on its node, computes whether the node is over threshold, and `amrex::ParallelDescriptor::ReduceBoolOr` makes the abort decision collective so all ranks exit together.

The abort message includes the parameter name, step, local used/total/available bytes, local observed fraction, maximum observed fraction across ranks, whether this rank exceeded the threshold, the threshold, and the remediation text: lower problem size or raise `warpx.max_system_memory_fraction`.

## Testing

- `git diff --check`
- Incremental CPU 2D WarpX rebuild from `development` `f199fe2` with `WarpX_DIMS=2`, `WarpX_COMPUTE=NOACC`, `WarpX_MPI=ON`, and `BUILD_TESTING=ON`.
- `ctest --test-dir build -R SystemMemory --output-on-failure`: `WarpXSystemMemoryInfoTest` and `WarpXSystemMemoryGuardTest` passed.
- Smoke runs covered default no-op, enabled `0.01` clean abort, invalid negative, invalid greater-than-one, invalid parseable NaN, and 2-rank MPI collective abort behavior.

