### PR TITLE
Redistribute virtual photons after generating them with beam-size effect

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/VirtualPhotonCreation.cpp
+++ b/Source/Particles/Collision/BinaryCollision/VirtualPhotonCreation.cpp
@@ -286,6 +286,7 @@ void GenerateVirtualPhotons (MultiParticleContainer* mypc){
             } // mfi
         } // lev
 
+#if defined (WARPX_DIM_3D)
         if (do_beam_size_effect) {
             // The beam-size effect displaces virtual photons away from the cell
             // of their parent particle, so they need a Redistribute to be placed
@@ -294,7 +295,7 @@ void GenerateVirtualPhotons (MultiParticleContainer* mypc){
             // kernel assumes that particles are already in the correct box/tile.
             vphotons.Redistribute();
         }
-
+#endif
     } // species
 
 #else

--- a/Source/Particles/Collision/BinaryCollision/VirtualPhotonCreation.cpp
+++ b/Source/Particles/Collision/BinaryCollision/VirtualPhotonCreation.cpp
@@ -287,6 +287,15 @@ void GenerateVirtualPhotons (MultiParticleContainer* mypc){
         } // lev
     } // species
 
+    if (do_beam_size_effect) {
+        // The beam-size effect displaces virtual photons away from the cell
+        // of their parent particle, so they need a Redistribute to be placed 
+        // in the correct box/tile. This must happen before they are used in 
+        // collisions (see CollisionHandler::doCollisions) since the collision
+        // kernel assumes that particles are already in the correct box/tile.
+        vphotons.Redistribute();
+    }
+
 #else
 
     WARPX_ABORT_WITH_MESSAGE("Compiling WarpX with QED support is required to call GenerateVirtualPhotons");

--- a/Source/Particles/Collision/BinaryCollision/VirtualPhotonCreation.cpp
+++ b/Source/Particles/Collision/BinaryCollision/VirtualPhotonCreation.cpp
@@ -289,8 +289,8 @@ void GenerateVirtualPhotons (MultiParticleContainer* mypc){
 
     if (do_beam_size_effect) {
         // The beam-size effect displaces virtual photons away from the cell
-        // of their parent particle, so they need a Redistribute to be placed 
-        // in the correct box/tile. This must happen before they are used in 
+        // of their parent particle, so they need a Redistribute to be placed
+        // in the correct box/tile. This must happen before they are used in
         // collisions (see CollisionHandler::doCollisions) since the collision
         // kernel assumes that particles are already in the correct box/tile.
         vphotons.Redistribute();

--- a/Source/Particles/Collision/BinaryCollision/VirtualPhotonCreation.cpp
+++ b/Source/Particles/Collision/BinaryCollision/VirtualPhotonCreation.cpp
@@ -288,8 +288,8 @@ void GenerateVirtualPhotons (MultiParticleContainer* mypc){
 
         if (do_beam_size_effect) {
             // The beam-size effect displaces virtual photons away from the cell
-            // of their parent particle, so they need a Redistribute to be placed 
-            // in the correct box/tile. This must happen before they are used in 
+            // of their parent particle, so they need a Redistribute to be placed
+            // in the correct box/tile. This must happen before they are used in
             // collisions (see CollisionHandler::doCollisions) since the collision
             // kernel assumes that particles are already in the correct box/tile.
             vphotons.Redistribute();

--- a/Source/Particles/Collision/BinaryCollision/VirtualPhotonCreation.cpp
+++ b/Source/Particles/Collision/BinaryCollision/VirtualPhotonCreation.cpp
@@ -285,16 +285,17 @@ void GenerateVirtualPhotons (MultiParticleContainer* mypc){
                 });
             } // mfi
         } // lev
-    } // species
 
-    if (do_beam_size_effect) {
-        // The beam-size effect displaces virtual photons away from the cell
-        // of their parent particle, so they need a Redistribute to be placed 
-        // in the correct box/tile. This must happen before they are used in 
-        // collisions (see CollisionHandler::doCollisions) since the collision
-        // kernel assumes that particles are already in the correct box/tile.
-        vphotons.Redistribute();
-    }
+        if (do_beam_size_effect) {
+            // The beam-size effect displaces virtual photons away from the cell
+            // of their parent particle, so they need a Redistribute to be placed 
+            // in the correct box/tile. This must happen before they are used in 
+            // collisions (see CollisionHandler::doCollisions) since the collision
+            // kernel assumes that particles are already in the correct box/tile.
+            vphotons.Redistribute();
+        }
+
+    } // species
 
 #else
 


### PR DESCRIPTION
In [`doCollisions`](https://github.com/BLAST-WarpX/warpx/blob/development/Source/Particles/Collision/CollisionHandler.cpp#L122), the collisions are performed immediately after creating virtual photons with `GenerateVirtualPhotons`.

However, when the beam-size effect is activated, the virtual photons may not be on the correct box/tile after being generated (which is needed for the collision kernel to work correctly). 

This PR fixes it by calling `Redistribute`.