### PR TITLE
Load External Field directly into Pinned Memory

### DIFF
--- a/Source/Initialization/ExternalField.cpp
+++ b/Source/Initialization/ExternalField.cpp
@@ -391,7 +391,7 @@ void ExternalFieldReader::load_data (amrex::RealBox const& pbox)
 
     if (has_load) {
         const auto num_cells = std::accumulate(chunk_extent.begin(), chunk_extent.end(),
-                                               1, std::multiplies<std::uint64_t>());
+                                               1, std::multiplies<>());
         m_FC_data_cpu.reset(
             reinterpret_cast<double*>(amrex::The_Pinned_Arena()->alloc(num_cells*sizeof(double))),
             [](double *p){ amrex::The_Pinned_Arena()->free(reinterpret_cast<void*>(p)); });

--- a/Source/Initialization/ExternalField.cpp
+++ b/Source/Initialization/ExternalField.cpp
@@ -390,7 +390,12 @@ void ExternalFieldReader::load_data (amrex::RealBox const& pbox)
 #endif
 
     if (has_load) {
-        m_FC_data_cpu = FC.loadChunk<double>(chunk_offset,chunk_extent);
+        const auto num_cells = std::accumulate(chunk_extent.begin(), chunk_extent.end(),
+                                               1, std::multiplies<std::uint64_t>());
+        m_FC_data_cpu.reset(
+            reinterpret_cast<double*>(amrex::The_Pinned_Arena()->alloc(num_cells*sizeof(double))),
+            [](double *p){ amrex::The_Pinned_Arena()->free(reinterpret_cast<void*>(p)); });
+        FC.loadChunk<double>(m_FC_data_cpu, chunk_offset, chunk_extent);
     }
     series.flush();
 


### PR DESCRIPTION
After loading the data a `Gpu::htod_memcpy_async` is done. For this it is better if the data is in pinned memory, otherwise it has to be copied to pinned memory first before it goes to the GPU. Additionally on Jupiter I was seeing "unspecified launch failure" CUDA errors from the htod_memcpy_async which got fixed by this change.