### PR TITLE
MultiParticleContainer.cpp : ensure that physical_species has a value before using it

### DIFF
--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -74,7 +74,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <format>
 #include <fstream>
 #include <limits>
 #include <map>
@@ -326,7 +325,7 @@ MultiParticleContainer::ReadParameters ()
                     const auto physical_species = species::from_string(type_string);
                     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                         physical_species.has_value(),
-                        std::format("'{}' is not a valid species_type", type_string));
+                        "'" + type_string + "' is not a valid species_type");
                     species_type_is_photon =
                         (physical_species.value() == PhysicalSpecies::photon);
                 }

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -74,6 +74,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <format>
 #include <fstream>
 #include <limits>
 #include <map>
@@ -322,8 +323,10 @@ MultiParticleContainer::ReadParameters ()
                 bool species_type_is_photon = false;
                 const ParmParse pp_species(name);
                 if (auto type_string = std::string {}; pp_species.query("species_type", type_string)){
-                    const auto physical_species =
-                        species::from_string(type_string);
+                    const auto physical_species = species::from_string(type_string);
+                    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                        physical_species.has_value(),
+                        std::format("'{}' is not a valid species_type", type_string));
                     species_type_is_photon =
                         (physical_species.value() == PhysicalSpecies::photon);
                 }


### PR DESCRIPTION
The code 
```C++
const auto physical_species = species::from_string(type_string);
species_type_is_photon = (physical_species.value() == PhysicalSpecies::photon);
```
can fail without a clear error message if the species type is misspelled in the inputfile. Indeed, in this case, `physical_species` is an `std::nullopt` and has no value.

This PR adds the check : 
```C++
WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
    physical_species.has_value(),
    "'" + type_string + "' is not a valid species_type");
```

The error message now looks like 
```
0::Assertion `physical_species.has_value()' failed, file "/home/luca/Projects/WarpX/Source/Particles/MultiParticleContainer.cpp", line 326, Msg: 
### ERROR   : 'electrons' is not a valid species_type
 !!!
```
instead of 
```
terminate called after throwing an instance of 'std::bad_optional_access'
  what():  bad optional access
```