### PR TITLE
Used a closed interval for laser continuous injection check

### DIFF
--- a/Source/Particles/LaserParticleContainer.cpp
+++ b/Source/Particles/LaserParticleContainer.cpp
@@ -306,8 +306,8 @@ LaserParticleContainer::ContinuousInjection (const RealBox& injection_box)
     // the case for the R coordinate of the laser antenna in RZ (since
     // that equals 0 and thus coincides with the low end of the injection
     // box along R, which also equals 0).
-    const bool is_contained = (injection_box.lo(1) < p_pos[1] &&
-                               p_pos[1] < injection_box.hi(1));
+    const bool is_contained = (injection_box.lo(1) <= p_pos[1] &&
+                               p_pos[1] <= injection_box.hi(1));
 #else
     const bool is_contained = injection_box.contains(p_pos);
 #endif


### PR DESCRIPTION
This matches the new behavior for amrex::RealBox::contains (https://github.com/AMReX-Codes/amrex/pull/5445) for RZ geometry.
Previously in a test with
prob_hi_z = 0, laser.position_z = 0, gamma_boost = 9, 
moving_window_v = 1, laser.do_continuous_injection = 1, geometry.dims = RZ
the laser did not get injected, while in 3D, or with this change, it does.