### PR TITLE
Add ability to choose mesh in particle density file

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1623,7 +1623,8 @@ Particle initialization
     * ``read_from_file``: load the density profile from an openPMD file.
       An additional parameter, indicating the path of an openPMD data file,
       ``<species_name>.read_density_from_path`` must be specified. The openPMD
-      file must contain a field named ``density``. See
+      file must contain a field with the name given by ``<species_name>.density_mesh_name``
+      (default ``density``). See
       `this file <https://github.com/BLAST-WarpX/warpx/blob/development/Examples/Tests/load_density/inputs_test_3d_load_density_prepare.py>`__
       for an example of how to prepare the openPMD data file. There is
       another optional parameter,

--- a/Source/Initialization/InjectorDensity.H
+++ b/Source/Initialization/InjectorDensity.H
@@ -62,7 +62,8 @@ struct InjectorDensityParser
 // struct whose getDensity returns density from file.
 struct InjectorDensityFromFile
 {
-    InjectorDensityFromFile (std::string const& a_file_name, amrex::Geometry const& a_geom, bool a_distributed);
+    InjectorDensityFromFile (std::string const& a_file_name, std::string const& a_F_name,
+                             amrex::Geometry const& a_geom, bool a_distributed);
 
     void clear ();
 
@@ -135,9 +136,10 @@ struct InjectorDensity
 
     // This constructor stores a InjectorDensityFromFile in union object.
     InjectorDensity (InjectorDensityFromFile* t, std::string const& a_file_name,
-                     amrex::Geometry const& a_geom, bool a_distributed)
+                     std::string const& a_F_name, amrex::Geometry const& a_geom,
+                     bool a_distributed)
         : type(Type::fromfile),
-          object(t,a_file_name,a_geom,a_distributed)
+          object(t,a_file_name,a_F_name,a_geom,a_distributed)
     { }
 
     // Explicitly prevent the compiler from generating copy constructors
@@ -207,8 +209,9 @@ private:
         Object (InjectorDensityParser*, amrex::ParserExecutor<3> const& a_parser) noexcept
             : parser(a_parser) {}
         Object (InjectorDensityFromFile*, std::string const& a_file_name,
-                amrex::Geometry const& a_geom, bool a_distributed)
-            : fromfile(a_file_name, a_geom, a_distributed) {}
+                std::string const& a_F_name, amrex::Geometry const& a_geom,
+                bool a_distributed)
+            : fromfile(a_file_name, a_F_name, a_geom, a_distributed) {}
         InjectorDensityConstant   constant;
         InjectorDensityParser     parser;
         InjectorDensityFromFile   fromfile;

--- a/Source/Initialization/InjectorDensity.cpp
+++ b/Source/Initialization/InjectorDensity.cpp
@@ -99,11 +99,12 @@ bool InjectorDensity::distributed () const
 }
 
 InjectorDensityFromFile::InjectorDensityFromFile (std::string const& a_file_name,
+                                                  std::string const& a_F_name,
                                                   amrex::Geometry const& a_geom,
                                                   bool a_distributed)
 {
     m_external_field_reader = new ExternalFieldReader
-        (a_file_name, "density", "", a_geom.ProbLoArray(), a_geom.CellSizeArray(),
+        (a_file_name, a_F_name, "", a_geom.ProbLoArray(), a_geom.CellSizeArray(),
          amrex::convert(a_geom.Domain(),amrex::IntVect(1)), a_distributed);
 }
 

--- a/Source/Utils/SpeciesUtils.cpp
+++ b/Source/Utils/SpeciesUtils.cpp
@@ -104,10 +104,13 @@ namespace SpeciesUtils {
                 density_parser->compile<3>()));
         } else if (rho_prof_s == "read_from_file") {
             std::string density_file;
+            std::string field_name = "density";
             bool distributed = true;
             utils::parser::get(pp_species, source_name, "read_density_from_path", density_file);
+            utils::parser::querry(pp_species, source_name, "density_mesh_name", field_name);
             pp_species.query("read_density_distributed", distributed);
-            h_inj_rho.reset(new InjectorDensity((InjectorDensityFromFile*)nullptr, density_file, geom, distributed));
+            h_inj_rho.reset(new InjectorDensity((InjectorDensityFromFile*)nullptr,
+                density_file, field_name, geom, distributed));
         } else {
             StringParseAbortMessage("Density profile type", rho_prof_s);
         }

--- a/Source/Utils/SpeciesUtils.cpp
+++ b/Source/Utils/SpeciesUtils.cpp
@@ -107,7 +107,7 @@ namespace SpeciesUtils {
             std::string field_name = "density";
             bool distributed = true;
             utils::parser::get(pp_species, source_name, "read_density_from_path", density_file);
-            utils::parser::querry(pp_species, source_name, "density_mesh_name", field_name);
+            utils::parser::query(pp_species, source_name, "density_mesh_name", field_name);
             pp_species.query("read_density_distributed", distributed);
             h_inj_rho.reset(new InjectorDensity((InjectorDensityFromFile*)nullptr,
                 density_file, field_name, geom, distributed));


### PR DESCRIPTION
When running a simulation with multiple spcies that each load the density from a file, it can be handy to put them all in the same file with different mesh component names. This PR adds a way to specify the mesh name instead while keeping "density" as the default.
```
elec.density_mesh_name = "dens_e"
ion_Ar.density_mesh_name = "dens_Ar"
```
The parameter name is chosen to be the same as in HiPACE++ where this functionality already exists. https://github.com/Hi-PACE/hipace/pull/1352