### PR TITLE
[WIP] Fix RZ particle injection: do not compare azimuthal angle against ymin/ymax

### DIFF
--- a/Source/Particles/ParticleCreation/AddParticles.cpp
+++ b/Source/Particles/ParticleCreation/AddParticles.cpp
@@ -1025,7 +1025,14 @@ PhysicalParticleContainer::AddPlasma (PlasmaInjector& plasma_injector, int lev, 
                                      - std::pow(rmin, 1._rt + radial_numpercell_power);
                 amrex::Real const rminp = std::pow(rmin, 1._rt + radial_numpercell_power);
                 amrex::Real const xb = std::pow(xu*rc + rminp, 1._rt/(1._rt + radial_numpercell_power));
-                amrex::Real const yb = theta;
+                // `xb` and `yb` are used in the `insideBounds` checks below, i.e. they are
+                // compared against the (Cartesian) species bounds xmin/xmax and ymin/ymax.
+                // They must therefore be the radius and the y position *before* the azimuthal
+                // rotation (which is 0, since injection happens in the r-z plane). Using `theta`
+                // here would compare the azimuthal angle (in [-pi, pi]) against ymin/ymax (in
+                // meters), which spuriously rejects all particles whenever ymin/ymax are set
+                // (see https://github.com/BLAST-WarpX/warpx/discussions/6788).
+                amrex::Real const yb = 0._rt;
 
                 pos.x = xb*std::cos(theta);
                 pos.y = xb*std::sin(theta);
@@ -1046,7 +1053,10 @@ PhysicalParticleContainer::AddPlasma (PlasmaInjector& plasma_injector, int lev, 
                                      - std::pow(rmin, 1._rt + radial_numpercell_power);
                 amrex::Real const rminp = std::pow(rmin, 1._rt + radial_numpercell_power);
                 amrex::Real const xb = std::pow(xu*rc + rminp, 1._rt/(1._rt + radial_numpercell_power));
-                amrex::Real const yb = theta;
+                // See the comment in the RZ/RCYLINDER branch above: `yb` is compared against
+                // ymin/ymax in the `insideBounds` checks and must be the y position before the
+                // azimuthal rotation (0), not the azimuthal angle `theta`.
+                amrex::Real const yb = 0._rt;
 
                 pos.x = xb*cos_phi*std::cos(theta);
                 pos.y = xb*cos_phi*std::sin(theta);


### PR DESCRIPTION
In RZ (and RCYLINDER/RSPHERE) geometry, setting explicit species position bounds `ymin`/`ymax` led to zero particles being loaded (see discussion #6788).

Root cause: in `PhysicalParticleContainer::AddPlasma`, the value `yb` that is passed to `inj_pos->insideBounds(xb, yb, z0)` was set to the azimuthal angle `theta` (in `[-pi, pi]`). `insideBounds` compares it against `ymin`/`ymax`, which are Cartesian positions in meters. With a typical transverse bound such as `ymin = -18e-6`, `ymax = 18e-6`, only a fraction `(ymax - ymin) / (2*pi)` ~ 6e-6 of the azimuthal angles fall inside the bounds, so essentially every particle is rejected. Removing `ymin`/`ymax` made the check pass (defaults are +/- huge), which is exactly the workaround reported in the discussion.

This was a regression introduced when the RZ injection code was refactored (commit 9e4494bec9): previously `yb` was the y position in the r-z plane *before* the azimuthal rotation (always 0 from `getCellCoords`), so the `ymin`/`ymax` check only required the bounds to bracket 0.

Fix: set `yb = 0` (the pre-rotation y position) in the RZ/RCYLINDER and RSPHERE branches, restoring the previous, behavior-preserving semantics. `xb` is left unchanged (the radius) since it is also reused for the particle weight and the stored `r` attribute. A true Cartesian-box interpretation of `xmin/xmax/ymin/ymax` on the rotated position would be a separate behavior change.