### PR TITLE
Use reaction-dependent lower energy threshold for fusion cross sections

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/BoschHaleFusionCrossSection.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/BoschHaleFusionCrossSection.H
@@ -37,8 +37,13 @@ amrex::ParticleReal BoschHaleFusionCrossSection (
     constexpr amrex::ParticleReal joule_to_keV = 1.e-3_prt/PhysConst::q_e;
     const amrex::ParticleReal E_keV = E_kin_star*joule_to_keV;
 
-    // If kinetic energy is 0, return a 0 cross section and avoid later division by 0.
-    if (E_keV == 0._prt) {return 0._prt;}
+    // The parameterization used to compute fusion cross sections by Bosch
+    // and Hale has a lower cutoff energy between 0.3 keV and 0.5 keV.
+    // Return 0 cross section if below the threshold.
+    if (fusion_type == NuclearFusionType::DeuteriumHeliumToProtonHelium) {
+        if (E_keV < 0.3_prt) {return 0._prt;}
+    }
+    else if (E_keV < 0.5_prt) {return 0._prt;}
 
     // Compute the Gamow constant B_G (in keV^{1/2})
     // (See Eq. 3 in H.-S. Bosch and G.M. Hale 1992 Nucl. Fusion 32 611)

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/BoschHaleFusionCrossSection.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/BoschHaleFusionCrossSection.H
@@ -39,12 +39,11 @@ amrex::ParticleReal BoschHaleFusionCrossSection (
 
     // The parameterization used to compute fusion cross sections by Bosch and Hale
     // is only valid above a lower cutoff energy, which is 0.3 keV for the He3(d,p)He4
-    // reaction and 0.5 keV for the other reactions. Return a 0 cross section below
-    // this threshold. See H.-S. Bosch and G.M. Hale 1992 Nucl. Fusion 32 611, Table IV.
-    if (fusion_type == NuclearFusionType::DeuteriumHeliumToProtonHelium) {
-        if (E_keV < 0.3_prt) {return 0._prt;}
-    }
-    else if (E_keV < 0.5_prt) {return 0._prt;}
+    // reaction and 0.5 keV for the other reactions. Return 0 cross section for energies
+    // below this threshold. See H.-S. Bosch and G.M. Hale 1992 Nucl. Fusion 32 611, Table IV.
+    const amrex::ParticleReal E_cutoff_keV =
+    (fusion_type == NuclearFusionType::DeuteriumHeliumToProtonHelium) ? 0.3_prt : 0.5_prt;
+    if (E_keV < E_cutoff_keV) {return 0._prt;}
 
     // Compute the Gamow constant B_G (in keV^{1/2})
     // (See Eq. 3 in H.-S. Bosch and G.M. Hale 1992 Nucl. Fusion 32 611)

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/BoschHaleFusionCrossSection.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/BoschHaleFusionCrossSection.H
@@ -37,9 +37,10 @@ amrex::ParticleReal BoschHaleFusionCrossSection (
     constexpr amrex::ParticleReal joule_to_keV = 1.e-3_prt/PhysConst::q_e;
     const amrex::ParticleReal E_keV = E_kin_star*joule_to_keV;
 
-    // The parameterization used to compute fusion cross sections by Bosch
-    // and Hale has a lower cutoff energy between 0.3 keV and 0.5 keV.
-    // Return 0 cross section if below the threshold.
+    // The parameterization used to compute fusion cross sections by Bosch and Hale
+    // is only valid above a lower cutoff energy, which is 0.3 keV for the He3(d,p)He4
+    // reaction and 0.5 keV for the other reactions. Return a 0 cross section below
+    // this threshold. See H.-S. Bosch and G.M. Hale 1992 Nucl. Fusion 32 611, Table IV.
     if (fusion_type == NuclearFusionType::DeuteriumHeliumToProtonHelium) {
         if (E_keV < 0.3_prt) {return 0._prt;}
     }

--- a/Source/Particles/Collision/BinaryCollision/NuclearFusion/BoschHaleFusionCrossSection.H
+++ b/Source/Particles/Collision/BinaryCollision/NuclearFusion/BoschHaleFusionCrossSection.H
@@ -37,10 +37,10 @@ amrex::ParticleReal BoschHaleFusionCrossSection (
     constexpr amrex::ParticleReal joule_to_keV = 1.e-3_prt/PhysConst::q_e;
     const amrex::ParticleReal E_keV = E_kin_star*joule_to_keV;
 
-    // The parameterization used to compute fusion cross sections by Bosch and Hale
-    // is only valid above a lower cutoff energy, which is 0.3 keV for the He3(d,p)He4
-    // reaction and 0.5 keV for the other reactions. Return 0 cross section for energies
-    // below this threshold. See H.-S. Bosch and G.M. Hale 1992 Nucl. Fusion 32 611, Table IV.
+    // The Bosch-Hale fusion cross-section parameterization is only valid above a
+    // lower energy threshold: 0.3 keV for He3(d,p)He4 and 0.5 keV for all other
+    // reactions. Since the fusion cross section is negligible below these thresholds,
+    // return zero. See H.-S. Bosch and G.M. Hale 1992 Nucl. Fusion 32 611, Table IV.
     const amrex::ParticleReal E_cutoff_keV =
     (fusion_type == NuclearFusionType::DeuteriumHeliumToProtonHelium) ? 0.3_prt : 0.5_prt;
     if (E_keV < E_cutoff_keV) {return 0._prt;}


### PR DESCRIPTION
The parameterization used to compute fusion cross sections by Bosch and Hale 1992 has a lower cutoff energy between 0.3 keV and 0.5 keV. This PR returns 0 value for the cross section if the relative energy is below the threshold.