### PR TITLE
Add allocdata Python callback

### DIFF
--- a/Python/pywarpx/callbacks.py
+++ b/Python/pywarpx/callbacks.py
@@ -29,6 +29,7 @@ Functions can be called at the following times:
 * ``beforeInitEsolve``: before the initial solve for the E fields (i.e. before the PIC loop starts)
 * ``afterInitEsolve``: after the initial solve for the E fields (i.e. before the PIC loop starts)
 * ``afterinit``: immediately after the init is complete
+* ``allocdata``: during initialization (from scratch and from restart), when new MultiFabs should be allocated
 * ``beforeEsolve``: before the solve for E fields (not called during init E solve, use beforeInitEsolve to apply to first solve)
 * ``poissonsolver``: In place of the computePhi call but only in an electrostatic simulation
 * ``afterEsolve``: after the solve for E fields (not called after init E solve, use afterInitEsolve to apply to first solve)
@@ -282,6 +283,7 @@ callback_instances = {
     "afterInitEsolve": {},
     "afterInitatRestart": {},
     "afterinit": {},
+    "allocdata": {},
     "beforecollisions": {},
     "aftercollisions": {},
     "beforeEsolve": {},
@@ -425,6 +427,16 @@ def callfromafterinit(f):
 
 def installafterinit(f):
     installcallback("afterinit", f)
+
+
+# ----------------------------------------------------------------------------
+def callfromallocdata(f):
+    installcallback("allocdata", f)
+    return f
+
+
+def installallocdata(f):
+    installcallback("allocdata", f)
 
 
 # ----------------------------------------------------------------------------

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -24,6 +24,7 @@
 #include "FieldSolver/ImplicitSolvers/ImplicitSolver.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Particles/WarpXParticleContainer.H"
+#include "Python/callbacks.H"
 #include "Utils/TextMsg.H"
 
 #include <ablastr/fields/MultiFabRegister.H>

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -214,7 +214,7 @@ WarpX::InitFromCheckpoint ()
             AllocLevelData(lev, ba, dm);
         }
 
-        ExecutePythonCallback("allocdata")
+        ExecutePythonCallback("allocdata");
 
         mypc->ReadHeader(is);
         const int n_species = mypc->nSpecies();

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -214,6 +214,8 @@ WarpX::InitFromCheckpoint ()
             AllocLevelData(lev, ba, dm);
         }
 
+        ExecutePythonCallback("allocdata")
+
         mypc->ReadHeader(is);
         const int n_species = mypc->nSpecies();
         for (int i=0; i<n_species; i++)

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -1013,6 +1013,7 @@ WarpX::InitFromScratch ()
 
     InitPML();
 
+    ExecutePythonCallback("allocdata")
 }
 
 void

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -1013,7 +1013,7 @@ WarpX::InitFromScratch ()
 
     InitPML();
 
-    ExecutePythonCallback("allocdata")
+    ExecutePythonCallback("allocdata");
 }
 
 void


### PR DESCRIPTION
This adds a new call back to the Python interface. This call back, `allocdata`, is called during initialization, both from scratch and from restart. New MultiFabs should be allocated at this point.

This is associated with the PR #6954 which allows writing of any MultiFabs to the diagnostics and to checkpoint files. The new MultiFabs would need to be added in the `allocdata` call back to be included in the diagnostics.

This also implements similar capability from PR #6889.