### PR TITLE
Support non-EB RZ cases with effective potential solver

### DIFF
--- a/Source/ablastr/fields/EffectivePotentialPoissonSolver.H
+++ b/Source/ablastr/fields/EffectivePotentialPoissonSolver.H
@@ -189,9 +189,6 @@ computeEffectivePotentialPhi (
         }
         else if (is_rz)
         {
-            amrex::Abort("The effective potential ES solver is not supported in RZ without EBs.");
-            // The above assert can be removed once AMReX::MLEBNodeFDLaplacian
-            // is extended to support a sigma MF when not compiled with EB support.
             auto linop_nodelap = std::make_unique<amrex::MLEBNodeFDLaplacian>();
             linop_nodelap->define(
                 amrex::Vector<amrex::Geometry>{geom[lev]},

--- a/dependencies.json
+++ b/dependencies.json
@@ -5,7 +5,7 @@
     "version_picsar": "26.05",
     "version_pybind11_min": "v3.0.0",
     "version_picmi": "0.34.0",
-    "commit_amrex": "2e29733c176e1cdae5be953a069f0a0f3f123e0a",
+    "commit_amrex": "c06ae3291a6df1fb43fdf7714d48f1ca79d9613d",
     "commit_pyamrex": "0952566bbd3477fc2c556bc892657bbf9314cf3c",
     "commit_picsar": "26.05",
     "commit_pybind11": "v3.0.4",


### PR DESCRIPTION
This is a follow-up to #6961 since support for non-EB RZ simulations has now also been added to https://github.com/AMReX-Codes/amrex/pull/5507.