### PR TITLE
pyWarpX: Only export `_PyInit_warpx_pybind`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -403,6 +403,25 @@ foreach(D IN LISTS WarpX_DIMS)
             PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/pywarpx
             COMPILE_PDB_OUTPUT_DIRECTORY ${CMAKE_PYTHON_OUTPUT_DIRECTORY}/pywarpx
         )
+
+        # The CXX_VISIBILITY_PRESET above only hides pyWarpX's own objects, but
+        # statically-embedded dependencies (HDF5, openPMD, ADIOS2, and the WarpX
+        # lib) are compiled without hidden visibility and would otherwise
+        # be re-exported from this extension. If another extension loaded in the
+        # same process also statically embeds them (openpmd_api, ImpactX, a second
+        # openPMD/HDF5), the duplicate exported symbols cross-bind, one has two
+        # HDF5/openPMD instances in one process, UBs and crashes.
+        # Export only the module init symbol so each extension keeps its
+        # dependencies private.
+        # Windows does not auto-export and Emscripten links a single namespace, so
+        # neither needs this.
+        if(APPLE)
+            target_link_options(pyWarpX_${SD} PRIVATE
+                "LINKER:-exported_symbol,_PyInit_warpx_pybind_${SD}")
+        elseif(NOT WIN32 AND NOT EMSCRIPTEN)
+            target_link_options(pyWarpX_${SD} PRIVATE "LINKER:--exclude-libs,ALL")
+        endif()
+
         get_property(isMultiConfig GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
         if(isMultiConfig)
             foreach(CFG IN LISTS CMAKE_CONFIGURATION_TYPES)


### PR DESCRIPTION
Hide all other symbols to avoid clashes when loading transient (static) dependencies in workflows that combine ImpactX, WarpX, and openPMD-api.

Relevant for pip/wheels that do static builds (i.e. Python wheels): Currently, openPMD-api and ImpactX could not be `import`-ed together because HDF5 would clash.

Not a problem when installing with shared dependencies (of HDF5, openPMD, ABLASTR, etc.), i.e., from conda-forge or Spack.

See https://github.com/BLAST-ImpactX/impactx/pull/1538 https://github.com/BLAST-WarpX/warpx/issues/6499#issuecomment-4814161541