### PR TITLE
Replace query/get_enum_sloppy with query/get_enum_case_insensitive

### DIFF
--- a/Source/BoundaryConditions/FieldBoundaries.cpp
+++ b/Source/BoundaryConditions/FieldBoundaries.cpp
@@ -52,11 +52,10 @@ namespace warpx::boundary_conditions
         const auto pp_boundary = amrex::ParmParse{"boundary"};
 
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-            // query_enum_sloppy with "_" needed to map "absorbing_silver_mueller" to "Absorbing_SilverMueller"
-            pp_boundary.query_enum_sloppy("field_lo",
-                field_boundary_lo[idim], "_", idim);
-            pp_boundary.query_enum_sloppy("field_hi",
-                field_boundary_hi[idim], "_", idim);
+            pp_boundary.query_enum_case_insensitive("field_lo",
+                field_boundary_lo[idim], idim);
+            pp_boundary.query_enum_case_insensitive("field_hi",
+                field_boundary_hi[idim], idim);
         }
 
         detail::check_periodicity_consistency(field_boundary_lo, field_boundary_hi);

--- a/Source/BoundaryConditions/FieldBoundaries.cpp
+++ b/Source/BoundaryConditions/FieldBoundaries.cpp
@@ -53,9 +53,9 @@ namespace warpx::boundary_conditions
 
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
             pp_boundary.query_enum_sloppy("field_lo",
-                field_boundary_lo[idim], "-_", idim);
+                field_boundary_lo[idim], "_", idim);
             pp_boundary.query_enum_sloppy("field_hi",
-                field_boundary_hi[idim], "-_", idim);
+                field_boundary_hi[idim], "_", idim);
         }
 
         detail::check_periodicity_consistency(field_boundary_lo, field_boundary_hi);

