### PR TITLE
Remove redundant species_type input from test_2d_charge_exchange_dsmc

### DIFF
--- a/Examples/Tests/collision/inputs_test_2d_charge_exchange_dsmc
+++ b/Examples/Tests/collision/inputs_test_2d_charge_exchange_dsmc
@@ -46,7 +46,6 @@ electrons.mass = m_e
 electrons.momentum_distribution_type = gaussian
 electrons.num_particles_per_cell_each_dim = 8 8
 electrons.profile = constant
-electrons.species_type = electron
 electrons.ux_th = sqrt(Te*q_e/m_e)/clight
 electrons.uy_th = sqrt(Te*q_e/m_e)/clight
 electrons.uz_th = sqrt(Te*q_e/m_e)/clight

--- a/Examples/Tests/collision/inputs_test_2d_charge_exchange_dsmc
+++ b/Examples/Tests/collision/inputs_test_2d_charge_exchange_dsmc
@@ -122,3 +122,4 @@ warpx.reduced_diags_names = field_energy particle_energy
 warpx.serialize_initial_conditions = 1
 warpx.use_filter = 0
 warpx.verbose = 1
+warpx.abort_on_warning_threshold = low


### PR DESCRIPTION
## Overview

Remove the redundant argument `electrons.species_type = electron` from the input file of the CI test `test_2d_charge_exchange_dsmc`, which previously triggered the following warning:
```
**** WARNINGS ******************************************************************
* GLOBAL warning list  after  [ FIRST STEP ]
*
* --> [!! ] [Species] [raised once]
*     Both 'electrons.charge' and electrons.species_type' are specified.
*     electrons.charge' will take precedence.
*     @ Raised by: ALL
*
* --> [!! ] [Species] [raised once]
*     Both 'electrons.mass' and electrons.species_type' are specified.
*     electrons.mass' will take precedence.
*     @ Raised by: ALL
*
********************************************************************************
```

## Notes

Noticed while debugging the test in #6779.