### PR TITLE
Fix strings in WarpX_PETSc.cpp

### DIFF
--- a/Source/NonlinearSolvers/WarpX_PETSc.cpp
+++ b/Source/NonlinearSolvers/WarpX_PETSc.cpp
@@ -250,9 +250,8 @@ void PETScSolver_impl::setOptions()
 
         std::string pctype = "asm"; // default
         {
-            std::string key = "type";
             std::string val = pctype;
-            pp_pc.query(key.c_str(), val);
+            pp_pc.query("type", val);
             PetscOptionsSetValue( NULL, "-pc_type", val.c_str());
             pctype = val;
         }
@@ -260,47 +259,42 @@ void PETScSolver_impl::setOptions()
         if (pctype == "asm") {
 
             {
-                std::string key = "asm_overlap";
                 int val = 0;
-                pp_pc.query(key.c_str(), val);
-                char valstr[10]; sprintf(valstr, "%d", val);
-                PetscOptionsSetValue( NULL, "-pc_asm_overlap", valstr);
+                pp_pc.query("asm_overlap", val);
+                std::string valstr = std::to_string(val);
+                PetscOptionsSetValue( NULL, "-pc_asm_overlap", valstr.c_str());
             }
 
             std::string subpctype = "ilu"; // default
             {
-                std::string key = "sub_type";
                 std::string val = subpctype;
-                pp_pc.query(key.c_str(), val);
+                pp_pc.query("sub_type", val);
                 PetscOptionsSetValue( NULL, "-sub_pc_type", val.c_str());
                 subpctype = val;
             }
 
             if (subpctype == "ilu") {
-                std::string key = "ilu_factor_levels";
                 int val = 2;
-                pp_pc.query(key.c_str(), val);
-                char valstr[10]; sprintf(valstr, "%d", val);
-                PetscOptionsSetValue( NULL, "-sub_pc_factor_levels", valstr);
+                pp_pc.query("ilu_factor_levels", val);
+                std::string valstr = std::to_string(val);
+                PetscOptionsSetValue( NULL, "-sub_pc_factor_levels", valstr.c_str());
             }
 
         } else if (pctype == "hypre") {
 
             std::string hyprepctype = "euclid"; // default
             {
-                std::string key = "hypre_type";
                 std::string val = hyprepctype;
-                pp_pc.query(key.c_str(), val);
+                pp_pc.query("hypre_type", val);
                 PetscOptionsSetValue( NULL, "-pc_hypre_type", val.c_str());
                 hyprepctype = val;
             }
 
             if (hyprepctype == "euclid") {
-                std::string key = "euclid_factor_levels";
                 int val = 2;
-                pp_pc.query(key.c_str(), val);
-                char valstr[10]; sprintf(valstr, "%d", val);
-                PetscOptionsSetValue( NULL, "-pc_hypre_euclid_level", valstr);
+                pp_pc.query("euclid_factor_levels", val);
+                std::string valstr = std::to_string(val);
+                PetscOptionsSetValue( NULL, "-pc_hypre_euclid_level", valstr.c_str());
             }
 
         } else {


### PR DESCRIPTION
This cleans up some use of strings in WarpX_PETSc.cpp.
- It removes the use of the deprecated (and unsafe) `sprintf`
- It passes the string values directly into the ParmParse queries

This removes a warning that arises during compilation of the use of the deprecated `sprintf`.