--- a/Source/BoundaryConditions/FieldBoundaries.cpp
+++ b/Source/BoundaryConditions/FieldBoundaries.cpp
@@ -52,6 +52,7 @@ namespace warpx::boundary_conditions
         const auto pp_boundary = amrex::ParmParse{"boundary"};
 
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+            // query_enum_sloppy with "_" needed to map "absorbing_silver_mueller" to "Absorbing_SilverMueller"
             pp_boundary.query_enum_sloppy("field_lo",
                 field_boundary_lo[idim], "_", idim);
             pp_boundary.query_enum_sloppy("field_hi",

--- a/Source/BoundaryConditions/PEC_Insulator.cpp
+++ b/Source/BoundaryConditions/PEC_Insulator.cpp
@@ -635,8 +635,8 @@ PEC_Insulator::ApplyPEC_InsulatortoField (
 
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 
-            if (!(field_boundary_lo[idim] == FieldBoundaryType::PECInsulator) &&
-                !(field_boundary_hi[idim] == FieldBoundaryType::PECInsulator)) { continue; }
+            if (!(field_boundary_lo[idim] == FieldBoundaryType::PEC_Insulator) &&
+                !(field_boundary_hi[idim] == FieldBoundaryType::PEC_Insulator)) { continue; }
 
             if ( (node_box.smallEnd()[idim] > domain_lo[idim]) &&
                  (node_box.bigEnd()[idim] < domain_hi[idim]) ) { continue; }
@@ -672,8 +672,8 @@ PEC_Insulator::ApplyPEC_InsulatortoField (
             // Loop over sides, iside = -1 (lo), iside = +1 (hi)
             for (int iside = -1; iside <= +1; iside += 2) {
 
-                if ((iside == -1 && (field_boundary_lo[idim] != FieldBoundaryType::PECInsulator)) ||
-                    (iside == +1 && (field_boundary_hi[idim] != FieldBoundaryType::PECInsulator))) { continue; }
+                if ((iside == -1 && (field_boundary_lo[idim] != FieldBoundaryType::PEC_Insulator)) ||
+                    (iside == +1 && (field_boundary_hi[idim] != FieldBoundaryType::PEC_Insulator))) { continue; }
 
                 if ((iside == -1 && (node_box.smallEnd()[idim] > domain_lo[idim])) ||
                     (iside == +1 && (node_box.bigEnd()[idim] < domain_hi[idim]))) { continue; }
@@ -803,8 +803,8 @@ PEC_Insulator::ZeroParallelScalarInConductor (
 
         for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
 
-            if (!(field_boundary_lo[idim] == FieldBoundaryType::PECInsulator) &&
-                !(field_boundary_hi[idim] == FieldBoundaryType::PECInsulator)) { continue; }
+            if (!(field_boundary_lo[idim] == FieldBoundaryType::PEC_Insulator) &&
+                !(field_boundary_hi[idim] == FieldBoundaryType::PEC_Insulator)) { continue; }
 
             if ( (node_box.smallEnd()[idim] > domain_lo[idim]) &&
                  (node_box.bigEnd()[idim] < domain_hi[idim]) ) { continue; }
@@ -816,8 +816,8 @@ PEC_Insulator::ZeroParallelScalarInConductor (
             // Loop over sides, iside = -1 (lo), iside = +1 (hi)
             for (int iside = -1; iside <= +1; iside += 2) {
 
-                if ((iside == -1 && (field_boundary_lo[idim] != FieldBoundaryType::PECInsulator)) ||
-                    (iside == +1 && (field_boundary_hi[idim] != FieldBoundaryType::PECInsulator))) { continue; }
+                if ((iside == -1 && (field_boundary_lo[idim] != FieldBoundaryType::PEC_Insulator)) ||
+                    (iside == +1 && (field_boundary_hi[idim] != FieldBoundaryType::PEC_Insulator))) { continue; }
 
                 if ((iside == -1 && (node_box.smallEnd()[idim] > domain_lo[idim])) ||
                     (iside == +1 && (node_box.bigEnd()[idim] < domain_hi[idim]))) { continue; }

--- a/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
+++ b/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
@@ -124,7 +124,7 @@ void WarpX::ApplyEfieldBoundary(const int lev, PatchType patch_type, amrex::Real
         }
     }
 
-    if (::isAnyBoundary<FieldBoundaryType::PECInsulator>(field_boundary_lo, field_boundary_hi)) {
+    if (::isAnyBoundary<FieldBoundaryType::PEC_Insulator>(field_boundary_lo, field_boundary_hi)) {
         if (patch_type == PatchType::fine) {
             pec_insulator_boundary->ApplyPEC_InsulatortoEfield(
                     m_fields.get_alldirs(FieldType::Efield_fp, lev),
@@ -209,7 +209,7 @@ void WarpX::ApplyBfieldBoundary (const int lev, PatchType patch_type, Subcycling
         }
     }
 
-    if (::isAnyBoundary<FieldBoundaryType::PECInsulator>(field_boundary_lo, field_boundary_hi)) {
+    if (::isAnyBoundary<FieldBoundaryType::PEC_Insulator>(field_boundary_lo, field_boundary_hi)) {
         if (patch_type == PatchType::fine) {
             pec_insulator_boundary->ApplyPEC_InsulatortoBfield(
                 m_fields.get_alldirs(FieldType::Bfield_fp, lev),
@@ -260,7 +260,7 @@ void WarpX::ApplyRhofieldBoundary (const int lev, MultiFab* rho,
     if (::isAnyBoundary<ParticleBoundaryType::Reflecting>(particle_boundary_lo, particle_boundary_hi) ||
         ::isAnyBoundary<ParticleBoundaryType::Thermal>(particle_boundary_lo, particle_boundary_hi) ||
         ::isAnyBoundary<FieldBoundaryType::PEC>(field_boundary_lo, field_boundary_hi) ||
-        ::isAnyBoundary<FieldBoundaryType::PECInsulator>(field_boundary_lo, field_boundary_hi) ||
+        ::isAnyBoundary<FieldBoundaryType::PEC_Insulator>(field_boundary_lo, field_boundary_hi) ||
         ::isAnyBoundary<FieldBoundaryType::PMC>(field_boundary_lo, field_boundary_hi))
     {
         PEC::ApplyReflectiveBoundarytoRhofield(rho,
@@ -269,7 +269,7 @@ void WarpX::ApplyRhofieldBoundary (const int lev, MultiFab* rho,
             Geom(lev), lev, patch_type, ref_ratio);
     }
 
-    if (::isAnyBoundary<FieldBoundaryType::PECInsulator>(field_boundary_lo, field_boundary_hi)) {
+    if (::isAnyBoundary<FieldBoundaryType::PEC_Insulator>(field_boundary_lo, field_boundary_hi)) {
         pec_insulator_boundary->ZeroParallelScalarInConductor(rho,
             field_boundary_lo, field_boundary_hi,
             Geom(lev), lev, patch_type, ref_ratio);
@@ -284,7 +284,7 @@ void WarpX::ApplyJfieldBoundary (const int lev, amrex::MultiFab* Jx,
     if (::isAnyBoundary<ParticleBoundaryType::Reflecting>(particle_boundary_lo, particle_boundary_hi) ||
         ::isAnyBoundary<ParticleBoundaryType::Thermal>(particle_boundary_lo, particle_boundary_hi) ||
         ::isAnyBoundary<FieldBoundaryType::PEC>(field_boundary_lo, field_boundary_hi) ||
-        ::isAnyBoundary<FieldBoundaryType::PECInsulator>(field_boundary_lo, field_boundary_hi) ||
+        ::isAnyBoundary<FieldBoundaryType::PEC_Insulator>(field_boundary_lo, field_boundary_hi) ||
         ::isAnyBoundary<FieldBoundaryType::PMC>(field_boundary_lo, field_boundary_hi))
     {
         PEC::ApplyReflectiveBoundarytoJfield(Jx, Jy, Jz,
@@ -293,7 +293,7 @@ void WarpX::ApplyJfieldBoundary (const int lev, amrex::MultiFab* Jx,
             Geom(lev), lev, patch_type, ref_ratio);
     }
 
-    if (::isAnyBoundary<FieldBoundaryType::PECInsulator>(field_boundary_lo, field_boundary_hi)) {
+    if (::isAnyBoundary<FieldBoundaryType::PEC_Insulator>(field_boundary_lo, field_boundary_hi)) {
         pec_insulator_boundary->ZeroParallelFieldInConductor({Jx, Jy, Jz},
             field_boundary_lo, field_boundary_hi,
             get_ng_fieldgather(), Geom(lev),

--- a/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
+++ b/Source/BoundaryConditions/WarpXFieldBoundaries.cpp
@@ -230,7 +230,7 @@ void WarpX::ApplyBfieldBoundary (const int lev, PatchType patch_type, Subcycling
     // E and B are staggered in time, which is only true after the first half-push
     if (lev == 0) {
         if (subcycling_half == SubcyclingHalf::FirstHalf) {
-            if(::isAnyBoundary<FieldBoundaryType::Absorbing_SilverMueller>(field_boundary_lo, field_boundary_hi)){
+            if(::isAnyBoundary<FieldBoundaryType::Absorbing_Silver_Mueller>(field_boundary_lo, field_boundary_hi)){
                 auto Efield_fp = m_fields.get_mr_levels_alldirs(FieldType::Efield_fp, max_level);
                 auto Bfield_fp = m_fields.get_mr_levels_alldirs(FieldType::Bfield_fp, max_level);
                 m_fdtd_solver_fp[0]->ApplySilverMuellerBoundary(

--- a/Source/BoundaryConditions/WarpX_PEC.cpp
+++ b/Source/BoundaryConditions/WarpX_PEC.cpp
@@ -758,14 +758,14 @@ PEC::ApplyReflectiveBoundarytoRhofield (
                                ||  (particle_boundary_lo[idim] == ParticleBoundaryType::Thermal)
                                ||  (field_boundary_lo[idim] == FieldBoundaryType::PMC)
                                ||  (field_boundary_lo[idim] == FieldBoundaryType::PEC)
-                               ||  (field_boundary_lo[idim] == FieldBoundaryType::PECInsulator) );
+                               ||  (field_boundary_lo[idim] == FieldBoundaryType::PEC_Insulator) );
 
         // Check if boundary is reflective on hi side
         is_reflective[idim][1] = ( (particle_boundary_hi[idim] == ParticleBoundaryType::Reflecting)
                                ||  (particle_boundary_hi[idim] == ParticleBoundaryType::Thermal)
                                ||  (field_boundary_hi[idim] == FieldBoundaryType::PMC)
                                ||  (field_boundary_hi[idim] == FieldBoundaryType::PEC)
-                               ||  (field_boundary_hi[idim] == FieldBoundaryType::PECInsulator) );
+                               ||  (field_boundary_hi[idim] == FieldBoundaryType::PEC_Insulator) );
 
         // Set psign on lo side
         psign[idim][0] = ( (particle_boundary_lo[idim] == ParticleBoundaryType::Reflecting)
@@ -784,8 +784,8 @@ PEC::ApplyReflectiveBoundarytoRhofield (
         mirrorfac[idim][1] = 2*domain_hi[idim] - (1 - rho_nodal[idim]);
 
         // Whether the J-parallel in the guard cells is summed on the boundary
-        sum_on_boundary[idim][0] = (field_boundary_lo[idim] == FieldBoundaryType::PECInsulator);
-        sum_on_boundary[idim][1] = (field_boundary_hi[idim] == FieldBoundaryType::PECInsulator);
+        sum_on_boundary[idim][0] = (field_boundary_lo[idim] == FieldBoundaryType::PEC_Insulator);
+        sum_on_boundary[idim][1] = (field_boundary_hi[idim] == FieldBoundaryType::PEC_Insulator);
 
     }
 
@@ -935,14 +935,14 @@ PEC::ApplyReflectiveBoundarytoJfield (
                                ||  (particle_boundary_lo[idim] == ParticleBoundaryType::Thermal)
                                ||  (field_boundary_lo[idim] == FieldBoundaryType::PMC)
                                ||  (field_boundary_lo[idim] == FieldBoundaryType::PEC)
-                               ||  (field_boundary_lo[idim] == FieldBoundaryType::PECInsulator) );
+                               ||  (field_boundary_lo[idim] == FieldBoundaryType::PEC_Insulator) );
 
         // Check if boundary is reflective on hi side
         is_reflective[idim][1] = ( (particle_boundary_hi[idim] == ParticleBoundaryType::Reflecting)
                                ||  (particle_boundary_hi[idim] == ParticleBoundaryType::Thermal)
                                ||  (field_boundary_hi[idim] == FieldBoundaryType::PMC)
                                ||  (field_boundary_hi[idim] == FieldBoundaryType::PEC)
-                               ||  (field_boundary_hi[idim] == FieldBoundaryType::PECInsulator) );
+                               ||  (field_boundary_hi[idim] == FieldBoundaryType::PEC_Insulator) );
 
         for (int icomp = 0; icomp < 3; ++icomp) {
             // Set the psign value for each component of J for each direction
@@ -984,8 +984,8 @@ PEC::ApplyReflectiveBoundarytoJfield (
         mirrorfac[idim][2][1] = 2*domain_hi[idim] - (1 - Jz_nodal[idim]);
 
         // Whether the J-parallel in the guard cells is summed on the boundary
-        sum_on_boundary[idim][0] = (field_boundary_lo[idim] == FieldBoundaryType::PECInsulator);
-        sum_on_boundary[idim][1] = (field_boundary_hi[idim] == FieldBoundaryType::PECInsulator);
+        sum_on_boundary[idim][0] = (field_boundary_lo[idim] == FieldBoundaryType::PEC_Insulator);
+        sum_on_boundary[idim][1] = (field_boundary_hi[idim] == FieldBoundaryType::PEC_Insulator);
 
     }
 

--- a/Source/Diagnostics/ReducedDiags/FieldReduction.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldReduction.cpp
@@ -60,7 +60,7 @@ FieldReduction::FieldReduction (const std::string& rd_name)
     parser_string = std::regex_replace(parser_string, std::regex("\n\\s*"), " ");
 
     // read reduction type
-    pp_rd_name.get_enum_sloppy("reduction_type", m_reduction_type, "-_");
+    pp_rd_name.get_enum_case_insensitive("reduction_type", m_reduction_type);
 
     if (amrex::ParallelDescriptor::IOProcessor())
     {

--- a/Source/FieldSolver/FiniteDifferenceSolver/ApplySilverMuellerBoundary.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/ApplySilverMuellerBoundary.cpp
@@ -84,10 +84,10 @@ void FiniteDifferenceSolver::ApplySilverMuellerBoundary (
 #endif
 
     // Infer whether the Silver-Mueller needs to be applied in each direction
-    bool const apply_hi_r = (field_boundary_hi[0] == FieldBoundaryType::Absorbing_SilverMueller);
+    bool const apply_hi_r = (field_boundary_hi[0] == FieldBoundaryType::Absorbing_Silver_Mueller);
 #if defined(WARPX_DIM_RZ)
-    bool const apply_lo_z = (field_boundary_lo[1] == FieldBoundaryType::Absorbing_SilverMueller);
-    bool const apply_hi_z = (field_boundary_hi[1] == FieldBoundaryType::Absorbing_SilverMueller);
+    bool const apply_lo_z = (field_boundary_lo[1] == FieldBoundaryType::Absorbing_Silver_Mueller);
+    bool const apply_hi_z = (field_boundary_hi[1] == FieldBoundaryType::Absorbing_Silver_Mueller);
 #endif
 
     // tiling is usually set by TilingIfNotGPU()
@@ -231,15 +231,15 @@ void FiniteDifferenceSolver::ApplySilverMuellerBoundary (
     amrex::Real const coef2_z = 2._rt*cdt_over_dz/(1._rt + cdt_over_dz) / PhysConst::c;
 
 #if (defined WARPX_DIM_3D || WARPX_DIM_XZ)
-    bool const apply_lo_x = (field_boundary_lo[0] == FieldBoundaryType::Absorbing_SilverMueller);
-    bool const apply_hi_x = (field_boundary_hi[0] == FieldBoundaryType::Absorbing_SilverMueller);
+    bool const apply_lo_x = (field_boundary_lo[0] == FieldBoundaryType::Absorbing_Silver_Mueller);
+    bool const apply_hi_x = (field_boundary_hi[0] == FieldBoundaryType::Absorbing_Silver_Mueller);
 #endif
 #ifdef WARPX_DIM_3D
-    bool const apply_lo_y = (field_boundary_lo[1] == FieldBoundaryType::Absorbing_SilverMueller);
-    bool const apply_hi_y = (field_boundary_hi[1] == FieldBoundaryType::Absorbing_SilverMueller);
+    bool const apply_lo_y = (field_boundary_lo[1] == FieldBoundaryType::Absorbing_Silver_Mueller);
+    bool const apply_hi_y = (field_boundary_hi[1] == FieldBoundaryType::Absorbing_Silver_Mueller);
 #endif
-    bool const apply_lo_z = (field_boundary_lo[WARPX_ZINDEX] == FieldBoundaryType::Absorbing_SilverMueller);
-    bool const apply_hi_z = (field_boundary_hi[WARPX_ZINDEX] == FieldBoundaryType::Absorbing_SilverMueller);
+    bool const apply_lo_z = (field_boundary_lo[WARPX_ZINDEX] == FieldBoundaryType::Absorbing_Silver_Mueller);
+    bool const apply_hi_z = (field_boundary_hi[WARPX_ZINDEX] == FieldBoundaryType::Absorbing_Silver_Mueller);
 
     // Loop through the grids, and over the tiles within each grid
 #ifdef AMREX_USE_OMP

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -73,7 +73,7 @@ Array<LinOpBCType,AMREX_SPACEDIM> ImplicitSolver::convertFieldBCToLinOpBC (const
             lbc[i] = LinOpBCType::Dirichlet;
         } else if (a_fbc[i] == FieldBoundaryType::Damped) {
             WARPX_ABORT_WITH_MESSAGE("LinOpBCType not set for this FieldBoundaryType");
-        } else if (a_fbc[i] == FieldBoundaryType::Absorbing_SilverMueller) {
+        } else if (a_fbc[i] == FieldBoundaryType::Absorbing_Silver_Mueller) {
             ablastr::warn_manager::WMRecordWarning("Implicit solver",
                 "With SilverMueller, in the Curl-Curl preconditioner Symmetry boundary will be used since the full boundary is not yet implemented.",
                 ablastr::warn_manager::WarnPriority::medium);

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -81,7 +81,7 @@ Array<LinOpBCType,AMREX_SPACEDIM> ImplicitSolver::convertFieldBCToLinOpBC (const
         } else if (a_fbc[i] == FieldBoundaryType::Neumann) {
             // Also for FieldBoundaryType::PMC
             lbc[i] = LinOpBCType::symmetry;
-        } else if (a_fbc[i] == FieldBoundaryType::PECInsulator) {
+        } else if (a_fbc[i] == FieldBoundaryType::PEC_Insulator) {
             const int voltage_driven = m_WarpX->GetPECInsulator_IsESet(i,bdry_side);
             if (voltage_driven) { // Dirichlet for E
                 lbc[i] = LinOpBCType::Dirichlet;

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
@@ -320,7 +320,7 @@ void ThetaImplicitEM::InitializeCurlCurlBCMasks ()
                     val0 = 0.5_rt;
                     val1 = 1.0_rt;
                 }
-                if (bc_type == FieldBoundaryType::PECInsulator) {
+                if (bc_type == FieldBoundaryType::PEC_Insulator) {
                     const int voltage_driven = m_WarpX->GetPECInsulator_IsESet(bdry_dir,bdry_side);
                     if (voltage_driven) { // Dirichlet boundary for E
                         val0 = 0.0_rt;
@@ -340,7 +340,7 @@ void ThetaImplicitEM::InitializeCurlCurlBCMasks ()
 #endif
 
                 // Need to overwrite BC masks for certain BCs in this geometry
-                if (bc_type == FieldBoundaryType::PECInsulator &&
+                if (bc_type == FieldBoundaryType::PEC_Insulator &&
                    !m_WarpX->GetPECInsulator_IsESet(bdry_dir,bdry_side)) { // Dirichlet for B
                     const amrex::Real ibdry_real = (bdry_side == 0 ? static_cast<amrex::Real>(domain_lo[bdry_dir])
                                                                    : static_cast<amrex::Real>(domain_hi[bdry_dir]));
@@ -444,7 +444,7 @@ void ThetaImplicitEM::InitializeCurlCurlBCMasks ()
                         val1 = 2.0_rt;
                         val2 = 2.0_rt;
                     }
-                    if (bc_type == FieldBoundaryType::PECInsulator) {
+                    if (bc_type == FieldBoundaryType::PEC_Insulator) {
                         const int voltage_driven = m_WarpX->GetPECInsulator_IsESet(bdry_dir,bdry_side);
                         if (voltage_driven) { // Dirichlet boundary for E
                             val0 = 0.0_rt;
@@ -461,7 +461,7 @@ void ThetaImplicitEM::InitializeCurlCurlBCMasks ()
 #if defined(WARPX_DIM_RZ)
                     // Need to overwrite BC masks for certain BCs in this geometry
                     if (bdry_dir == 0) {
-                        if (bc_type == FieldBoundaryType::PECInsulator &&
+                        if (bc_type == FieldBoundaryType::PEC_Insulator &&
                            !m_WarpX->GetPECInsulator_IsESet(bdry_dir,bdry_side)) { // Dirichlet for B
                             const amrex::Real ibdry_real = (bdry_side == 0 ? static_cast<amrex::Real>(domain_lo[bdry_dir])
                                                                            : static_cast<amrex::Real>(domain_hi[bdry_dir]));

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
@@ -316,7 +316,7 @@ void ThetaImplicitEM::InitializeCurlCurlBCMasks ()
                     val0 = 1.0_rt;
                     val1 = 2.0_rt;
                 }
-                if (bc_type == FieldBoundaryType::Absorbing_SilverMueller) {
+                if (bc_type == FieldBoundaryType::Absorbing_Silver_Mueller) {
                     val0 = 0.5_rt;
                     val1 = 1.0_rt;
                 }

--- a/Source/Parallelization/GuardCellManager.cpp
+++ b/Source/Parallelization/GuardCellManager.cpp
@@ -169,9 +169,9 @@ guardCellManager::Init (
             ng_alloc_Rho[i] += static_cast<int>(std::ceil(PhysConst::c * dt_Rho / dx[i]));
             ng_alloc_J[i]   += static_cast<int>(std::ceil(PhysConst::c * dt_J / dx[i]));
         }
-    } else if (evolve_scheme == EvolveScheme::ThetaImplicitEM ||
-               evolve_scheme == EvolveScheme::SemiImplicitEM ||
-               evolve_scheme == EvolveScheme::StrangImplicitSpectralEM) {
+    } else if (evolve_scheme == EvolveScheme::Theta_Implicit_EM ||
+               evolve_scheme == EvolveScheme::Semi_Implicit_EM ||
+               evolve_scheme == EvolveScheme::Strang_Implicit_Spectral_EM) {
         // When using these implicit schemes, the speed of light Courant limit may be significantly
         // violated, but the number of guard cells only need to be adjusted based on the particle motion.
         for (int i = 0; i < AMREX_SPACEDIM; i++) {
@@ -381,9 +381,9 @@ guardCellManager::Init (
         }
     }
 
-    if (evolve_scheme == EvolveScheme::ThetaImplicitEM ||
-        evolve_scheme == EvolveScheme::SemiImplicitEM ||
-        evolve_scheme == EvolveScheme::StrangImplicitSpectralEM) {
+    if (evolve_scheme == EvolveScheme::Theta_Implicit_EM ||
+        evolve_scheme == EvolveScheme::Semi_Implicit_EM ||
+        evolve_scheme == EvolveScheme::Strang_Implicit_Spectral_EM) {
         // For these implicit schemes, the number of ghost cells
         // for EB gather must be consistent with those for J.
         ng_alloc_EB.max( ng_alloc_J );

--- a/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/ParticleCreationFunc.cpp
@@ -55,7 +55,7 @@ ParticleCreationFunc::ParticleCreationFunc (const std::string& collision_name,
     if (m_collision_type == CollisionType::ProtonBoronToAlphasFusion
         || BinaryCollisionUtils::is_two_product_fusion_type(m_collision_type))
     {
-        pp_collision_name.query_enum_sloppy("scattering_angle_model", m_scattering_angle_model, "-_");
+        pp_collision_name.query_enum_case_insensitive("scattering_angle_model", m_scattering_angle_model);
     }
 
 #ifdef AMREX_USE_GPU

--- a/Source/Particles/ParticleBoundaries.cpp
+++ b/Source/Particles/ParticleBoundaries.cpp
@@ -77,8 +77,8 @@ namespace warpx::particles
         }
         else{
             for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-                pp_boundary.query_enum_sloppy("particle_lo", particle_boundary_lo[idim], "-_", idim);
-                pp_boundary.query_enum_sloppy("particle_hi", particle_boundary_hi[idim], "-_", idim);
+                pp_boundary.query_enum_case_insensitive("particle_lo", particle_boundary_lo[idim], idim);
+                pp_boundary.query_enum_case_insensitive("particle_hi", particle_boundary_hi[idim], idim);
             }
 
             detail::check_consistency(

--- a/Source/Particles/Pusher/ImplicitPushPX.cpp
+++ b/Source/Particles/Pusher/ImplicitPushPX.cpp
@@ -459,11 +459,11 @@ PhysicalParticleContainer::ImplicitPushXP (WarpXParIter & pti,
         do_cropping[idim][0] = m_crop_on_PEC_boundary &&
                                 (box.smallEnd(idim) <= domain_box.smallEnd(idim) &&
                                  (field_boundary_lo[idim] == FieldBoundaryType::PEC
-                               || field_boundary_lo[idim] == FieldBoundaryType::PECInsulator));
+                               || field_boundary_lo[idim] == FieldBoundaryType::PEC_Insulator));
         do_cropping[idim][1] = m_crop_on_PEC_boundary &&
                                 (box.bigEnd(idim) >= domain_box.bigEnd(idim) &&
                                  (field_boundary_hi[idim] == FieldBoundaryType::PEC
-                               || field_boundary_hi[idim] == FieldBoundaryType::PECInsulator));
+                               || field_boundary_hi[idim] == FieldBoundaryType::PEC_Insulator));
 
         domain_double[idim][0] = static_cast<double>(domain_box.smallEnd(idim) - box.smallEnd(idim));
         domain_double[idim][1] = static_cast<double>(domain_box.bigEnd(idim) - box.smallEnd(idim));
@@ -782,11 +782,11 @@ PhysicalParticleContainer::ImplicitPushXPSubOrbits (WarpXParIter& pti,
         do_cropping[idim][0] = m_crop_on_PEC_boundary &&
                                 (box.smallEnd(idim) <= domain_box.smallEnd(idim) &&
                                  (field_boundary_lo[idim] == FieldBoundaryType::PEC
-                               || field_boundary_lo[idim] == FieldBoundaryType::PECInsulator));
+                               || field_boundary_lo[idim] == FieldBoundaryType::PEC_Insulator));
         do_cropping[idim][1] = m_crop_on_PEC_boundary &&
                                 (box.bigEnd(idim) >= domain_box.bigEnd(idim) &&
                                  (field_boundary_hi[idim] == FieldBoundaryType::PEC
-                               || field_boundary_hi[idim] == FieldBoundaryType::PECInsulator));
+                               || field_boundary_hi[idim] == FieldBoundaryType::PEC_Insulator));
 
         domain_double[idim][0] = static_cast<double>(domain_box.smallEnd(idim) - box.smallEnd(idim));
         domain_double[idim][1] = static_cast<double>(domain_box.bigEnd(idim) - box.smallEnd(idim));

--- a/Source/Particles/RigidInjectedParticleContainer.cpp
+++ b/Source/Particles/RigidInjectedParticleContainer.cpp
@@ -77,7 +77,7 @@ RigidInjectedParticleContainer::RigidInjectedParticleContainer (AmrCore* amr_cor
         } else if (raw == "false" || raw == "0") {
             rigid_advance_mode = RigidAdvanceMode::vz;
         } else {
-            pp_species_name.query_enum_sloppy("rigid_advance", rigid_advance_mode, "-_");
+            pp_species_name.query_enum_case_insensitive("rigid_advance", rigid_advance_mode);
         }
     }
 }

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -533,11 +533,11 @@ WarpXParticleContainer::DepositCurrent (WarpXParIter& pti,
         do_cropping[idim][0] = m_crop_on_PEC_boundary &&
                                 (tilebox.smallEnd(idim) <= domain_box.smallEnd(idim) &&
                                  (field_boundary_lo[idim] == FieldBoundaryType::PEC
-                               || field_boundary_lo[idim] == FieldBoundaryType::PECInsulator));
+                               || field_boundary_lo[idim] == FieldBoundaryType::PEC_Insulator));
         do_cropping[idim][1] = m_crop_on_PEC_boundary &&
                                 (tilebox.bigEnd(idim) >= domain_box.bigEnd(idim) &&
                                  (field_boundary_hi[idim] == FieldBoundaryType::PEC
-                               || field_boundary_hi[idim] == FieldBoundaryType::PECInsulator));
+                               || field_boundary_hi[idim] == FieldBoundaryType::PEC_Insulator));
 
         domain_double[idim][0] = static_cast<double>(domain_box.smallEnd(idim) - tilebox.smallEnd(idim));
         domain_double[idim][1] = static_cast<double>(domain_box.bigEnd(idim) - tilebox.smallEnd(idim));
@@ -1118,11 +1118,11 @@ WarpXParticleContainer::DepositMassMatrices (WarpXParIter& pti, const RealVector
         do_cropping[idim][0] = m_crop_on_PEC_boundary &&
                                 (tilebox.smallEnd(idim) <= domain_box.smallEnd(idim) &&
                                  (field_boundary_lo[idim] == FieldBoundaryType::PEC
-                               || field_boundary_lo[idim] == FieldBoundaryType::PECInsulator));
+                               || field_boundary_lo[idim] == FieldBoundaryType::PEC_Insulator));
         do_cropping[idim][1] = m_crop_on_PEC_boundary &&
                                 (tilebox.bigEnd(idim) >= domain_box.bigEnd(idim) &&
                                  (field_boundary_hi[idim] == FieldBoundaryType::PEC
-                               || field_boundary_hi[idim] == FieldBoundaryType::PECInsulator));
+                               || field_boundary_hi[idim] == FieldBoundaryType::PEC_Insulator));
 
         domain_double[idim][0] = static_cast<double>(domain_box.smallEnd(idim) - tilebox.smallEnd(idim));
         domain_double[idim][1] = static_cast<double>(domain_box.bigEnd(idim) - tilebox.smallEnd(idim));

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -31,9 +31,9 @@ AMREX_ENUM(MediumForEM,
   */
 AMREX_ENUM(EvolveScheme,
            Explicit,
-           ThetaImplicitEM,
-           SemiImplicitEM,
-           StrangImplicitSpectralEM,
+           Theta_Implicit_EM,
+           Semi_Implicit_EM,
+           Strang_Implicit_Spectral_EM,
            Default = Explicit);
 
 /**
@@ -135,7 +135,7 @@ AMREX_ENUM(FieldBoundaryType,
            Open,    // Used in the Integrated Green Function Poisson solver
                     // Note that the solver implicitely assumes open BCs:
                     // no need to enforce them separately
-           PECInsulator, // Mixed boundary with PEC and insulator
+           PEC_Insulator, // Mixed boundary with PEC and insulator
            Default = PML);
 
 /** Particle boundary conditions at the domain boundary

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -129,8 +129,8 @@ AMREX_ENUM(FieldBoundaryType,
            Neumann = PMC, // For electrostatic, the normal E is set to zero
            Damped,   // Fields in the guard cells are damped for PSATD
                      //in the moving window direction
-           Absorbing_SilverMueller, // Silver-Mueller boundary condition
-           absorbingsilvermueller = Absorbing_SilverMueller,
+           Absorbing_Silver_Mueller, // Silver-Mueller boundary condition
+           absorbingsilvermueller = Absorbing_Silver_Mueller,
            None,    // The fields values at the boundary are not updated. This is
                     // useful for RZ simulations, at r=0.
            Open,    // Used in the Integrated Green Function Poisson solver

--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -130,7 +130,6 @@ AMREX_ENUM(FieldBoundaryType,
            Damped,   // Fields in the guard cells are damped for PSATD
                      //in the moving window direction
            Absorbing_Silver_Mueller, // Silver-Mueller boundary condition
-           absorbingsilvermueller = Absorbing_Silver_Mueller,
            None,    // The fields values at the boundary are not updated. This is
                     // useful for RZ simulations, at r=0.
            Open,    // Used in the Integrated Green Function Poisson solver

--- a/Source/Utils/WarpXUtil.cpp
+++ b/Source/Utils/WarpXUtil.cpp
@@ -246,7 +246,7 @@ void CheckGriddingForRZSpectral ()
 #ifdef WARPX_DIM_RZ
     const ParmParse pp_algo("algo");
     auto electromagnetic_solver_id = ElectromagneticSolverAlgo::Default;
-    pp_algo.query_enum_sloppy("maxwell_solver", electromagnetic_solver_id, "-_");
+    pp_algo.query_enum_case_insensitive("maxwell_solver", electromagnetic_solver_id);
 
     // only check for PSATD in RZ
     if (electromagnetic_solver_id != ElectromagneticSolverAlgo::PSATD) {

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -818,7 +818,7 @@ WarpX::ReadParameters ()
             );
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 (electromagnetic_solver_id == ElectromagneticSolverAlgo::None ||
-                 evolve_scheme == EvolveScheme::ThetaImplicitEM),
+                 evolve_scheme == EvolveScheme::Theta_Implicit_EM),
                 "For electromagnetic solvers, warpx.dt_update_interval can only be used with algo.evolve_scheme = theta_implicit_em."
             );
         }
@@ -1257,19 +1257,19 @@ WarpX::ReadParameters ()
         pp_algo.query_enum_case_insensitive("particle_pusher", particle_pusher_algo);
 
         // check for implicit evolve scheme
-        if (evolve_scheme == EvolveScheme::SemiImplicitEM) {
+        if (evolve_scheme == EvolveScheme::Semi_Implicit_EM) {
             m_implicit_solver = std::make_unique<SemiImplicitEM>();
         }
-        else if (evolve_scheme == EvolveScheme::ThetaImplicitEM) {
+        else if (evolve_scheme == EvolveScheme::Theta_Implicit_EM) {
             m_implicit_solver = std::make_unique<ThetaImplicitEM>();
         }
-        else if (evolve_scheme == EvolveScheme::StrangImplicitSpectralEM) {
+        else if (evolve_scheme == EvolveScheme::Strang_Implicit_Spectral_EM) {
             m_implicit_solver = std::make_unique<StrangImplicitSpectralEM>();
         }
 
         // implicit evolve schemes not setup to use mirrors
-        if (evolve_scheme == EvolveScheme::SemiImplicitEM ||
-            evolve_scheme == EvolveScheme::ThetaImplicitEM) {
+        if (evolve_scheme == EvolveScheme::Semi_Implicit_EM ||
+            evolve_scheme == EvolveScheme::Theta_Implicit_EM) {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE( m_num_mirrors == 0,
                 "Mirrors cannot be used with Implicit evolve schemes.");
         }
@@ -1368,9 +1368,9 @@ WarpX::ReadParameters ()
                                                 m_macroscopic_solver_algo);
         }
 
-        if (evolve_scheme == EvolveScheme::SemiImplicitEM ||
-            evolve_scheme == EvolveScheme::ThetaImplicitEM ||
-            evolve_scheme == EvolveScheme::StrangImplicitSpectralEM) {
+        if (evolve_scheme == EvolveScheme::Semi_Implicit_EM ||
+            evolve_scheme == EvolveScheme::Theta_Implicit_EM ||
+            evolve_scheme == EvolveScheme::Strang_Implicit_Spectral_EM) {
 
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 current_deposition_algo == CurrentDepositionAlgo::Esirkepov ||
@@ -1393,7 +1393,7 @@ WarpX::ReadParameters ()
                 field_gathering_algo != GatheringAlgo::MomentumConserving,
                     "With implicit and semi-implicit schemes, the momentum conserving field gather is not supported as it would not conserve energy");
         }
-        if (evolve_scheme == EvolveScheme::StrangImplicitSpectralEM) {
+        if (evolve_scheme == EvolveScheme::Strang_Implicit_Spectral_EM) {
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD,
                 "With the strang_implicit_spectral_em evolve scheme, the algo.maxwell_solver must be psatd");
@@ -1470,8 +1470,8 @@ WarpX::ReadParameters ()
             }
 
             // These evolve schemes permit time steps that violate the CFL condition
-            if (evolve_scheme == EvolveScheme::ThetaImplicitEM ||
-                evolve_scheme == EvolveScheme::StrangImplicitSpectralEM) {
+            if (evolve_scheme == EvolveScheme::Theta_Implicit_EM ||
+                evolve_scheme == EvolveScheme::Strang_Implicit_Spectral_EM) {
                 pp_particles.query("max_grid_crossings", particle_max_grid_crossings);
             }
 
@@ -3100,7 +3100,7 @@ void WarpX::AllocLevelSpectralSolverRZ (amrex::Vector<std::unique_ptr<SpectralSo
 
     amrex::Real solver_dt = dt[lev];
     if (WarpX::m_JRhom) { solver_dt /= static_cast<amrex::Real>(WarpX::m_JRhom_subintervals); }
-    if (evolve_scheme == EvolveScheme::StrangImplicitSpectralEM) {
+    if (evolve_scheme == EvolveScheme::Strang_Implicit_Spectral_EM) {
         // The step is Strang split into two half steps
         solver_dt /= 2.;
     }
@@ -3159,7 +3159,7 @@ void WarpX::AllocLevelSpectralSolver (amrex::Vector<std::unique_ptr<SpectralSolv
 
     amrex::Real solver_dt = dt[lev];
     if (WarpX::m_JRhom) { solver_dt /= static_cast<amrex::Real>(WarpX::m_JRhom_subintervals); }
-    if (evolve_scheme == EvolveScheme::StrangImplicitSpectralEM) {
+    if (evolve_scheme == EvolveScheme::Strang_Implicit_Spectral_EM) {
         // The step is Strang split into two half steps
         solver_dt /= 2.;
     }

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -561,7 +561,7 @@ WarpX::ReadParameters ()
 
     {
         const ParmParse pp_algo("algo");
-        pp_algo.query_enum_sloppy("maxwell_solver", electromagnetic_solver_id, "-_");
+        pp_algo.query_enum_case_insensitive("maxwell_solver", electromagnetic_solver_id);
         if (electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT && !EB::enabled()) {
             throw std::runtime_error("ECP Solver requires to enable embedded boundaries at runtime.");
         }
@@ -595,7 +595,7 @@ WarpX::ReadParameters ()
         "PMC boundary not implemented for PSATD, yet!");
 
 
-        pp_algo.query_enum_sloppy("evolve_scheme", evolve_scheme, "-_");
+        pp_algo.query_enum_case_insensitive("evolve_scheme", evolve_scheme);
     }
 
     {
@@ -726,7 +726,7 @@ WarpX::ReadParameters ()
         maxlevel_extEMfield_init = maxLevel();
         pp_warpx.query("maxlevel_extEMfield_init", maxlevel_extEMfield_init);
 
-        pp_warpx.query_enum_sloppy("do_electrostatic", electrostatic_solver_id, "-_");
+        pp_warpx.query_enum_case_insensitive("do_electrostatic", electrostatic_solver_id);
         // if an electrostatic solver is used, set the Maxwell solver to None
         if (electrostatic_solver_id != ElectrostaticSolverAlgo::None) {
             electromagnetic_solver_id = ElectromagneticSolverAlgo::None;
@@ -737,7 +737,7 @@ WarpX::ReadParameters ()
                   "Electrostatic solver not supported with 1D cylindrical and spherical");
 #endif
 
-        pp_warpx.query_enum_sloppy("poisson_solver", poisson_solver_id, "-_");
+        pp_warpx.query_enum_case_insensitive("poisson_solver", poisson_solver_id);
 #ifndef WARPX_DIM_3D
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         poisson_solver_id!=PoissonSolverAlgo::IntegratedGreenFunction,
@@ -1094,7 +1094,7 @@ WarpX::ReadParameters ()
 
         // Integer that corresponds to the type of grid used in the simulation
         // (collocated, staggered, hybrid)
-        pp_warpx.query_enum_sloppy("grid_type", grid_type, "-_");
+        pp_warpx.query_enum_case_insensitive("grid_type", grid_type);
 
         // Use same shape factors in all directions, for gathering
         if (grid_type == GridType::Collocated) { galerkin_interpolation = false; }
@@ -1251,9 +1251,9 @@ WarpX::ReadParameters ()
             electrostatic_solver_id != ElectrostaticSolverAlgo::None) {
             current_deposition_algo = CurrentDepositionAlgo::Direct;
         }
-        pp_algo.query_enum_sloppy("current_deposition", current_deposition_algo, "-_");
-        pp_algo.query_enum_sloppy("charge_deposition", charge_deposition_algo, "-_");
-        pp_algo.query_enum_sloppy("particle_pusher", particle_pusher_algo, "-_");
+        pp_algo.query_enum_case_insensitive("current_deposition", current_deposition_algo);
+        pp_algo.query_enum_case_insensitive("charge_deposition", charge_deposition_algo);
+        pp_algo.query_enum_case_insensitive("particle_pusher", particle_pusher_algo);
 
         // check for implicit evolve scheme
         if (evolve_scheme == EvolveScheme::SemiImplicitEM) {
@@ -1303,7 +1303,7 @@ WarpX::ReadParameters ()
 
         // Query algo.field_gathering from input, set field_gathering_algo to
         // "default" if not found (default defined in Utils/WarpXAlgorithmSelection.cpp)
-        pp_algo.query_enum_sloppy("field_gathering", field_gathering_algo, "-_");
+        pp_algo.query_enum_case_insensitive("field_gathering", field_gathering_algo);
 
         // Set default field gathering algorithm for hybrid grids (momentum-conserving)
         std::string tmp_algo;
@@ -1360,10 +1360,10 @@ WarpX::ReadParameters ()
                 " combined with mesh refinement is currently not implemented");
         }
 
-        pp_algo.query_enum_sloppy("em_solver_medium", m_em_solver_medium, "-_");
+        pp_algo.query_enum_case_insensitive("em_solver_medium", m_em_solver_medium);
         if (m_em_solver_medium == MediumForEM::Macroscopic ) {
-            pp_algo.query_enum_sloppy("macroscopic_sigma_method",
-                                      m_macroscopic_solver_algo, "-_");
+            pp_algo.query_enum_case_insensitive("macroscopic_sigma_method",
+                                                m_macroscopic_solver_algo);
         }
 
         if (evolve_scheme == EvolveScheme::SemiImplicitEM ||
@@ -1409,7 +1409,7 @@ WarpX::ReadParameters ()
         }
         utils::parser::queryWithParser(pp_algo, "load_balance_efficiency_ratio_threshold",
                         load_balance_efficiency_ratio_threshold);
-        pp_algo.query_enum_sloppy("load_balance_costs_update", load_balance_costs_update_algo, "-_");
+        pp_algo.query_enum_case_insensitive("load_balance_costs_update", load_balance_costs_update_algo);
         if (WarpX::load_balance_costs_update_algo==LoadBalanceCostsUpdateAlgo::Heuristic) {
             utils::parser::queryWithParser(
                 pp_algo, "costs_heuristic_cells_wt", costs_heuristic_cells_wt);
@@ -1592,7 +1592,7 @@ WarpX::ReadParameters ()
         // Integer that corresponds to the order of the PSATD solution
         // (whether the PSATD equations are derived from first-order or
         // second-order solution)
-        pp_psatd.query_enum_sloppy("solution_type", m_psatd_solution_type, "-_");
+        pp_psatd.query_enum_case_insensitive("solution_type", m_psatd_solution_type);
 
         std::string JRhom_input;
         pp_psatd.query("JRhom", JRhom_input);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -953,10 +953,10 @@ WarpX::ReadParameters ()
 
         const auto at_least_one_boundary_is_silver_mueller =
             (std::any_of(WarpX::field_boundary_lo.begin(), WarpX::field_boundary_lo.end(),
-                [](const auto& cc){return cc == FieldBoundaryType::Absorbing_SilverMueller;})
+                [](const auto& cc){return cc == FieldBoundaryType::Absorbing_Silver_Mueller;})
             ||
             std::any_of(WarpX::field_boundary_hi.begin(), WarpX::field_boundary_hi.end(),
-                [](const auto& cc){return cc == FieldBoundaryType::Absorbing_SilverMueller;})
+                [](const auto& cc){return cc == FieldBoundaryType::Absorbing_Silver_Mueller;})
             );
 
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -1303,7 +1303,8 @@ WarpX::ReadParameters ()
 
         // Query algo.field_gathering from input, set field_gathering_algo to
         // "default" if not found (default defined in Utils/WarpXAlgorithmSelection.cpp)
-        pp_algo.query_enum_case_insensitive("field_gathering", field_gathering_algo);
+        pp_algo.query_enum_sloppy("field_gathering", field_gathering_algo, "-");
+        // query_enum_sloppy with "-" needed to map "energy-conserving" to "Algo::EnergyConserving"
 
         // Set default field gathering algorithm for hybrid grids (momentum-conserving)
         std::string tmp_algo;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -726,8 +726,8 @@ WarpX::ReadParameters ()
         maxlevel_extEMfield_init = maxLevel();
         pp_warpx.query("maxlevel_extEMfield_init", maxlevel_extEMfield_init);
 
+        // query_enum_sloppy with "-" needed to map "labframe-electromagnetostatic" to "LabFrameElectroMagnetostatic"
         pp_warpx.query_enum_sloppy("do_electrostatic", electrostatic_solver_id, "-");
-        // query_enum_sloppy with "-" needed to map "labframe-electromagnetostatic" to the enum value
         // if an electrostatic solver is used, set the Maxwell solver to None
         if (electrostatic_solver_id != ElectrostaticSolverAlgo::None) {
             electromagnetic_solver_id = ElectromagneticSolverAlgo::None;
@@ -1304,8 +1304,8 @@ WarpX::ReadParameters ()
 
         // Query algo.field_gathering from input, set field_gathering_algo to
         // "default" if not found (default defined in Utils/WarpXAlgorithmSelection.cpp)
+        // query_enum_sloppy with "-" needed to map e.g. "energy-conserving" to "EnergyConserving"
         pp_algo.query_enum_sloppy("field_gathering", field_gathering_algo, "-");
-        // query_enum_sloppy with "-" needed to map "energy-conserving" to "Algo::EnergyConserving"
 
         // Set default field gathering algorithm for hybrid grids (momentum-conserving)
         std::string tmp_algo;
@@ -1594,8 +1594,8 @@ WarpX::ReadParameters ()
         // Integer that corresponds to the order of the PSATD solution
         // (whether the PSATD equations are derived from first-order or
         // second-order solution)
+        // query_enum_sloppy with "-" needed to map "first-order" to "FirstOrder"
         pp_psatd.query_enum_sloppy("solution_type", m_psatd_solution_type, "-");
-        // query_enum_sloppy with "-" needed to map "first-order" to the enum value
 
         std::string JRhom_input;
         pp_psatd.query("JRhom", JRhom_input);

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -726,7 +726,8 @@ WarpX::ReadParameters ()
         maxlevel_extEMfield_init = maxLevel();
         pp_warpx.query("maxlevel_extEMfield_init", maxlevel_extEMfield_init);
 
-        pp_warpx.query_enum_case_insensitive("do_electrostatic", electrostatic_solver_id);
+        pp_warpx.query_enum_sloppy("do_electrostatic", electrostatic_solver_id, "-");
+        // query_enum_sloppy with "-" needed to map "labframe-electromagnetostatic" to the enum value
         // if an electrostatic solver is used, set the Maxwell solver to None
         if (electrostatic_solver_id != ElectrostaticSolverAlgo::None) {
             electromagnetic_solver_id = ElectromagneticSolverAlgo::None;
@@ -1593,7 +1594,8 @@ WarpX::ReadParameters ()
         // Integer that corresponds to the order of the PSATD solution
         // (whether the PSATD equations are derived from first-order or
         // second-order solution)
-        pp_psatd.query_enum_case_insensitive("solution_type", m_psatd_solution_type);
+        pp_psatd.query_enum_sloppy("solution_type", m_psatd_solution_type, "-");
+        // query_enum_sloppy with "-" needed to map "first-order" to the enum value
 
         std::string JRhom_input;
         pp_psatd.query("JRhom", JRhom_input);


### PR DESCRIPTION
Most of our `query_enum_sloppy` / `get_enum_sloppy` calls used the `"-_"` ignore-set, but I think that this was done to imitate the first time `query_enum_sloppy` had been added in the code, not because `"-_"` was really needed. 

This PR replaces all calls to `query_enum_sloppy` / `get_enum_sloppy` with the more semantically accurate `query_enum_case_insensitive` / `get_enum_case_insensitive` (with a few exceptions), which makes the intent clearer and avoids silently accepting malformed inputs.

