### PR TITLE
[WIP] Add a `dissociation` scattering process to DSMC collisions (A + BC → A + B + C)

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
@@ -45,6 +45,7 @@ DSMCFunc::DSMCFunc (
         amrex::ParticleReal energy = 0._prt;
         if (scattering_process.find("excitation") != std::string::npos ||
             scattering_process.find("ionization") != std::string::npos ||
+            scattering_process.find("dissociation") != std::string::npos ||
             scattering_process.find("forward") != std::string::npos ||
             scattering_process.find("two_product_reaction") != std::string::npos ) {
             const std::string kw_energy = scattering_process + "_energy";
@@ -61,9 +62,10 @@ DSMCFunc::DSMCFunc (
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(process.type() != ScatteringProcessType::INVALID,
                                         "Cannot add an unknown scattering process type");
 
-        if (process.type() == ScatteringProcessType::IONIZATION || process.type() == ScatteringProcessType::TWOPRODUCT_REACTION) {
-            // Only one ionization process is currently supported as part of a given
-            // collision set.
+        if (process.type() == ScatteringProcessType::IONIZATION || process.type() == ScatteringProcessType::TWOPRODUCT_REACTION
+            || process.type() == ScatteringProcessType::DISSOCIATION) {
+            // Only one reaction that produces new species is currently supported as part of a
+            // given collision set.
             if (reaction_produces_new_species) {
                 amrex::Abort("Multiple reactions that produce new species were specified in " + collision_name +
                 ".scattering_processes, but DSMC only supports a single reaction that produces new species.");

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -145,7 +145,8 @@ public:
                 return ((mask[i] > 0) &&
                         (mask[i] != int(ScatteringProcessType::IONIZATION)) &&
                         (mask[i] != int(ScatteringProcessType::TWOPRODUCT_REACTION)) &&
-                        (mask[i] != int(ScatteringProcessType::CHARGE_EXCHANGE))) ? 1 : 0;
+                        (mask[i] != int(ScatteringProcessType::CHARGE_EXCHANGE)) &&
+                        (mask[i] != int(ScatteringProcessType::DISSOCIATION))) ? 1 : 0;
             },
             [=] AMREX_GPU_DEVICE (index_type i, index_type s) { no_product_offsets_data[i] = s; },
             amrex::Scan::Type::exclusive, amrex::Scan::retSum
@@ -171,7 +172,8 @@ public:
             [=] AMREX_GPU_DEVICE (index_type i) -> index_type {
                 return ((mask[i] == int(ScatteringProcessType::IONIZATION)) |
                         (mask[i] == int(ScatteringProcessType::TWOPRODUCT_REACTION)) |
-                        (mask[i] == int(ScatteringProcessType::CHARGE_EXCHANGE))) ? 1 : 0;
+                        (mask[i] == int(ScatteringProcessType::CHARGE_EXCHANGE)) |
+                        (mask[i] == int(ScatteringProcessType::DISSOCIATION))) ? 1 : 0;
             },
             [=] AMREX_GPU_DEVICE (index_type i, index_type s) { with_product_offsets_data[i] = s; },
             amrex::Scan::Type::exclusive, amrex::Scan::retSum
@@ -227,6 +229,7 @@ public:
 
         const int num_product_species = m_num_product_species;
         const auto reaction_energy = m_reaction_energy;
+        const auto fragment_energy = m_fragment_energy;
 
         // Grab the masses of the true product species (slots 2 and 3)
         amrex::ParticleReal mass_slot2 = 0;
@@ -240,7 +243,7 @@ public:
         amrex::ParallelForRNG(n_total_pairs,
         [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
         {
-            if ((mask[i] > 0) && (mask[i] != int(ScatteringProcessType::IONIZATION)) && (mask[i] != int(ScatteringProcessType::TWOPRODUCT_REACTION)) && (mask[i] != int(ScatteringProcessType::CHARGE_EXCHANGE)))
+            if ((mask[i] > 0) && (mask[i] != int(ScatteringProcessType::IONIZATION)) && (mask[i] != int(ScatteringProcessType::TWOPRODUCT_REACTION)) && (mask[i] != int(ScatteringProcessType::CHARGE_EXCHANGE)) && (mask[i] != int(ScatteringProcessType::DISSOCIATION)))
             {
                 const auto slot0_idx = products_np_data[0] + no_product_offsets_data[i];
                 // Make a copy of the particle from the first reactant species
@@ -580,6 +583,119 @@ public:
                 uy0 = ux0buf_new*std::sin(-theta) + uy0*std::cos(-theta);
 #endif
             }
+            else if (mask[i] == int(ScatteringProcessType::DISSOCIATION))
+            {
+                // Dissociation of a molecule by impact of a (lighter) incident particle,
+                // e.g. e- + H2 -> e- + H + H. The incident species (slot 0) survives the
+                // collision, the target molecule (slot 1) is consumed, and two neutral
+                // fragments are created (slots 2 and 3). The incident particle loses
+                // `reaction_energy` (the impact-dissociation threshold); the two fragments
+                // additionally share `fragment_energy` (the Franck-Condon kinetic-energy
+                // release) back-to-back. Because no charge is created, this reaction cannot
+                // drive a charge-multiplication / field runaway.
+
+                // Surviving incident particle (slot 0): placed after the non-product copies,
+                // exactly as for ionization.
+                const auto slot0_idx = products_np_data[0] + no_product_total + with_product_offsets_data[i];
+                copy_species0[0](soa_products_data[0], soa_0, static_cast<int>(p_pair_indices_0[i]),
+                               static_cast<int>(slot0_idx), engine);
+                soa_products_data[0].m_rdata[PIdx::w][slot0_idx] = p_pair_reaction_weight[i];
+
+                // Two fragments (slots 2 and 3), both copied from the target molecule (slot 1).
+                const auto slot2_idx = products_np_data[2] + with_product_offsets_data[i];
+                copy_species1[2](soa_products_data[2], soa_1, static_cast<int>(p_pair_indices_1[i]),
+                                static_cast<int>(slot2_idx), engine);
+                soa_products_data[2].m_rdata[PIdx::w][slot2_idx] = p_pair_reaction_weight[i];
+
+                const auto slot3_idx = products_np_data[3] + with_product_offsets_data[i];
+                copy_species1[3](soa_products_data[3], soa_1, static_cast<int>(p_pair_indices_1[i]),
+                                static_cast<int>(slot3_idx), engine);
+                soa_products_data[3].m_rdata[PIdx::w][slot3_idx] = p_pair_reaction_weight[i];
+
+                auto& ux0 = soa_products_data[0].m_rdata[PIdx::ux][slot0_idx];
+                auto& uy0 = soa_products_data[0].m_rdata[PIdx::uy][slot0_idx];
+                auto& uz0 = soa_products_data[0].m_rdata[PIdx::uz][slot0_idx];
+                auto& ux2 = soa_products_data[2].m_rdata[PIdx::ux][slot2_idx];
+                auto& uy2 = soa_products_data[2].m_rdata[PIdx::uy][slot2_idx];
+                auto& uz2 = soa_products_data[2].m_rdata[PIdx::uz][slot2_idx];
+                auto& ux3 = soa_products_data[3].m_rdata[PIdx::ux][slot3_idx];
+                auto& uy3 = soa_products_data[3].m_rdata[PIdx::uy][slot3_idx];
+                auto& uz3 = soa_products_data[3].m_rdata[PIdx::uz][slot3_idx];
+
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
+                /* See the equivalent block in the ionization branch: rotate the incident
+                 * particle's transverse momentum into the (cylindrical) frame of the target. */
+                amrex::ParticleReal const theta = (
+                    soa_products_data[2].m_rdata[PIdx::theta][slot2_idx]
+                    - soa_products_data[0].m_rdata[PIdx::theta][slot0_idx]
+                );
+                amrex::ParticleReal const ux0buf = ux0;
+                ux0 = ux0buf*std::cos(theta) - uy0*std::sin(theta);
+                uy0 = ux0buf*std::sin(theta) + uy0*std::cos(theta);
+#endif
+
+                // The two fragments currently both carry the target molecule's velocity.
+                const amrex::ParticleReal vmolx = ux2;
+                const amrex::ParticleReal vmoly = uy2;
+                const amrex::ParticleReal vmolz = uz2;
+
+                // Non-relativistic center-of-momentum velocity of incident (m0) + molecule (m1).
+                auto const uCOM_x = (m0 * ux0 + m1 * vmolx) / (m0 + m1);
+                auto const uCOM_y = (m0 * uy0 + m1 * vmoly) / (m0 + m1);
+                auto const uCOM_z = (m0 * uz0 + m1 * vmolz) / (m0 + m1);
+
+                // Incident particle momentum in the COM frame, and the collision energy.
+                ux0 -= uCOM_x;
+                uy0 -= uCOM_y;
+                uz0 -= uCOM_z;
+                const amrex::ParticleReal p_in = m0 * std::sqrt(ux0*ux0 + uy0*uy0 + uz0*uz0);
+                const amrex::ParticleReal E_coll = 0.5_prt * p_in * p_in * (1.0_prt/m0 + 1.0_prt/m1);
+                // Energy left for the incident + molecule-COM relative motion after paying the
+                // dissociation threshold (converted from eV to J). Clamped for numerical safety;
+                // the cross-section is 0 below threshold so this is >= 0 whenever this branch runs.
+                const amrex::ParticleReal E_out = amrex::max(0._prt, E_coll - reaction_energy * PhysConst::q_e);
+
+                // Step A: incident particle and the molecule's center of mass recoil back-to-back
+                // and isotropically in the COM frame, sharing E_out (collinear-momentum model).
+                const amrex::ParticleReal m_frag_tot = mass_slot2 + mass_slot3; // = m1 by mass conservation
+                const amrex::ParticleReal p_A = std::sqrt( 2.0_prt * E_out / (1.0_prt/m0 + 1.0_prt/m_frag_tot) );
+                amrex::ParticleReal na_x, na_y, na_z;
+                ParticleUtils::getRandomVector(na_x, na_y, na_z, engine);
+                ux0 = (p_A/m0) * na_x;
+                uy0 = (p_A/m0) * na_y;
+                uz0 = (p_A/m0) * na_z;
+                // Molecule center-of-mass velocity in the COM frame (momentum balance).
+                const amrex::ParticleReal vmcom_x = -(p_A/m_frag_tot) * na_x;
+                const amrex::ParticleReal vmcom_y = -(p_A/m_frag_tot) * na_y;
+                const amrex::ParticleReal vmcom_z = -(p_A/m_frag_tot) * na_z;
+
+                // Step B: the molecule splits into two fragments that recoil back-to-back and
+                // isotropically about the molecule's center of mass, with relative kinetic
+                // energy `fragment_energy` (two-body kinematics, valid for unequal masses).
+                const amrex::ParticleReal E_frag = fragment_energy * PhysConst::q_e;
+                const amrex::ParticleReal m_red  = mass_slot2 * mass_slot3 / m_frag_tot;
+                const amrex::ParticleReal v_rel  = std::sqrt( 2.0_prt * E_frag / m_red );
+                amrex::ParticleReal nb_x, nb_y, nb_z;
+                ParticleUtils::getRandomVector(nb_x, nb_y, nb_z, engine);
+                ux2 = vmcom_x + (mass_slot3/m_frag_tot) * v_rel * nb_x;
+                uy2 = vmcom_y + (mass_slot3/m_frag_tot) * v_rel * nb_y;
+                uz2 = vmcom_z + (mass_slot3/m_frag_tot) * v_rel * nb_z;
+                ux3 = vmcom_x - (mass_slot2/m_frag_tot) * v_rel * nb_x;
+                uy3 = vmcom_y - (mass_slot2/m_frag_tot) * v_rel * nb_y;
+                uz3 = vmcom_z - (mass_slot2/m_frag_tot) * v_rel * nb_z;
+
+                // Transform all products back to the lab frame.
+                ux0 += uCOM_x; uy0 += uCOM_y; uz0 += uCOM_z;
+                ux2 += uCOM_x; uy2 += uCOM_y; uz2 += uCOM_z;
+                ux3 += uCOM_x; uy3 += uCOM_y; uz3 += uCOM_z;
+
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
+                /* Undo the earlier velocity rotation for the surviving incident particle. */
+                amrex::ParticleReal const ux0buf2 = ux0;
+                ux0 = ux0buf2*std::cos(-theta) - uy0*std::sin(-theta);
+                uy0 = ux0buf2*std::sin(-theta) + uy0*std::cos(-theta);
+#endif
+            }
         });
 
         // Initialize the user runtime components
@@ -598,8 +714,10 @@ public:
 private:
     // How many different type of species the collision produces
     int m_num_product_species;
-    // If ionization collisions are included, what is the energy cost
+    // If ionization or dissociation collisions are included, what is the energy cost
     amrex::ParticleReal m_reaction_energy = 0.0;
+    // For dissociation: kinetic energy (in eV) released to the fragments (Franck-Condon energy).
+    amrex::ParticleReal m_fragment_energy = 0.0;
     // Vector of size m_num_product_species: for each product slot, the number of new particles
     // created per *reaction* event (ionization, two-product reaction, charge exchange).
     // Weight-split particles added to slots 0 and 1 during non-reaction events are NOT counted

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.cpp
@@ -22,7 +22,7 @@ SplitAndScatterFunc::SplitAndScatterFunc (const std::string& collision_name,
         amrex::Vector<std::string> scattering_processes;
         pp_collision_name.queryarr("scattering_processes", scattering_processes);
         const bool reaction_produces_new_species = std::any_of(scattering_processes.begin(), scattering_processes.end(), [](const std::string& process) {
-            return process == "ionization" || process == "charge_exchange" || process == "two_product_reaction";
+            return process == "ionization" || process == "charge_exchange" || process == "two_product_reaction" || process == "dissociation";
         });
 
         if (reaction_produces_new_species) {
@@ -55,6 +55,23 @@ SplitAndScatterFunc::SplitAndScatterFunc (const std::string& collision_name,
 
                 // get the reaction energy, assuming zero energy for charge exchange
                 pp_collision_name.query("two_product_reaction_energy", m_reaction_energy);
+            }
+
+            // For dissociation (e.g. e- + H2 -> e- + H + H):
+            if (std::find(scattering_processes.begin(), scattering_processes.end(), "dissociation") != scattering_processes.end()) {
+                m_num_product_species = 4;
+                m_num_products_host.push_back(1); // slot 0: incident (non-target) species, e.g. the electron; survives the collision
+                m_num_products_host.push_back(0); // slot 1: target species (the molecule); consumed by the reaction
+                m_num_products_host.push_back(1); // slot 2: first neutral fragment
+                m_num_products_host.push_back(1); // slot 3: second neutral fragment
+
+                // Energy (eV) the incident particle loses to break up the molecule (the impact
+                // threshold, e.g. ~8.5 eV for the H2 b3Sigma_u+ channel). The cross-section must
+                // be 0 at this energy (enforced in ScatteringProcess::init).
+                pp_collision_name.get("dissociation_energy", m_reaction_energy);
+                // Optional Franck-Condon kinetic-energy release (eV) shared back-to-back by the two
+                // fragments (e.g. ~4 eV = threshold - bond energy for H2). Defaults to 0.
+                pp_collision_name.query("dissociation_fragment_energy", m_fragment_energy);
             }
 
         } else {

--- a/Source/Particles/Collision/ScatteringProcess.H
+++ b/Source/Particles/Collision/ScatteringProcess.H
@@ -26,6 +26,7 @@ enum class ScatteringProcessType {
     EXCITATION,
     IONIZATION,
     FORWARD,
+    DISSOCIATION,
 };
 
 class ScatteringProcess

--- a/Source/Particles/Collision/ScatteringProcess.cpp
+++ b/Source/Particles/Collision/ScatteringProcess.cpp
@@ -86,6 +86,8 @@ ScatteringProcess::parseProcessType(const std::string& scattering_process)
         return ScatteringProcessType::TWOPRODUCT_REACTION;
     } else if (scattering_process == "ionization") {
         return ScatteringProcessType::IONIZATION;
+    } else if (scattering_process == "dissociation") {
+        return ScatteringProcessType::DISSOCIATION;
     } else if (scattering_process.find("excitation") != std::string::npos) {
         return ScatteringProcessType::EXCITATION;
     } else if (scattering_process.find("forward") != std::string::npos) {


### PR DESCRIPTION
## Scope

This adds a new `dissociation` scattering process to the DSMC binary-collision
module, for reactions of the form

    A + BC  ->  A + B + C

where an incident particle A breaks up a target molecule BC into two fragments
while itself surviving. The motivating case is electron-impact molecular
dissociation,

    e- + H2  ->  e- + H + H

the dominant inelastic e-H2 channel at low electron energy.

The existing DSMC processes don't cover this multiplicity (one incident in →
incident + two products out): `ionization` hard-wires electron+ion product
kinematics, and `charge_exchange`/`two_product_reaction` consume both reactants.
Hence a dedicated process.

## What's in it

A new `ScatteringProcessType::DISSOCIATION`:
- the incident species survives (with modified momentum), the target molecule is
  consumed, and two product fragments are created, with product-slot multiplicity
  `[1,0,1,1]`, mirroring the existing `ionization` layout;
- a momentum-conserving, non-relativistic two-stage kernel: the incident particle
  deposits the dissociation threshold energy and scatters isotropically off the
  molecule's centre of mass, then the molecule splits back-to-back into two
  fragments sharing a (Franck-Condon) kinetic-energy release. General two-body
  kinematics, so unequal fragment masses are handled.
- the usual cross-section / threshold plumbing, consistent with the other DSMC
  processes. Cross sections are user-supplied.

### Input syntax
    <collision>.scattering_processes         = elastic dissociation
    <collision>.dissociation_cross_section   = <sigma_file>
    <collision>.dissociation_energy          = <threshold, eV>
    <collision>.dissociation_fragment_energy = <fragment KER, eV>   # optional, default 0
    <collision>.product_species              = <B> <C>

As with `ionization`, only one new-species-producing reaction is allowed per
collision set; to combine with ionization, use a second collision on the same
species pair.

## Status (WIP)

Functionally complete and in use locally (builds on CPU and CUDA; reproduces the
analytic Maxwellian rate coefficient ⟨σv⟩(T) of the input cross section to a few
percent, conserves nuclei and momentum, and respects the energy threshold).
Remaining before merge:
- [ ] automated CI test (rate-recovery / conservation)
- [ ] docs entry for the new process
- [ ] review of the kinematics model + input API

Feedback on the kinematics model and the input API is welcome.
