### PR TITLE
use exit_status for nonlinear solvers.

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -400,7 +400,14 @@ void WarpX::OneStep (
     // implicit solver
     if (m_implicit_solver) {
         // advance fields and particles by one time step
-        m_implicit_solver->OneStep(a_cur_time, a_dt, a_step);
+        const int exit_status = m_implicit_solver->OneStep(a_cur_time, a_dt, a_step);
+        if (exit_status < 0) {
+            std::stringstream solverMsg;
+            solverMsg << "ImplicitSolver::OneStep() failed at step = " << a_step
+                      << " using dt = " << a_dt << ".\n"
+                      << "Nonlinear solver failed to converge: exit status = " << exit_status;
+            WARPX_ABORT_WITH_MESSAGE(solverMsg.str());
+        }
     }
     // explicit solver
     else {

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
@@ -61,9 +61,9 @@ public:
     /**
      * \brief Advance fields and particles by one time step using the specified implicit algorithm
      */
-    virtual void OneStep ( amrex::Real  a_time,
-                           amrex::Real  a_dt,
-                           int          a_step ) = 0;
+    virtual int OneStep (amrex::Real  a_time,
+                         amrex::Real  a_dt,
+                         int          a_step) = 0;
 
     //
     // the following routines are called by the linear and nonlinear solvers

--- a/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.H
+++ b/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.H
@@ -57,9 +57,9 @@ public:
 
     void PrintParameters () const override;
 
-    void OneStep ( amrex::Real  start_time,
-                   amrex::Real  a_dt,
-                   int          a_step ) override;
+    int OneStep (amrex::Real  start_time,
+                 amrex::Real  a_dt,
+                 int          a_step) override;
 
     void ComputeRHS ( WarpXSolverVec&  a_RHS,
                 const WarpXSolverVec&  a_E,

--- a/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
@@ -57,9 +57,9 @@ void SemiImplicitEM::PrintParameters () const
     amrex::Print() << "-----------------------------------------------------------\n\n";
 }
 
-void SemiImplicitEM::OneStep ( amrex::Real  start_time,
-                               amrex::Real  a_dt,
-                               int          a_step )
+int SemiImplicitEM::OneStep (amrex::Real  start_time,
+                             amrex::Real  a_dt,
+                             int          a_step)
 {
     BL_PROFILE("SemiImplicitEM::OneStep()");
 
@@ -92,6 +92,9 @@ void SemiImplicitEM::OneStep ( amrex::Real  start_time,
     // Particles will be advanced to t_{n+1/2}
     m_nlsolver->Solve(m_E, m_Eold, start_time, m_dt, a_step);
 
+    const int exit_status = m_nlsolver->GetExitStatus();
+    if (exit_status < 0) { return exit_status; }
+
     // Update WarpX owned Efield_fp to t_{n+1/2}
     m_WarpX->SetElectricFieldAndApplyBCs(m_E, half_time);
     m_WarpX->reduced_diags->ComputeDiagsMidStep(a_step);
@@ -110,6 +113,7 @@ void SemiImplicitEM::OneStep ( amrex::Real  start_time,
     m_WarpX->EvolveB(0.5_rt*m_dt, SubcyclingHalf::SecondHalf, half_time);
     m_WarpX->FillBoundaryB(m_WarpX->getngEB(), true);
 
+    return exit_status;
 }
 
 void SemiImplicitEM::ComputeRHS ( WarpXSolverVec&  a_RHS,

--- a/Source/FieldSolver/ImplicitSolvers/StrangImplicitSpectralEM.H
+++ b/Source/FieldSolver/ImplicitSolvers/StrangImplicitSpectralEM.H
@@ -58,9 +58,9 @@ public:
 
     void PrintParameters () const override;
 
-    void OneStep ( amrex::Real  start_time,
-                   amrex::Real  a_dt,
-                   int          a_step ) override;
+    int OneStep (amrex::Real  start_time,
+                 amrex::Real  a_dt,
+                 int          a_step) override;
 
     void ComputeRHS ( WarpXSolverVec&  a_RHS,
                 const WarpXSolverVec&  a_E,

--- a/Source/FieldSolver/ImplicitSolvers/StrangImplicitSpectralEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/StrangImplicitSpectralEM.cpp
@@ -55,9 +55,9 @@ void StrangImplicitSpectralEM::PrintParameters () const
     amrex::Print() << "-----------------------------------------------------------\n\n";
 }
 
-void StrangImplicitSpectralEM::OneStep ( amrex::Real start_time,
-                                         amrex::Real a_dt,
-                                         int a_step )
+int StrangImplicitSpectralEM::OneStep (amrex::Real start_time,
+                                       amrex::Real a_dt,
+                                       int a_step)
 {
     amrex::ignore_unused(a_step);
 
@@ -87,6 +87,9 @@ void StrangImplicitSpectralEM::OneStep ( amrex::Real start_time,
     // Particles will be advanced to t_{n+1/2}
     m_nlsolver->Solve(m_E, m_Eold, start_time, m_dt, a_step);
 
+    const int exit_status = m_nlsolver->GetExitStatus();
+    if (exit_status < 0) { return exit_status; }
+
     // Update WarpX owned Efield_fp and Bfield_fp to t_{n+1/2}
     UpdateWarpXFields(m_E, half_time);
     m_WarpX->reduced_diags->ComputeDiagsMidStep(a_step);
@@ -102,6 +105,7 @@ void StrangImplicitSpectralEM::OneStep ( amrex::Real start_time,
     // Advance the fields to time n+1 source free
     m_WarpX->SpectralSourceFreeFieldAdvance(half_time);
 
+    return exit_status;
 }
 
 void StrangImplicitSpectralEM::ComputeRHS ( WarpXSolverVec& a_RHS,

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.H
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.H
@@ -74,9 +74,9 @@ public:
      * \param[in] a_dt The time step size
      * \param[in] a_step The time step number
      */
-    void OneStep ( amrex::Real  start_time,
-                   amrex::Real  a_dt,
-                   int          a_step ) override;
+    int OneStep (amrex::Real  start_time,
+                 amrex::Real  a_dt,
+                 int          a_step) override;
 
     void ComputeRHS ( WarpXSolverVec&  a_RHS,
                 const WarpXSolverVec&  a_E,

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
@@ -83,9 +83,9 @@ void ThetaImplicitEM::PrintParameters () const
     amrex::Print() << "-----------------------------------------------------------\n\n";
 }
 
-void ThetaImplicitEM::OneStep ( const amrex::Real  start_time,
-                                const amrex::Real  a_dt,
-                                const int          a_step )
+int ThetaImplicitEM::OneStep (const amrex::Real  start_time,
+                              const amrex::Real  a_dt,
+                              const int          a_step)
 {
     BL_PROFILE("ThetaImplicitEM::OneStep()");
 
@@ -122,12 +122,7 @@ void ThetaImplicitEM::OneStep ( const amrex::Real  start_time,
     m_nlsolver->Solve(m_E, m_Eold, start_time, m_dt, a_step);
 
     const int exit_status = m_nlsolver->GetExitStatus();
-    if (exit_status < 0) {
-        std::stringstream solverMsg;
-        solverMsg << "Nonlinear solver failed to converge."
-                  << "Exit status = " << exit_status;
-        WARPX_ABORT_WITH_MESSAGE(solverMsg.str());
-    }
+    if (exit_status < 0) { return exit_status; }
 
     // Update WarpX owned Efield_fp and Bfield_fp to t_{n+theta}
     UpdateWarpXFields(m_E, start_time);
@@ -141,6 +136,7 @@ void ThetaImplicitEM::OneStep ( const amrex::Real  start_time,
     // Advance Eg and Bg from time n+theta to time n+1
     FinishFieldUpdate(new_time);
 
+    return exit_status;
 }
 
 void ThetaImplicitEM::ComputeRHS ( WarpXSolverVec&  a_RHS,

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
@@ -121,6 +121,14 @@ void ThetaImplicitEM::OneStep ( const amrex::Real  start_time,
     // Particles will be advanced to t_{n+1/2}
     m_nlsolver->Solve(m_E, m_Eold, start_time, m_dt, a_step);
 
+    const int exit_status = m_nlsolver->GetExitStatus();
+    if (exit_status < 0) {
+        std::stringstream solverMsg;
+        solverMsg << "Nonlinear solver failed to converge."
+                  << "Exit status = " << exit_status;
+        WARPX_ABORT_WITH_MESSAGE(solverMsg.str());
+    }
+
     // Update WarpX owned Efield_fp and Bfield_fp to t_{n+theta}
     UpdateWarpXFields(m_E, start_time);
     m_WarpX->reduced_diags->ComputeDiagsMidStep(a_step);

--- a/Source/NonlinearSolvers/NewtonSolver.H
+++ b/Source/NonlinearSolvers/NewtonSolver.H
@@ -42,18 +42,18 @@ public:
     NewtonSolver(NewtonSolver&&) noexcept = delete;
     NewtonSolver& operator=(NewtonSolver&&) noexcept = delete;
 
-    void Define ( const Vec&  a_U,
-                        Ops*  a_ops ) override;
+    void Define (const Vec&  a_U,
+                       Ops*  a_ops) override;
 
-    void Solve ( Vec&   a_U,
-           const Vec&   a_b,
-           amrex::Real  a_time,
-           amrex::Real  a_dt,
-           int          a_step) const override;
+    void Solve (Vec&   a_U,
+          const Vec&   a_b,
+          amrex::Real  a_time,
+          amrex::Real  a_dt,
+          int          a_step) const override;
 
-    void GetSolverParams ( amrex::Real&  a_rtol,
-                           amrex::Real&  a_atol,
-                           int&          a_maxits ) override
+    void GetSolverParams (amrex::Real&  a_rtol,
+                          amrex::Real&  a_atol,
+                          int&          a_maxits) override
     {
         a_rtol = m_rtol;
         a_atol = m_atol;
@@ -307,11 +307,11 @@ void NewtonSolver<Vec,Ops>::ParseParameters ()
 }
 
 template <class Vec, class Ops>
-void NewtonSolver<Vec,Ops>::Solve ( Vec&         a_U,
-                              const Vec&         a_b,
-                                    amrex::Real  a_time,
-                                    amrex::Real  a_dt,
-                                    int          a_step) const
+void NewtonSolver<Vec,Ops>::Solve (Vec&         a_U,
+                             const Vec&         a_b,
+                                   amrex::Real  a_time,
+                                   amrex::Real  a_dt,
+                                   int          a_step) const
 {
     BL_PROFILE("NewtonSolver::Solve()");
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
@@ -354,6 +354,7 @@ void NewtonSolver<Vec,Ops>::Solve ( Vec&         a_U,
         }
 
         if (norm_abs < m_atol) {
+            this->m_exit_status = 2;
             if (this->m_verbose) {
                 amrex::Print() << "Newton: exiting at iteration = " << std::setw(3) << iter
                                << ". Satisfied absolute tolerance " << m_atol << "\n";
@@ -362,6 +363,7 @@ void NewtonSolver<Vec,Ops>::Solve ( Vec&         a_U,
         }
 
         if (norm_rel < m_rtol) {
+            this->m_exit_status = 3;
             if (this->m_verbose) {
                 amrex::Print() << "Newton: exiting at iteration = " << std::setw(3) << iter
                                << ". Satisfied relative tolerance " << m_rtol << "\n";
@@ -370,6 +372,7 @@ void NewtonSolver<Vec,Ops>::Solve ( Vec&         a_U,
         }
 
         if (norm_abs > 100._rt*norm0) {
+            this->m_exit_status = -9;
             amrex::Print() << "Newton: exiting at iteration = " << std::setw(3) << iter
                            << ". SOLVER DIVERGED! relative tolerance = " << m_rtol << "\n";
             std::stringstream convergenceMsg;
@@ -409,18 +412,17 @@ void NewtonSolver<Vec,Ops>::Solve ( Vec&         a_U,
     m_total_linsol_iters += linear_solver_iters;
 
     if (m_rtol > 0. && iter == m_maxits) {
-       std::stringstream convergenceMsg;
-       convergenceMsg << "Newton solver failed to converge after " << iter <<
-                         " iterations. Relative norm is " << norm_rel <<
-                         " and the relative tolerance is " << m_rtol <<
-                         ". Absolute norm is " << norm_abs <<
-                         " and the absolute tolerance is " << m_atol;
-       if (this->m_verbose) { amrex::Print() << convergenceMsg.str() << "\n"; }
-       if (m_require_convergence) {
-           WARPX_ABORT_WITH_MESSAGE(convergenceMsg.str());
-       } else {
-           ablastr::warn_manager::WMRecordWarning("NewtonSolver", convergenceMsg.str());
-       }
+        std::stringstream convergenceMsg;
+        convergenceMsg << "Newton solver failed to converge after " << iter <<
+                          " iterations. Relative norm is " << norm_rel <<
+                          " and the relative tolerance is " << m_rtol <<
+                          ". Absolute norm is " << norm_abs <<
+                          " and the absolute tolerance is " << m_atol;
+        if (this->m_verbose) { amrex::Print() << convergenceMsg.str() << "\n"; }
+        ablastr::warn_manager::WMRecordWarning("NewtonSolver", convergenceMsg.str());
+
+        if (m_require_convergence) { this->m_exit_status = -5; }
+        else { this->m_exit_status = 0; }
     }
 
     if (!this->m_diagnostic_file.empty() && amrex::ParallelDescriptor::IOProcessor() &&

--- a/Source/NonlinearSolvers/NonlinearSolver.H
+++ b/Source/NonlinearSolvers/NonlinearSolver.H
@@ -58,11 +58,16 @@ public:
      *  Picard: U = b + R(U).
      *  Newton: F(U) = U - b - R(U) = 0.
      */
-    virtual void Solve ( Vec&,
-                   const Vec&,
-                         amrex::Real,
-                         amrex::Real,
-                         int) const = 0;
+    virtual void Solve (Vec&,
+                  const Vec&,
+                        amrex::Real,
+                        amrex::Real,
+                        int) const = 0;
+
+    /**
+     * \brief Return the nonlinear solver exit status.
+     */
+    int GetExitStatus() const { return m_exit_status; }
 
     /**
      * \brief Print parameters used by the nonlinear solver.
@@ -92,6 +97,8 @@ protected:
     std::string m_diagnostic_file;
     int m_diagnostic_interval = 1;
     bool m_usePC = false;
+
+    mutable int m_exit_status = 0;
 
 };
 

--- a/Source/NonlinearSolvers/PETScSNES_Wrapper.H
+++ b/Source/NonlinearSolvers/PETScSNES_Wrapper.H
@@ -59,13 +59,14 @@ class PETScSNES : public NonlinearSolver<Vec,Ops>
             this->m_usePC = m_solver->usePC();
         }
 
-        void Solve ( Vec& a_U,
-                     const Vec& a_b,
-                     RT a_time,
-                     RT a_dt,
-                     int a_step)  const override
+        void Solve (Vec& a_U,
+                    const Vec& a_b,
+                    RT a_time,
+                    RT a_dt,
+                    int a_step)  const override
         {
             m_solver->solve(a_U, a_b, a_time, a_dt, a_step);
+            this->m_exit_status = m_solver->getStatus();
 
             if (    !this->m_diagnostic_file.empty() && amrex::ParallelDescriptor::IOProcessor()
                 &&  ((a_step+1)%this->m_diagnostic_interval==0 || a_step==0)) {

--- a/Source/NonlinearSolvers/PicardSolver.H
+++ b/Source/NonlinearSolvers/PicardSolver.H
@@ -38,18 +38,18 @@ public:
     PicardSolver(PicardSolver&&) noexcept = delete;
     PicardSolver& operator=(PicardSolver&&) noexcept = delete;
 
-    void Define ( const Vec&  a_U,
-                        Ops*  a_ops ) override;
+    void Define (const Vec&  a_U,
+                       Ops*  a_ops) override;
 
-    void Solve ( Vec&   a_U,
-           const Vec&   a_b,
-           amrex::Real  a_time,
-           amrex::Real  a_dt,
-           int          a_step) const override;
+    void Solve (Vec&   a_U,
+          const Vec&   a_b,
+          amrex::Real  a_time,
+          amrex::Real  a_dt,
+          int          a_step) const override;
 
-    void GetSolverParams ( amrex::Real&  a_rtol,
-                           amrex::Real&  a_atol,
-                           int&          a_maxits ) override
+    void GetSolverParams (amrex::Real&  a_rtol,
+                          amrex::Real&  a_atol,
+                          int&          a_maxits) override
     {
         a_rtol = m_rtol;
         a_atol = m_atol;
@@ -106,8 +106,8 @@ private:
 };
 
 template <class Vec, class Ops>
-void PicardSolver<Vec,Ops>::Define ( const Vec&  a_U,
-                                     Ops*        a_ops )
+void PicardSolver<Vec,Ops>::Define (const Vec&  a_U,
+                                    Ops*        a_ops)
 {
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         !this->m_is_defined,
@@ -167,11 +167,11 @@ void PicardSolver<Vec,Ops>::ParseParameters ()
 }
 
 template <class Vec, class Ops>
-void PicardSolver<Vec,Ops>::Solve ( Vec&         a_U,
-                              const Vec&         a_b,
-                                    amrex::Real  a_time,
-                                    amrex::Real  a_dt,
-                                    int          a_step) const
+void PicardSolver<Vec,Ops>::Solve (Vec&         a_U,
+                             const Vec&         a_b,
+                                   amrex::Real  a_time,
+                                   amrex::Real  a_dt,
+                                   int          a_step) const
 {
     BL_PROFILE("PicardSolver::Solve()");
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
@@ -217,6 +217,7 @@ void PicardSolver<Vec,Ops>::Solve ( Vec&         a_U,
         }
 
         if (norm_abs < m_atol) {
+            this->m_exit_status = 2;
             if (this->m_verbose) {
                 amrex::Print() << "Picard: exiting at iter = " << std::setw(3) << iter
                                << ". Satisfied absolute tolerance " << m_atol << "\n";
@@ -225,6 +226,7 @@ void PicardSolver<Vec,Ops>::Solve ( Vec&         a_U,
         }
 
         if (norm_rel < m_rtol) {
+            this->m_exit_status = 3;
             if (this->m_verbose) {
                 amrex::Print() << "Picard: exiting at iter = " << std::setw(3) << iter
                                << ". Satisfied relative tolerance " << m_rtol << "\n";
@@ -246,18 +248,17 @@ void PicardSolver<Vec,Ops>::Solve ( Vec&         a_U,
     m_total_iters += iter;
 
     if (m_rtol > 0. && iter == m_maxits) {
-       std::stringstream convergenceMsg;
-       convergenceMsg << "Picard solver failed to converge after " << iter <<
-                         " iterations. Relative norm is " << norm_rel <<
-                         " and the relative tolerance is " << m_rtol <<
-                         ". Absolute norm is " << norm_abs <<
-                         " and the absolute tolerance is " << m_atol;
-       if (this->m_verbose) { amrex::Print() << convergenceMsg.str() << "\n"; }
-       if (m_require_convergence) {
-           WARPX_ABORT_WITH_MESSAGE(convergenceMsg.str());
-       } else {
-           ablastr::warn_manager::WMRecordWarning("PicardSolver", convergenceMsg.str());
-       }
+        std::stringstream convergenceMsg;
+        convergenceMsg << "Picard solver failed to converge after " << iter <<
+                          " iterations. Relative norm is " << norm_rel <<
+                          " and the relative tolerance is " << m_rtol <<
+                          ". Absolute norm is " << norm_abs <<
+                          " and the absolute tolerance is " << m_atol;
+        if (this->m_verbose) { amrex::Print() << convergenceMsg.str() << "\n"; }
+        ablastr::warn_manager::WMRecordWarning("PicardSolver", convergenceMsg.str());
+
+        if (m_require_convergence) { this->m_exit_status = -5; }
+        else { this->m_exit_status = 0; }
     }
 
     if (!this->m_diagnostic_file.empty() && amrex::ParallelDescriptor::IOProcessor() &&

--- a/Source/NonlinearSolvers/WarpX_PETSc.H
+++ b/Source/NonlinearSolvers/WarpX_PETSc.H
@@ -153,13 +153,13 @@ class KSP_impl : public PETScSolver_impl
         //! Set verbosity
         void setVerbose(int);
 
-        //! Get number of iterations for recentmost solve
+        //! Get number of iterations for recent most solve
         inline int getNumIters() const { return m_niters; }
 
-        //! Get status for recentmost solve
+        //! Get status for recent most linear solve
         inline int getStatus() const { return m_status; }
 
-        //! Get relative norm for recentmost solve
+        //! Get relative norm for recent most solve
         inline amrex::Real getResidualNorm() const { return m_norm; }
 
         //! Check if object is defined
@@ -182,11 +182,11 @@ class KSP_impl : public PETScSolver_impl
         //! verbosity
         int m_verbose = 1;
 
-        //! number of iterations for recentmost solve
+        //! number of iterations for recent most solve
         int m_niters = -1;
-        //! status for recentmost solve
+        //! status for recent most solve
         int m_status = -1;
-        //! residual norm (relative) for recentmost solve
+        //! residual norm (relative) for recent most solve
         amrex::Real m_norm = DBL_MAX;
 
         //! Solver object
@@ -274,6 +274,9 @@ class SNES_impl : public PETScSolver_impl
         AMREX_FORCE_INLINE
         auto normLinResidual() const { return m_norm_lin; }
 
+        //! Get status for recent most nonlinear solve
+        inline int getStatus() const { return m_status; }
+
         //! Using SNES FD?
         bool m_fd_jac_comput = false;
 
@@ -302,15 +305,15 @@ class SNES_impl : public PETScSolver_impl
         //! maximum iterations
         int m_maxits_l = 1000;
 
-        //! number of iterations for recentmost solve
+        //! number of iterations for recent most solve
         mutable int m_niters = -1;
-        //! number of linear solver iterations for recentmost solve
+        //! number of linear solver iterations for recent most solve
         mutable int m_niters_l = -1;
-        //! status for recentmost solve
+        //! status for recent most solve
         mutable int m_status = -1;
-        //! residual norm (relative) for recentmost solve
+        //! residual norm (relative) for recent most solve
         mutable amrex::Real m_norm = DBL_MAX;
-        //! residual norm (relative) for recentmost linear solve
+        //! residual norm (relative) for recent most linear solve
         mutable amrex::Real m_norm_lin = DBL_MAX;
 
         //! Simulation time

--- a/Source/NonlinearSolvers/WarpX_PETSc.cpp
+++ b/Source/NonlinearSolvers/WarpX_PETSc.cpp
@@ -781,11 +781,11 @@ bool SNES_impl::usePC() const
     return dynamic_cast<JacobianFunctionMF<VecType,TIType>*>(m_linop.get())->usePreconditioner();
 }
 
-void SNES_impl::solve(  VecType& a_U,
-                        const VecType& a_B,
-                        amrex::Real a_time,
-                        amrex::Real a_dt,
-                        int a_step ) const
+void SNES_impl::solve (VecType& a_U,
+                       const VecType& a_B,
+                       amrex::Real a_time,
+                       amrex::Real a_dt,
+                       int a_step) const
 {
     BL_PROFILE("SNES_impl::solve()");
     AMREX_ALWAYS_ASSERT(isDefined());
@@ -808,11 +808,12 @@ void SNES_impl::solve(  VecType& a_U,
 
     SNESConvergedReason reason;
     SNESGetConvergedReason( m_snes->obj, &reason );
-    m_status = (int) reason;
+    m_status = (int)reason;
     SNESGetFunctionNorm(m_snes->obj, &m_norm);
 
     const char* conv_reason;
     SNESGetConvergedReasonString(m_snes->obj, &conv_reason);
+    // see https://petsc.org/release/docs/manualpages/SNES/SNESConvergedReason/
     if (m_verbose) {
         amrex::Print() << "Newton (PETSc SNES): exited due to \""
                        << conv_reason << "\" "


### PR DESCRIPTION
This PR adds an `exit_status` flag to the nonlinear solvers used by the implicit time-advance routines. This functionality is needed for a future PR that will improve solver robustness by allowing failed implicit steps to be sub-cycled and retried, rather than aborting execution when a nonlinear solve does not converge.

The `exit_status `values correspond to PETSc's SNESConvergedReason enumeration:
https://petsc.org/release/docs/manualpages/SNES/SNESConvergedReason/