### PR TITLE
DSMC refactoring: use ScatteringProcess::Executor object inside SplitAndScatterFunc kernel

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -59,7 +59,6 @@
 
 #include <cmath>
 #include <string>
-#include <type_traits>
 
 /**
  * \brief This class performs generic binary collisions.
@@ -81,15 +80,6 @@ class BinaryCollision final
     using ParticleTileDataType = ParticleTileType::ParticleTileDataType;
     using ParticleBins = amrex::DenseBins<ParticleTileDataType>;
     using index_type = ParticleBins::index_type;
-
-    // For DSMC, the per-pair selection array does not just flag whether a collision occurred:
-    // it stores the *index* of the selected scattering process (with -1 meaning "no collision"),
-    // so that SplitAndScatterFunc can look up the process type and energy penalty. This requires
-    // a signed integer. For all other collision types the array is a plain 0/1 particle-creation
-    // mask, so the unsigned index_type is used.
-    static constexpr bool stores_process_index = std::is_same_v<CollisionFunctor, DSMCFunc>;
-    using selection_type = std::conditional_t<stores_process_index,
-                                              std::make_signed_t<index_type>, index_type>;
 
 public:
     /**
@@ -439,11 +429,10 @@ public:
             index_type* AMREX_RESTRICT p_coll_offsets = coll_offsets.dataPtr();
             ABLASTR_PROFILE_VAR_STOP(prof_computeNumberOfPairs);
 
-            // mask: for DSMC, the index of the selected scattering process (-1 = no collision);
+            // mask: for DSMC, the index+1 of the selected scattering process (0 = no collision);
             // for other collision types, 1 if particle creation occurs, 0 otherwise
-            amrex::Gpu::DeviceVector<selection_type> mask(
-                n_total_pairs, stores_process_index ? selection_type(-1) : selection_type(0));
-            selection_type* AMREX_RESTRICT p_mask = mask.dataPtr();
+            amrex::Gpu::DeviceVector<index_type> mask(n_total_pairs, index_type(0));
+            index_type* AMREX_RESTRICT p_mask = mask.dataPtr();
             // Will be filled with the index of the first particle of a given pair
             amrex::Gpu::DeviceVector<index_type> pair_indices_1(n_total_pairs);
             index_type* AMREX_RESTRICT p_pair_indices_1 = pair_indices_1.dataPtr();
@@ -927,11 +916,10 @@ public:
             index_type* AMREX_RESTRICT p_coll_offsets = coll_offsets.dataPtr();
             ABLASTR_PROFILE_VAR_STOP(prof_computeNumberOfPairs);
 
-            // mask: for DSMC, the index of the selected scattering process (-1 = no collision);
+            // mask: for DSMC, the index+1 of the selected scattering process (0 = no collision);
             // for other collision types, 1 if particle creation occurs, 0 otherwise
-            amrex::Gpu::DeviceVector<selection_type> mask(
-                n_total_pairs, stores_process_index ? selection_type(-1) : selection_type(0));
-            selection_type* AMREX_RESTRICT p_mask = mask.dataPtr();
+            amrex::Gpu::DeviceVector<index_type> mask(n_total_pairs, index_type(0));
+            index_type* AMREX_RESTRICT p_mask = mask.dataPtr();
             // Will be filled with the index of the first particle of a given pair
             amrex::Gpu::DeviceVector<index_type> pair_indices_1(n_total_pairs);
             index_type* AMREX_RESTRICT p_pair_indices_1 = pair_indices_1.dataPtr();

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -59,6 +59,7 @@
 
 #include <cmath>
 #include <string>
+#include <type_traits>
 
 /**
  * \brief This class performs generic binary collisions.
@@ -80,6 +81,15 @@ class BinaryCollision final
     using ParticleTileDataType = ParticleTileType::ParticleTileDataType;
     using ParticleBins = amrex::DenseBins<ParticleTileDataType>;
     using index_type = ParticleBins::index_type;
+
+    // For DSMC, the per-pair selection array does not just flag whether a collision occurred:
+    // it stores the *index* of the selected scattering process (with -1 meaning "no collision"),
+    // so that SplitAndScatterFunc can look up the process type and energy penalty. This requires
+    // a signed integer. For all other collision types the array is a plain 0/1 particle-creation
+    // mask, so the unsigned index_type is used.
+    static constexpr bool stores_process_index = std::is_same_v<CollisionFunctor, DSMCFunc>;
+    using selection_type = std::conditional_t<stores_process_index,
+                                              std::make_signed_t<index_type>, index_type>;
 
 public:
     /**
@@ -429,9 +439,11 @@ public:
             index_type* AMREX_RESTRICT p_coll_offsets = coll_offsets.dataPtr();
             ABLASTR_PROFILE_VAR_STOP(prof_computeNumberOfPairs);
 
-            // mask: equal to 1 if particle creation occurs for a given pair, 0 otherwise
-            amrex::Gpu::DeviceVector<index_type> mask(n_total_pairs);
-            index_type* AMREX_RESTRICT p_mask = mask.dataPtr();
+            // mask: for DSMC, the index of the selected scattering process (-1 = no collision);
+            // for other collision types, 1 if particle creation occurs, 0 otherwise
+            amrex::Gpu::DeviceVector<selection_type> mask(
+                n_total_pairs, stores_process_index ? selection_type(-1) : selection_type(0));
+            selection_type* AMREX_RESTRICT p_mask = mask.dataPtr();
             // Will be filled with the index of the first particle of a given pair
             amrex::Gpu::DeviceVector<index_type> pair_indices_1(n_total_pairs);
             index_type* AMREX_RESTRICT p_pair_indices_1 = pair_indices_1.dataPtr();
@@ -915,9 +927,11 @@ public:
             index_type* AMREX_RESTRICT p_coll_offsets = coll_offsets.dataPtr();
             ABLASTR_PROFILE_VAR_STOP(prof_computeNumberOfPairs);
 
-            // mask: equal to 1 if particle creation occurs for a given pair, 0 otherwise
-            amrex::Gpu::DeviceVector<index_type> mask(n_total_pairs, index_type(0));
-            index_type* AMREX_RESTRICT p_mask = mask.dataPtr();
+            // mask: for DSMC, the index of the selected scattering process (-1 = no collision);
+            // for other collision types, 1 if particle creation occurs, 0 otherwise
+            amrex::Gpu::DeviceVector<selection_type> mask(
+                n_total_pairs, stores_process_index ? selection_type(-1) : selection_type(0));
+            selection_type* AMREX_RESTRICT p_mask = mask.dataPtr();
             // Will be filled with the index of the first particle of a given pair
             amrex::Gpu::DeviceVector<index_type> pair_indices_1(n_total_pairs);
             index_type* AMREX_RESTRICT p_pair_indices_1 = pair_indices_1.dataPtr();

--- a/Source/Particles/Collision/BinaryCollision/DSMC/CollisionFilterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/CollisionFilterFunc.H
@@ -26,8 +26,9 @@
  * @param[in] dV is the volume of the corresponding cell.
  * @param[in] pair_index is the index of the colliding pair.
  * @param[out] p_selected_process for each pair, set to the index of the selected
- *             scattering process (0-based, in the order of the scattering_processes
- *             array) if a collision occurs, or -1 if no collision occurs.
+ *             scattering process plus one (i.e. 1-based, in the order of the
+ *             scattering_processes array) if a collision occurs, or 0 if no
+ *             collision occurs.
  * @param[out] p_pair_reaction_weight stores the weight of the product particles.
  * @param[in] multiplier factor by which the collision probability is increased to
  *            account for all other possible binary collision partners.
@@ -104,10 +105,10 @@ void CollisionPairFilter (const amrex::ParticleReal u1x, const amrex::ParticleRe
         for (int ii = 0; ii < process_count; ii++) {
             if (random_number <= sigma_sums[ii] / sigma_tot)
             {
-                // Store the index of the selected scattering process. This is later used
-                // (in SplitAndScatterFunc) to look up the process type and energy penalty
-                // for this pair.
-                p_selected_process[pair_index] = static_cast<index_type>(ii);
+                // Store the index of the selected scattering process, plus one (0 is
+                // reserved to mean "no collision"). SplitAndScatterFunc subtracts one
+                // to look up the process type and energy penalty for this pair.
+                p_selected_process[pair_index] = static_cast<index_type>(ii + 1);
                 p_pair_reaction_weight[pair_index] = w_min;
                 break;
             }
@@ -116,7 +117,7 @@ void CollisionPairFilter (const amrex::ParticleReal u1x, const amrex::ParticleRe
     else
     {
         // No collision occurs for this pair.
-        p_selected_process[pair_index] = index_type(-1);
+        p_selected_process[pair_index] = index_type(0);
     }
 }
 

--- a/Source/Particles/Collision/BinaryCollision/DSMC/CollisionFilterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/CollisionFilterFunc.H
@@ -25,10 +25,9 @@
  * @param[in] dt is the time step length between two collision calls.
  * @param[in] dV is the volume of the corresponding cell.
  * @param[in] pair_index is the index of the colliding pair.
- * @param[out] p_mask for each pair, set to the index of the selected
- *             scattering process plus one (i.e. 1-based, in the order of the
- *             scattering_processes array) if a collision occurs, or 0 if no
- *             collision occurs.
+ * @param[out] p_mask for each pair: 0 if no collision occurs ;
+ *             index+1 of the selected process for that pair if a collision occurs, 
+ *             where `index` is the index of the process in the `scattering_processes` array.
  * @param[out] p_pair_reaction_weight stores the weight of the product particles.
  * @param[in] multiplier factor by which the collision probability is increased to
  *            account for all other possible binary collision partners.
@@ -105,17 +104,15 @@ void CollisionPairFilter (const amrex::ParticleReal u1x, const amrex::ParticleRe
         for (int ii = 0; ii < process_count; ii++) {
             if (random_number <= sigma_sums[ii] / sigma_tot)
             {
-                // Store the index of the selected scattering process, plus one (0 is
-                // reserved to mean "no collision"). SplitAndScatterFunc subtracts one
-                // to look up the process type and energy penalty for this pair.
+                // Store index+1 of the selected scattering process 
+                // (0 is reserved to mean "no collision"), where `index` 
+                // is the index of the selected process in the `scattering_processes` array.
                 p_mask[pair_index] = static_cast<index_type>(ii + 1);
                 p_pair_reaction_weight[pair_index] = w_min;
-                break;
+                return;
             }
         }
-    }
-    else
-    {
+    } else {
         // No collision occurs for this pair.
         p_mask[pair_index] = index_type(0);
     }

--- a/Source/Particles/Collision/BinaryCollision/DSMC/CollisionFilterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/CollisionFilterFunc.H
@@ -26,7 +26,7 @@
  * @param[in] dV is the volume of the corresponding cell.
  * @param[in] pair_index is the index of the colliding pair.
  * @param[out] p_mask for each pair: 0 if no collision occurs ;
- *             index+1 of the selected process for that pair if a collision occurs, 
+ *             index+1 of the selected process for that pair if a collision occurs,
  *             where `index` is the index of the process in the `scattering_processes` array.
  * @param[out] p_pair_reaction_weight stores the weight of the product particles.
  * @param[in] multiplier factor by which the collision probability is increased to
@@ -104,8 +104,8 @@ void CollisionPairFilter (const amrex::ParticleReal u1x, const amrex::ParticleRe
         for (int ii = 0; ii < process_count; ii++) {
             if (random_number <= sigma_sums[ii] / sigma_tot)
             {
-                // Store index+1 of the selected scattering process 
-                // (0 is reserved to mean "no collision"), where `index` 
+                // Store index+1 of the selected scattering process
+                // (0 is reserved to mean "no collision"), where `index`
                 // is the index of the selected process in the `scattering_processes` array.
                 p_mask[pair_index] = static_cast<index_type>(ii + 1);
                 p_pair_reaction_weight[pair_index] = w_min;

--- a/Source/Particles/Collision/BinaryCollision/DSMC/CollisionFilterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/CollisionFilterFunc.H
@@ -25,8 +25,9 @@
  * @param[in] dt is the time step length between two collision calls.
  * @param[in] dV is the volume of the corresponding cell.
  * @param[in] pair_index is the index of the colliding pair.
- * @param[out] p_mask is a mask that will be set to a non-zero integer if a
- *             collision occurs. The integer encodes the scattering process.
+ * @param[out] p_selected_process for each pair, set to the index of the selected
+ *             scattering process (0-based, in the order of the scattering_processes
+ *             array) if a collision occurs, or -1 if no collision occurs.
  * @param[out] p_pair_reaction_weight stores the weight of the product particles.
  * @param[in] multiplier factor by which the collision probability is increased to
  *            account for all other possible binary collision partners.
@@ -42,7 +43,7 @@ void CollisionPairFilter (const amrex::ParticleReal u1x, const amrex::ParticleRe
                           const amrex::ParticleReal m1, const amrex::ParticleReal m2,
                           const amrex::ParticleReal w1, const amrex::ParticleReal w2,
                           const amrex::Real dt, const amrex::ParticleReal dV, const int pair_index,
-                          index_type* AMREX_RESTRICT p_mask,
+                          index_type* AMREX_RESTRICT p_selected_process,
                           amrex::ParticleReal* AMREX_RESTRICT p_pair_reaction_weight,
                           const int multiplier,
                           const int process_count,
@@ -74,13 +75,11 @@ void CollisionPairFilter (const amrex::ParticleReal u1x, const amrex::ParticleRe
 
     // Evaluate the cross-section for each scattering process to determine
     // the total collision probability.
-    // The size of the arrays below is a compile-time constant (template parameter)
+    // The size of the array below is a compile-time constant (template parameter)
     // for performance reasons: it avoids dynamic memory allocation on the GPU.
-    int coll_type[max_process_count] = {0};
     amrex::ParticleReal sigma_sums[max_process_count] = {0._prt};
     for (int ii = 0; ii < process_count; ii++) {
         auto const& scattering_process = scattering_processes[ii];
-        coll_type[ii] = int(scattering_process.m_type);
         const amrex::ParticleReal sigma = scattering_process.getCrossSection(E_coll);
         sigma_sums[ii] = sigma + ((ii == 0) ? 0._prt : sigma_sums[ii-1]);
     }
@@ -105,7 +104,10 @@ void CollisionPairFilter (const amrex::ParticleReal u1x, const amrex::ParticleRe
         for (int ii = 0; ii < process_count; ii++) {
             if (random_number <= sigma_sums[ii] / sigma_tot)
             {
-                p_mask[pair_index] = coll_type[ii];
+                // Store the index of the selected scattering process. This is later used
+                // (in SplitAndScatterFunc) to look up the process type and energy penalty
+                // for this pair.
+                p_selected_process[pair_index] = static_cast<index_type>(ii);
                 p_pair_reaction_weight[pair_index] = w_min;
                 break;
             }
@@ -113,7 +115,8 @@ void CollisionPairFilter (const amrex::ParticleReal u1x, const amrex::ParticleRe
     }
     else
     {
-        p_mask[pair_index] = false;
+        // No collision occurs for this pair.
+        p_selected_process[pair_index] = index_type(-1);
     }
 }
 

--- a/Source/Particles/Collision/BinaryCollision/DSMC/CollisionFilterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/CollisionFilterFunc.H
@@ -25,7 +25,7 @@
  * @param[in] dt is the time step length between two collision calls.
  * @param[in] dV is the volume of the corresponding cell.
  * @param[in] pair_index is the index of the colliding pair.
- * @param[out] p_selected_process for each pair, set to the index of the selected
+ * @param[out] p_mask for each pair, set to the index of the selected
  *             scattering process plus one (i.e. 1-based, in the order of the
  *             scattering_processes array) if a collision occurs, or 0 if no
  *             collision occurs.
@@ -44,7 +44,7 @@ void CollisionPairFilter (const amrex::ParticleReal u1x, const amrex::ParticleRe
                           const amrex::ParticleReal m1, const amrex::ParticleReal m2,
                           const amrex::ParticleReal w1, const amrex::ParticleReal w2,
                           const amrex::Real dt, const amrex::ParticleReal dV, const int pair_index,
-                          index_type* AMREX_RESTRICT p_selected_process,
+                          index_type* AMREX_RESTRICT p_mask,
                           amrex::ParticleReal* AMREX_RESTRICT p_pair_reaction_weight,
                           const int multiplier,
                           const int process_count,
@@ -108,7 +108,7 @@ void CollisionPairFilter (const amrex::ParticleReal u1x, const amrex::ParticleRe
                 // Store the index of the selected scattering process, plus one (0 is
                 // reserved to mean "no collision"). SplitAndScatterFunc subtracts one
                 // to look up the process type and energy penalty for this pair.
-                p_selected_process[pair_index] = static_cast<index_type>(ii + 1);
+                p_mask[pair_index] = static_cast<index_type>(ii + 1);
                 p_pair_reaction_weight[pair_index] = w_min;
                 break;
             }
@@ -117,7 +117,7 @@ void CollisionPairFilter (const amrex::ParticleReal u1x, const amrex::ParticleRe
     else
     {
         // No collision occurs for this pair.
-        p_selected_process[pair_index] = index_type(0);
+        p_mask[pair_index] = index_type(0);
     }
 }
 

--- a/Source/Particles/Collision/BinaryCollision/DSMC/CollisionFilterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/CollisionFilterFunc.H
@@ -109,7 +109,7 @@ void CollisionPairFilter (const amrex::ParticleReal u1x, const amrex::ParticleRe
                 // is the index of the selected process in the `scattering_processes` array.
                 p_mask[pair_index] = static_cast<index_type>(ii + 1);
                 p_pair_reaction_weight[pair_index] = w_min;
-                return;
+                break;
             }
         }
     } else {

--- a/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.H
@@ -79,7 +79,7 @@ public:
          * @param[in] coll_idx is the collision index offset.
          * @param[in] cell_start_pair is the start index of the pairs in that cell.
          * @param[out] p_mask for each pair: 0 if no collision occurs ;
-         * index+1 of the selected process for that pair if a collision occurs, 
+         * index+1 of the selected process for that pair if a collision occurs,
          * where `index` is the index of the process in the `m_scattering_processes_data` array.
          * @param[out] p_pair_indices_1,p_pair_indices_2 arrays that store the indices of the
          * particles of a given pair. They are only needed here to store information that will be used

--- a/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.H
@@ -28,8 +28,6 @@
 #include <AMReX_ParmParse.H>
 #include <AMReX_Random.H>
 
-#include <type_traits>
-
 /**
  * \brief This class performs DSMC (direct simulation Monte Carlo) collisions
  * within a cell. Particles are paired up and for each pair a stochastic process
@@ -44,9 +42,6 @@ class DSMCFunc
     using ParticleTileDataType = ParticleTileType::ParticleTileDataType;
     using ParticleBins = amrex::DenseBins<ParticleTileDataType>;
     using index_type = ParticleBins::index_type;
-    // Signed integer used for the per-pair selected-process array (see operator() below):
-    // it holds the index of the selected scattering process, or -1 when no collision occurs.
-    using selection_type = std::make_signed_t<index_type>;
     using SoaData_type = WarpXParticleContainer::ParticleTileType::ParticleTileDataType;
 
 public:
@@ -72,7 +67,7 @@ public:
          * \brief Executor of the DSMCFunc class. Performs DSMC collisions at the cell level.
          * Note that this function does not yet create the product particles, but
          * instead fills an array p_selected_process that stores, for each pair, the index of
-         * the selected scattering process (or -1 if no collision occurs for that pair).
+         * the selected scattering process plus one (or 0 if no collision occurs for that pair).
          *
          * @param[in] I1s,I2s is the start index for I1,I2 (inclusive).
          * @param[in] I1e,I2e is the stop index for I1,I2 (exclusive).
@@ -84,8 +79,8 @@ public:
          * @param[in] coll_idx is the collision index offset.
          * @param[in] cell_start_pair is the start index of the pairs in that cell.
          * @param[out] p_selected_process stores, for each pair, the index of the selected
-         * scattering process (or -1 if no collision occurs). It is only needed here to store
-         * information that will be used later on when actually creating the product particles.
+         * scattering process plus one (or 0 if no collision occurs). It is only needed here to
+         * store information used later when actually creating the product particles.
          * @param[out] p_pair_indices_1,p_pair_indices_2 arrays that store the indices of the
          * particles of a given pair. They are only needed here to store information that will be used
          * later on when actually creating the product particles.
@@ -108,7 +103,7 @@ public:
             amrex::ParticleReal const  /*q1*/, amrex::ParticleReal const  /*q2*/,
             amrex::ParticleReal const  m1, amrex::ParticleReal const  m2,
             amrex::Real const  dt, amrex::Real const dV, index_type coll_idx,
-            index_type const cell_start_pair, selection_type* AMREX_RESTRICT p_selected_process,
+            index_type const cell_start_pair, index_type* AMREX_RESTRICT p_selected_process,
             index_type* AMREX_RESTRICT p_pair_indices_1, index_type* AMREX_RESTRICT p_pair_indices_2,
             amrex::ParticleReal* AMREX_RESTRICT p_pair_reaction_weight,
             amrex::ParticleReal* /*p_product_data*/,
@@ -148,7 +143,7 @@ public:
                 // reduced to zero from a previous collision
                 if (idcpu1[ I1[i1] ]==amrex::ParticleIdCpus::Invalid ||
                     idcpu2[ I2[i2] ]==amrex::ParticleIdCpus::Invalid ) {
-                    p_selected_process[pair_index] = selection_type(-1);
+                    p_selected_process[pair_index] = index_type(0);
                 } else {
 
                     const int max_process_count = 4; // Pre-defined value, for performance reasons
@@ -164,7 +159,7 @@ public:
                         m_process_count, m_scattering_processes_data, engine);
 
                     // Remove pair reaction weight from the colliding particles' weights
-                    if (p_selected_process[pair_index] >= 0) {
+                    if (p_selected_process[pair_index] > 0) {
                         BinaryCollisionUtils::remove_weight_from_colliding_particle(
                             w1[ I1[i1] ], idcpu1[ I1[i1] ], p_pair_reaction_weight[pair_index]);
                         BinaryCollisionUtils::remove_weight_from_colliding_particle(

--- a/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.H
@@ -66,7 +66,7 @@ public:
         /**
          * \brief Executor of the DSMCFunc class. Performs DSMC collisions at the cell level.
          * Note that this function does not yet create the product particles, but
-         * instead fills an array p_selected_process that stores, for each pair, the index of
+         * instead fills an array p_mask that stores, for each pair, the index of
          * the selected scattering process plus one (or 0 if no collision occurs for that pair).
          *
          * @param[in] I1s,I2s is the start index for I1,I2 (inclusive).
@@ -78,7 +78,7 @@ public:
          * @param[in] dV is the volume of the corresponding cell.
          * @param[in] coll_idx is the collision index offset.
          * @param[in] cell_start_pair is the start index of the pairs in that cell.
-         * @param[out] p_selected_process stores, for each pair, the index of the selected
+         * @param[out] p_mask stores, for each pair, the index of the selected
          * scattering process plus one (or 0 if no collision occurs). It is only needed here to
          * store information used later when actually creating the product particles.
          * @param[out] p_pair_indices_1,p_pair_indices_2 arrays that store the indices of the
@@ -103,7 +103,7 @@ public:
             amrex::ParticleReal const  /*q1*/, amrex::ParticleReal const  /*q2*/,
             amrex::ParticleReal const  m1, amrex::ParticleReal const  m2,
             amrex::Real const  dt, amrex::Real const dV, index_type coll_idx,
-            index_type const cell_start_pair, index_type* AMREX_RESTRICT p_selected_process,
+            index_type const cell_start_pair, index_type* AMREX_RESTRICT p_mask,
             index_type* AMREX_RESTRICT p_pair_indices_1, index_type* AMREX_RESTRICT p_pair_indices_2,
             amrex::ParticleReal* AMREX_RESTRICT p_pair_reaction_weight,
             amrex::ParticleReal* /*p_product_data*/,
@@ -143,7 +143,7 @@ public:
                 // reduced to zero from a previous collision
                 if (idcpu1[ I1[i1] ]==amrex::ParticleIdCpus::Invalid ||
                     idcpu2[ I2[i2] ]==amrex::ParticleIdCpus::Invalid ) {
-                    p_selected_process[pair_index] = index_type(0);
+                    p_mask[pair_index] = index_type(0);
                 } else {
 
                     const int max_process_count = 4; // Pre-defined value, for performance reasons
@@ -154,12 +154,12 @@ public:
                         u1x[ I1[i1] ], u1y[ I1[i1] ], u1z[ I1[i1] ],
                         u2x[ I2[i2] ], u2y[ I2[i2] ], u2z[ I2[i2] ],
                         m1, m2, w1[ I1[i1] ], w2[ I2[i2] ],
-                        dt, dV, static_cast<int>(pair_index), p_selected_process,
+                        dt, dV, static_cast<int>(pair_index), p_mask,
                         p_pair_reaction_weight, multiplier_ratio,
                         m_process_count, m_scattering_processes_data, engine);
 
                     // Remove pair reaction weight from the colliding particles' weights
-                    if (p_selected_process[pair_index] > 0) {
+                    if (p_mask[pair_index] > 0) {
                         BinaryCollisionUtils::remove_weight_from_colliding_particle(
                             w1[ I1[i1] ], idcpu1[ I1[i1] ], p_pair_reaction_weight[pair_index]);
                         BinaryCollisionUtils::remove_weight_from_colliding_particle(

--- a/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.H
@@ -28,6 +28,8 @@
 #include <AMReX_ParmParse.H>
 #include <AMReX_Random.H>
 
+#include <type_traits>
+
 /**
  * \brief This class performs DSMC (direct simulation Monte Carlo) collisions
  * within a cell. Particles are paired up and for each pair a stochastic process
@@ -42,6 +44,9 @@ class DSMCFunc
     using ParticleTileDataType = ParticleTileType::ParticleTileDataType;
     using ParticleBins = amrex::DenseBins<ParticleTileDataType>;
     using index_type = ParticleBins::index_type;
+    // Signed integer used for the per-pair selected-process array (see operator() below):
+    // it holds the index of the selected scattering process, or -1 when no collision occurs.
+    using selection_type = std::make_signed_t<index_type>;
     using SoaData_type = WarpXParticleContainer::ParticleTileType::ParticleTileDataType;
 
 public:
@@ -66,7 +71,8 @@ public:
         /**
          * \brief Executor of the DSMCFunc class. Performs DSMC collisions at the cell level.
          * Note that this function does not yet create the product particles, but
-         * instead fills an array p_mask that stores which pairs result in a collision event.
+         * instead fills an array p_selected_process that stores, for each pair, the index of
+         * the selected scattering process (or -1 if no collision occurs for that pair).
          *
          * @param[in] I1s,I2s is the start index for I1,I2 (inclusive).
          * @param[in] I1e,I2e is the stop index for I1,I2 (exclusive).
@@ -77,9 +83,9 @@ public:
          * @param[in] dV is the volume of the corresponding cell.
          * @param[in] coll_idx is the collision index offset.
          * @param[in] cell_start_pair is the start index of the pairs in that cell.
-         * @param[out] p_mask is a mask that will be set to true if a fusion event occurs for a given
-         * pair. It is only needed here to store information that will be used later on when actually
-         * creating the product particles.
+         * @param[out] p_selected_process stores, for each pair, the index of the selected
+         * scattering process (or -1 if no collision occurs). It is only needed here to store
+         * information that will be used later on when actually creating the product particles.
          * @param[out] p_pair_indices_1,p_pair_indices_2 arrays that store the indices of the
          * particles of a given pair. They are only needed here to store information that will be used
          * later on when actually creating the product particles.
@@ -102,7 +108,7 @@ public:
             amrex::ParticleReal const  /*q1*/, amrex::ParticleReal const  /*q2*/,
             amrex::ParticleReal const  m1, amrex::ParticleReal const  m2,
             amrex::Real const  dt, amrex::Real const dV, index_type coll_idx,
-            index_type const cell_start_pair, index_type* AMREX_RESTRICT p_mask,
+            index_type const cell_start_pair, selection_type* AMREX_RESTRICT p_selected_process,
             index_type* AMREX_RESTRICT p_pair_indices_1, index_type* AMREX_RESTRICT p_pair_indices_2,
             amrex::ParticleReal* AMREX_RESTRICT p_pair_reaction_weight,
             amrex::ParticleReal* /*p_product_data*/,
@@ -142,7 +148,7 @@ public:
                 // reduced to zero from a previous collision
                 if (idcpu1[ I1[i1] ]==amrex::ParticleIdCpus::Invalid ||
                     idcpu2[ I2[i2] ]==amrex::ParticleIdCpus::Invalid ) {
-                    p_mask[pair_index] = false;
+                    p_selected_process[pair_index] = selection_type(-1);
                 } else {
 
                     const int max_process_count = 4; // Pre-defined value, for performance reasons
@@ -153,12 +159,12 @@ public:
                         u1x[ I1[i1] ], u1y[ I1[i1] ], u1z[ I1[i1] ],
                         u2x[ I2[i2] ], u2y[ I2[i2] ], u2z[ I2[i2] ],
                         m1, m2, w1[ I1[i1] ], w2[ I2[i2] ],
-                        dt, dV, static_cast<int>(pair_index), p_mask,
+                        dt, dV, static_cast<int>(pair_index), p_selected_process,
                         p_pair_reaction_weight, multiplier_ratio,
                         m_process_count, m_scattering_processes_data, engine);
 
                     // Remove pair reaction weight from the colliding particles' weights
-                    if (p_mask[pair_index]) {
+                    if (p_selected_process[pair_index] >= 0) {
                         BinaryCollisionUtils::remove_weight_from_colliding_particle(
                             w1[ I1[i1] ], idcpu1[ I1[i1] ], p_pair_reaction_weight[pair_index]);
                         BinaryCollisionUtils::remove_weight_from_colliding_particle(

--- a/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.H
@@ -78,9 +78,9 @@ public:
          * @param[in] dV is the volume of the corresponding cell.
          * @param[in] coll_idx is the collision index offset.
          * @param[in] cell_start_pair is the start index of the pairs in that cell.
-         * @param[out] p_mask stores, for each pair, the index of the selected
-         * scattering process plus one (or 0 if no collision occurs). It is only needed here to
-         * store information used later when actually creating the product particles.
+         * @param[out] p_mask for each pair: 0 if no collision occurs ;
+         * index+1 of the selected process for that pair if a collision occurs, 
+         * where `index` is the index of the process in the `m_scattering_processes_data` array.
          * @param[out] p_pair_indices_1,p_pair_indices_2 arrays that store the indices of the
          * particles of a given pair. They are only needed here to store information that will be used
          * later on when actually creating the product particles.
@@ -159,7 +159,7 @@ public:
                         m_process_count, m_scattering_processes_data, engine);
 
                     // Remove pair reaction weight from the colliding particles' weights
-                    if (p_mask[pair_index] > 0) {
+                    if (p_mask[pair_index]) {
                         BinaryCollisionUtils::remove_weight_from_colliding_particle(
                             w1[ I1[i1] ], idcpu1[ I1[i1] ], p_pair_reaction_weight[pair_index]);
                         BinaryCollisionUtils::remove_weight_from_colliding_particle(

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -620,7 +620,7 @@ private:
     // How many different type of species the collision produces
     int m_num_product_species;
     // The scattering processes, in the same order as the input list (and as the indices encoded
-    // in the per-pair mask). Used to look up, for each pair, the process type and energy penalty. 
+    // in the per-pair mask). Used to look up, for each pair, the process type and energy penalty.
     amrex::Vector<ScatteringProcess> m_scattering_processes;
     amrex::Gpu::DeviceVector<ScatteringProcess::Executor> m_scattering_processes_exe;
     // Vector of size m_num_product_species: for each product slot, the number of new particles

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -18,7 +18,6 @@
 #include "Utils/WarpXAlgorithmSelection.H"
 
 #include <array>
-#include <type_traits>
 
 /**
  * \brief This class defines an operator to create product particles from DSMC
@@ -32,9 +31,6 @@ class SplitAndScatterFunc
     using ParticleTileDataType = typename ParticleTileType::ParticleTileDataType;
     using ParticleBins = amrex::DenseBins<ParticleTileDataType>;
     using index_type = typename ParticleBins::index_type;
-    // Signed integer used for the per-pair selected-process array: it holds the index of
-    // the selected scattering process, or -1 when no collision occurs for that pair.
-    using selection_type = std::make_signed_t<index_type>;
     using SoaData_type = WarpXParticleContainer::ParticleTileType::ParticleTileDataType;
 
 public:
@@ -83,8 +79,8 @@ public:
      * @param[in]     m0                    rest mass of the first reactant species (slot 0).
      * @param[in]     m1                    rest mass of the other reactant species (slot 1).
      * @param[in]     selected_process      per-pair index of the selected scattering process
-     *                                      (0-based, in the order of the process list), or -1
-     *                                      if no collision occurred for that pair.
+     *                                      plus one (1-based, in the order of the process list),
+     *                                      or 0 if no collision occurred for that pair.
      * @param[in,out] products_np           macroparticle count of each product tile; updated in this
      *                                      kernel to reflect the number of new macroparticles added in each species.
      * @param[in]     copy_species0         array of SmartCopy functors (size m_num_product_species);
@@ -108,7 +104,7 @@ public:
         ParticleTileType** AMREX_RESTRICT tile_products,
         const amrex::ParticleReal m0, const amrex::ParticleReal m1,
         const amrex::Vector<amrex::ParticleReal>& /*products_mass*/,
-        const selection_type* AMREX_RESTRICT selected_process,
+        const index_type* AMREX_RESTRICT selected_process,
         amrex::Vector<index_type>& products_np,
         const SmartCopy* AMREX_RESTRICT copy_species0,
         const SmartCopy* AMREX_RESTRICT copy_species1,
@@ -151,8 +147,8 @@ public:
         index_type* AMREX_RESTRICT no_product_offsets_data = no_product_offsets.data();
         auto const no_product_total = amrex::Scan::PrefixSum<index_type>(n_total_pairs,
             [=] AMREX_GPU_DEVICE (index_type i) -> index_type {
-                if (selected_process[i] < 0) { return 0; }
-                const auto type = processes[selected_process[i]].m_type;
+                if (selected_process[i] == 0) { return 0; }
+                const auto type = processes[selected_process[i] - 1].m_type;
                 return ((type != ScatteringProcessType::IONIZATION) &&
                         (type != ScatteringProcessType::TWOPRODUCT_REACTION) &&
                         (type != ScatteringProcessType::CHARGE_EXCHANGE)) ? 1 : 0;
@@ -178,8 +174,8 @@ public:
         index_type* AMREX_RESTRICT with_product_offsets_data = with_product_offsets.data();
         auto const with_product_total = amrex::Scan::PrefixSum<index_type>(n_total_pairs,
             [=] AMREX_GPU_DEVICE (index_type i) -> index_type {
-                if (selected_process[i] < 0) { return 0; }
-                const auto type = processes[selected_process[i]].m_type;
+                if (selected_process[i] == 0) { return 0; }
+                const auto type = processes[selected_process[i] - 1].m_type;
                 return ((type == ScatteringProcessType::IONIZATION) ||
                         (type == ScatteringProcessType::TWOPRODUCT_REACTION) ||
                         (type == ScatteringProcessType::CHARGE_EXCHANGE)) ? 1 : 0;
@@ -251,9 +247,9 @@ public:
         [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
         {
             // Look up the type of the scattering process selected for this pair
-            // (INVALID if no collision occurred, i.e. selected_process[i] < 0).
-            const auto type = (selected_process[i] >= 0)
-                ? processes[selected_process[i]].m_type : ScatteringProcessType::INVALID;
+            // (INVALID if no collision occurred, i.e. selected_process[i] == 0).
+            const auto type = (selected_process[i] > 0)
+                ? processes[selected_process[i] - 1].m_type : ScatteringProcessType::INVALID;
 
             if ((type != ScatteringProcessType::INVALID) &&
                 (type != ScatteringProcessType::IONIZATION) &&
@@ -391,7 +387,7 @@ public:
                     soa_products_data[3].m_rdata[PIdx::ux][slot3_idx],
                     soa_products_data[3].m_rdata[PIdx::uy][slot3_idx],
                     soa_products_data[3].m_rdata[PIdx::uz][slot3_idx], mass_slot3,
-                    -processes[selected_process[i]].m_energy_penalty*PhysConst::q_e,
+                    -processes[selected_process[i] - 1].m_energy_penalty*PhysConst::q_e,
                     // TwoProductComputeProductMomenta expects the *released* energy here, hence the negative sign
                     // We also convert from eV to Joules
                     ScatteringAngleModel::Forward,
@@ -479,7 +475,7 @@ public:
                 const amrex::ParticleReal E_coll = 0.5_prt * p_non_target_in * p_non_target_in * (1.0_prt/m0 + 1.0_prt/m1);
                 // subtract the energy cost for ionization (converted from eV to J)
                 const amrex::ParticleReal E_out =
-                    E_coll - processes[selected_process[i]].m_energy_penalty * PhysConst::q_e;
+                    E_coll - processes[selected_process[i] - 1].m_energy_penalty * PhysConst::q_e;
 
                 // The kinematics of the ionization event (i.e. how the energy and momentum are
                 // distributed among the products) depend on the nature of the incident particle

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -18,6 +18,7 @@
 #include "Utils/WarpXAlgorithmSelection.H"
 
 #include <array>
+#include <type_traits>
 
 /**
  * \brief This class defines an operator to create product particles from DSMC
@@ -31,6 +32,9 @@ class SplitAndScatterFunc
     using ParticleTileDataType = typename ParticleTileType::ParticleTileDataType;
     using ParticleBins = amrex::DenseBins<ParticleTileDataType>;
     using index_type = typename ParticleBins::index_type;
+    // Signed integer used for the per-pair selected-process array: it holds the index of
+    // the selected scattering process, or -1 when no collision occurs for that pair.
+    using selection_type = std::make_signed_t<index_type>;
     using SoaData_type = WarpXParticleContainer::ParticleTileType::ParticleTileDataType;
 
 public:
@@ -78,8 +82,9 @@ public:
      *                                      appended to each tile.
      * @param[in]     m0                    rest mass of the first reactant species (slot 0).
      * @param[in]     m1                    rest mass of the other reactant species (slot 1).
-     * @param[in]     mask                  per-pair collision type: 0 = no collision,
-     *                                      otherwise cast of ScatteringProcessType to int.
+     * @param[in]     selected_process      per-pair index of the selected scattering process
+     *                                      (0-based, in the order of the process list), or -1
+     *                                      if no collision occurred for that pair.
      * @param[in,out] products_np           macroparticle count of each product tile; updated in this
      *                                      kernel to reflect the number of new macroparticles added in each species.
      * @param[in]     copy_species0         array of SmartCopy functors (size m_num_product_species);
@@ -103,7 +108,7 @@ public:
         ParticleTileType** AMREX_RESTRICT tile_products,
         const amrex::ParticleReal m0, const amrex::ParticleReal m1,
         const amrex::Vector<amrex::ParticleReal>& /*products_mass*/,
-        const index_type* AMREX_RESTRICT mask,
+        const selection_type* AMREX_RESTRICT selected_process,
         amrex::Vector<index_type>& products_np,
         const SmartCopy* AMREX_RESTRICT copy_species0,
         const SmartCopy* AMREX_RESTRICT copy_species1,
@@ -133,19 +138,23 @@ public:
         // zeros, indicating that for all the "product" species, there were no new macroparticles added.
         if (n_total_pairs == 0) { return amrex::Vector<int>(m_num_product_species, 0); }
 
+        // The list of scattering processes, used to look up the type (and, further below, the
+        // energy penalty) of the process selected for each pair via its index.
+        const ScatteringProcess::Executor* AMREX_RESTRICT processes = m_scattering_processes_data;
+
         // The following is used to calculate the appropriate offsets for
         // non-product producing collisions (i.e., not ionization, not two-product reaction).
-        // Note that a standard cummulative sum is not appropriate since the
-        // mask is also used to specify the type of collision and can therefore
-        // have values >1
+        // Note that a standard cummulative sum is not appropriate since we count 1 for each
+        // colliding pair, regardless of the index of the selected scattering process.
         amrex::Gpu::DeviceVector<index_type> no_product_offsets(n_total_pairs);
         index_type* AMREX_RESTRICT no_product_offsets_data = no_product_offsets.data();
         auto const no_product_total = amrex::Scan::PrefixSum<index_type>(n_total_pairs,
             [=] AMREX_GPU_DEVICE (index_type i) -> index_type {
-                return ((mask[i] > 0) &&
-                        (mask[i] != int(ScatteringProcessType::IONIZATION)) &&
-                        (mask[i] != int(ScatteringProcessType::TWOPRODUCT_REACTION)) &&
-                        (mask[i] != int(ScatteringProcessType::CHARGE_EXCHANGE))) ? 1 : 0;
+                if (selected_process[i] < 0) { return 0; }
+                const auto type = processes[selected_process[i]].m_type;
+                return ((type != ScatteringProcessType::IONIZATION) &&
+                        (type != ScatteringProcessType::TWOPRODUCT_REACTION) &&
+                        (type != ScatteringProcessType::CHARGE_EXCHANGE)) ? 1 : 0;
             },
             [=] AMREX_GPU_DEVICE (index_type i, index_type s) { no_product_offsets_data[i] = s; },
             amrex::Scan::Type::exclusive, amrex::Scan::retSum
@@ -162,16 +171,17 @@ public:
 
         // The following is used to calculate the appropriate offsets for
         // product producing processes (i.e., ionization and two-product reaction).
-        // Note that a standard cummulative sum is not appropriate since the
-        // mask is also used to specify the type of collision and can therefore
-        // have values >1
+        // Note that a standard cummulative sum is not appropriate since we count 1 for each
+        // colliding pair, regardless of the index of the selected scattering process.
         amrex::Gpu::DeviceVector<index_type> with_product_offsets(n_total_pairs);
         index_type* AMREX_RESTRICT with_product_offsets_data = with_product_offsets.data();
         auto const with_product_total = amrex::Scan::PrefixSum<index_type>(n_total_pairs,
             [=] AMREX_GPU_DEVICE (index_type i) -> index_type {
-                return ((mask[i] == int(ScatteringProcessType::IONIZATION)) |
-                        (mask[i] == int(ScatteringProcessType::TWOPRODUCT_REACTION)) |
-                        (mask[i] == int(ScatteringProcessType::CHARGE_EXCHANGE))) ? 1 : 0;
+                if (selected_process[i] < 0) { return 0; }
+                const auto type = processes[selected_process[i]].m_type;
+                return ((type == ScatteringProcessType::IONIZATION) ||
+                        (type == ScatteringProcessType::TWOPRODUCT_REACTION) ||
+                        (type == ScatteringProcessType::CHARGE_EXCHANGE)) ? 1 : 0;
             },
             [=] AMREX_GPU_DEVICE (index_type i, index_type s) { with_product_offsets_data[i] = s; },
             amrex::Scan::Type::exclusive, amrex::Scan::retSum
@@ -226,7 +236,6 @@ public:
 #endif
 
         const int num_product_species = m_num_product_species;
-        const auto reaction_energy = m_reaction_energy;
 
         // Grab the masses of the true product species (slots 2 and 3)
         amrex::ParticleReal mass_slot2 = 0;
@@ -240,7 +249,15 @@ public:
         amrex::ParallelForRNG(n_total_pairs,
         [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
         {
-            if ((mask[i] > 0) && (mask[i] != int(ScatteringProcessType::IONIZATION)) && (mask[i] != int(ScatteringProcessType::TWOPRODUCT_REACTION)) && (mask[i] != int(ScatteringProcessType::CHARGE_EXCHANGE)))
+            // Look up the type of the scattering process selected for this pair
+            // (INVALID if no collision occurred, i.e. selected_process[i] < 0).
+            const auto type = (selected_process[i] >= 0)
+                ? processes[selected_process[i]].m_type : ScatteringProcessType::INVALID;
+
+            if ((type != ScatteringProcessType::INVALID) &&
+                (type != ScatteringProcessType::IONIZATION) &&
+                (type != ScatteringProcessType::TWOPRODUCT_REACTION) &&
+                (type != ScatteringProcessType::CHARGE_EXCHANGE))
             {
                 const auto slot0_idx = products_np_data[0] + no_product_offsets_data[i];
                 // Make a copy of the particle from the first reactant species
@@ -280,7 +297,7 @@ public:
                 uy1 -= uCOM_y;
                 uz1 -= uCOM_z;
 
-                if (mask[i] == int(ScatteringProcessType::ELASTIC)) {
+                if (type == ScatteringProcessType::ELASTIC) {
                     // randomly rotate the velocity vector for the first particle
                     ParticleUtils::RandomizeVelocity(
                         ux0, uy0, uz0, std::sqrt(ux0*ux0 + uy0*uy0 + uz0*uz0), engine
@@ -290,7 +307,7 @@ public:
                     ux1 = -ux0 * m0 / m1;
                     uy1 = -uy0 * m0 / m1;
                     uz1 = -uz0 * m0 / m1;
-                } else if (mask[i] == int(ScatteringProcessType::BACK)) {
+                } else if (type == ScatteringProcessType::BACK) {
                     // reverse the velocity vectors of both particles
                     ux0 *= -1.0_prt;
                     uy0 *= -1.0_prt;
@@ -298,7 +315,7 @@ public:
                     ux1 *= -1.0_prt;
                     uy1 *= -1.0_prt;
                     uz1 *= -1.0_prt;
-                } else if (mask[i] == int(ScatteringProcessType::FORWARD)) {
+                } else if (type == ScatteringProcessType::FORWARD) {
                     amrex::Abort("Forward scattering with DSMC not implemented yet.");
                 }
                 else {
@@ -315,8 +332,8 @@ public:
             }
 
             // Next perform all product-producing collisions
-            else if ((mask[i] == int(ScatteringProcessType::TWOPRODUCT_REACTION)) ||
-                     (mask[i] == int(ScatteringProcessType::CHARGE_EXCHANGE)))
+            else if ((type == ScatteringProcessType::TWOPRODUCT_REACTION) ||
+                     (type == ScatteringProcessType::CHARGE_EXCHANGE))
             {
                 // create a copy of the first product species at the location of the first reactant species
                 const auto src0_idx = static_cast<int>(p_pair_indices_0[i]);
@@ -337,7 +354,7 @@ public:
                 // For charge exchange, swap positions at which the products are created
                 // to ensure local charge conservation. For instance in the reaction
                 // `A+ + B -> A + B+`, B+ will be created at the position of A+, instead of that of B.
-                if (mask[i] == int(ScatteringProcessType::CHARGE_EXCHANGE)) {
+                if (type == ScatteringProcessType::CHARGE_EXCHANGE) {
                     // The SoA components that define the positions depend on the geometry.
 #if defined(WARPX_DIM_1D_Z)
                     constexpr std::array<int, 1> position_indices = {PIdx::z};
@@ -373,7 +390,7 @@ public:
                     soa_products_data[3].m_rdata[PIdx::ux][slot3_idx],
                     soa_products_data[3].m_rdata[PIdx::uy][slot3_idx],
                     soa_products_data[3].m_rdata[PIdx::uz][slot3_idx], mass_slot3,
-                    -reaction_energy*PhysConst::q_e,
+                    -processes[selected_process[i]].m_energy_penalty*PhysConst::q_e,
                     // TwoProductComputeProductMomenta expects the *released* energy here, hence the negative sign
                     // We also convert from eV to Joules
                     ScatteringAngleModel::Forward,
@@ -381,7 +398,7 @@ public:
                     // as that of the reactant particle, in the center-of-mass frame
                     engine);
             }
-            else if (mask[i] == int(ScatteringProcessType::IONIZATION))
+            else if (type == ScatteringProcessType::IONIZATION)
             {
                 const auto slot0_idx = products_np_data[0] + no_product_total + with_product_offsets_data[i];
                 // Make a copy of the particle from the first reactant species (slot 0)
@@ -460,7 +477,8 @@ public:
                 const amrex::ParticleReal p_non_target_in = m0 * std::sqrt(ux0*ux0 + uy0*uy0 + uz0*uz0);
                 const amrex::ParticleReal E_coll = 0.5_prt * p_non_target_in * p_non_target_in * (1.0_prt/m0 + 1.0_prt/m1);
                 // subtract the energy cost for ionization (converted from eV to J)
-                const amrex::ParticleReal E_out = E_coll - reaction_energy * PhysConst::q_e;
+                const amrex::ParticleReal E_out =
+                    E_coll - processes[selected_process[i]].m_energy_penalty * PhysConst::q_e;
 
                 // The kinematics of the ionization event (i.e. how the energy and momentum are
                 // distributed among the products) depend on the nature of the incident particle
@@ -598,8 +616,12 @@ public:
 private:
     // How many different type of species the collision produces
     int m_num_product_species;
-    // If ionization collisions are included, what is the energy cost
-    amrex::ParticleReal m_reaction_energy = 0.0;
+    // The scattering processes, in the same order as the input list (and as the indices stored
+    // in the per-pair selected-process array). Used to look up, for each pair, the process type
+    // and energy penalty. m_scattering_processes_data points into the device copy below.
+    amrex::Vector<ScatteringProcess> m_scattering_processes;
+    amrex::Gpu::DeviceVector<ScatteringProcess::Executor> m_scattering_processes_exe;
+    const ScatteringProcess::Executor* m_scattering_processes_data = nullptr;
     // Vector of size m_num_product_species: for each product slot, the number of new particles
     // created per *reaction* event (ionization, two-product reaction, charge exchange).
     // Weight-split particles added to slots 0 and 1 during non-reaction events are NOT counted

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -620,9 +620,7 @@ private:
     // How many different type of species the collision produces
     int m_num_product_species;
     // The scattering processes, in the same order as the input list (and as the indices encoded
-    // in the per-pair mask). Used to look up, for each pair, the process type
-    // and energy penalty. m_scattering_processes keeps the host-side objects alive; the device
-    // executor array (m_scattering_processes_exe) is what the scatter kernel indexes into.
+    // in the per-pair mask). Used to look up, for each pair, the process type and energy penalty. 
     amrex::Vector<ScatteringProcess> m_scattering_processes;
     amrex::Gpu::DeviceVector<ScatteringProcess::Executor> m_scattering_processes_exe;
     // Vector of size m_num_product_species: for each product slot, the number of new particles

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -78,9 +78,9 @@ public:
      *                                      appended to each tile.
      * @param[in]     m0                    rest mass of the first reactant species (slot 0).
      * @param[in]     m1                    rest mass of the other reactant species (slot 1).
-     * @param[in]     mask                  per-pair index of the selected scattering process
-     *                                      plus one (1-based, in the order of the process list),
-     *                                      or 0 if no collision occurred for that pair.
+     * @param[in]     mask                  for each pair: 0 if no collision occurs ;
+     *                                      index+1 of the selected process for that pair if a collision occurs, 
+     *                                      where `index` is the index of the process in the `m_scattering_processes_exe` array.
      * @param[in,out] products_np           macroparticle count of each product tile; updated in this
      *                                      kernel to reflect the number of new macroparticles added in each species.
      * @param[in]     copy_species0         array of SmartCopy functors (size m_num_product_species);
@@ -135,8 +135,7 @@ public:
         if (n_total_pairs == 0) { return amrex::Vector<int>(m_num_product_species, 0); }
 
         // The list of scattering processes, used to look up the type (and, further below, the
-        // energy penalty) of the process selected for each pair via its index. (Named as in
-        // BackgroundMCCCollision, which uses the same ScatteringProcess::Executor objects.)
+        // energy penalty) of the process selected for each pair via its index.
         const ScatteringProcess::Executor* AMREX_RESTRICT scattering_processes =
             m_scattering_processes_exe.data();
 

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -79,7 +79,7 @@ public:
      * @param[in]     m0                    rest mass of the first reactant species (slot 0).
      * @param[in]     m1                    rest mass of the other reactant species (slot 1).
      * @param[in]     mask                  for each pair: 0 if no collision occurs ;
-     *                                      index+1 of the selected process for that pair if a collision occurs, 
+     *                                      index+1 of the selected process for that pair if a collision occurs,
      *                                      where `index` is the index of the process in the `m_scattering_processes_exe` array.
      * @param[in,out] products_np           macroparticle count of each product tile; updated in this
      *                                      kernel to reflect the number of new macroparticles added in each species.

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -78,7 +78,7 @@ public:
      *                                      appended to each tile.
      * @param[in]     m0                    rest mass of the first reactant species (slot 0).
      * @param[in]     m1                    rest mass of the other reactant species (slot 1).
-     * @param[in]     selected_process      per-pair index of the selected scattering process
+     * @param[in]     mask                  per-pair index of the selected scattering process
      *                                      plus one (1-based, in the order of the process list),
      *                                      or 0 if no collision occurred for that pair.
      * @param[in,out] products_np           macroparticle count of each product tile; updated in this
@@ -104,7 +104,7 @@ public:
         ParticleTileType** AMREX_RESTRICT tile_products,
         const amrex::ParticleReal m0, const amrex::ParticleReal m1,
         const amrex::Vector<amrex::ParticleReal>& /*products_mass*/,
-        const index_type* AMREX_RESTRICT selected_process,
+        const index_type* AMREX_RESTRICT mask,
         amrex::Vector<index_type>& products_np,
         const SmartCopy* AMREX_RESTRICT copy_species0,
         const SmartCopy* AMREX_RESTRICT copy_species1,
@@ -148,8 +148,8 @@ public:
         index_type* AMREX_RESTRICT no_product_offsets_data = no_product_offsets.data();
         auto const no_product_total = amrex::Scan::PrefixSum<index_type>(n_total_pairs,
             [=] AMREX_GPU_DEVICE (index_type i) -> index_type {
-                if (selected_process[i] == 0) { return 0; }
-                auto const& scattering_process = scattering_processes[selected_process[i] - 1];
+                if (mask[i] == 0) { return 0; }
+                auto const& scattering_process = scattering_processes[mask[i] - 1];
                 const auto type = scattering_process.m_type;
                 return ((type != ScatteringProcessType::IONIZATION) &&
                         (type != ScatteringProcessType::TWOPRODUCT_REACTION) &&
@@ -176,8 +176,8 @@ public:
         index_type* AMREX_RESTRICT with_product_offsets_data = with_product_offsets.data();
         auto const with_product_total = amrex::Scan::PrefixSum<index_type>(n_total_pairs,
             [=] AMREX_GPU_DEVICE (index_type i) -> index_type {
-                if (selected_process[i] == 0) { return 0; }
-                auto const& scattering_process = scattering_processes[selected_process[i] - 1];
+                if (mask[i] == 0) { return 0; }
+                auto const& scattering_process = scattering_processes[mask[i] - 1];
                 const auto type = scattering_process.m_type;
                 return ((type == ScatteringProcessType::IONIZATION) ||
                         (type == ScatteringProcessType::TWOPRODUCT_REACTION) ||
@@ -250,10 +250,10 @@ public:
         [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
         {
             // Skip pairs for which no collision occurred.
-            if (selected_process[i] == 0) { return; }
+            if (mask[i] == 0) { return; }
 
             // The scattering process selected for this pair, and its type.
-            auto const& scattering_process = scattering_processes[selected_process[i] - 1];
+            auto const& scattering_process = scattering_processes[mask[i] - 1];
             const auto type = scattering_process.m_type;
 
             if ((type != ScatteringProcessType::IONIZATION) &&
@@ -617,8 +617,8 @@ public:
 private:
     // How many different type of species the collision produces
     int m_num_product_species;
-    // The scattering processes, in the same order as the input list (and as the indices stored
-    // in the per-pair selected-process array). Used to look up, for each pair, the process type
+    // The scattering processes, in the same order as the input list (and as the indices encoded
+    // in the per-pair mask). Used to look up, for each pair, the process type
     // and energy penalty. m_scattering_processes keeps the host-side objects alive; the device
     // executor array (m_scattering_processes_exe) is what the scatter kernel indexes into.
     amrex::Vector<ScatteringProcess> m_scattering_processes;

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -140,7 +140,8 @@ public:
 
         // The list of scattering processes, used to look up the type (and, further below, the
         // energy penalty) of the process selected for each pair via its index.
-        const ScatteringProcess::Executor* AMREX_RESTRICT processes = m_scattering_processes_data;
+        const ScatteringProcess::Executor* AMREX_RESTRICT processes =
+            m_scattering_processes_exe.data();
 
         // The following is used to calculate the appropriate offsets for
         // non-product producing collisions (i.e., not ionization, not two-product reaction).
@@ -618,10 +619,10 @@ private:
     int m_num_product_species;
     // The scattering processes, in the same order as the input list (and as the indices stored
     // in the per-pair selected-process array). Used to look up, for each pair, the process type
-    // and energy penalty. m_scattering_processes_data points into the device copy below.
+    // and energy penalty. m_scattering_processes keeps the host-side objects alive; the device
+    // executor array (m_scattering_processes_exe) is what the scatter kernel indexes into.
     amrex::Vector<ScatteringProcess> m_scattering_processes;
     amrex::Gpu::DeviceVector<ScatteringProcess::Executor> m_scattering_processes_exe;
-    const ScatteringProcess::Executor* m_scattering_processes_data = nullptr;
     // Vector of size m_num_product_species: for each product slot, the number of new particles
     // created per *reaction* event (ionization, two-product reaction, charge exchange).
     // Weight-split particles added to slots 0 and 1 during non-reaction events are NOT counted

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -135,8 +135,9 @@ public:
         if (n_total_pairs == 0) { return amrex::Vector<int>(m_num_product_species, 0); }
 
         // The list of scattering processes, used to look up the type (and, further below, the
-        // energy penalty) of the process selected for each pair via its index.
-        const ScatteringProcess::Executor* AMREX_RESTRICT processes =
+        // energy penalty) of the process selected for each pair via its index. (Named as in
+        // BackgroundMCCCollision, which uses the same ScatteringProcess::Executor objects.)
+        const ScatteringProcess::Executor* AMREX_RESTRICT scattering_processes =
             m_scattering_processes_exe.data();
 
         // The following is used to calculate the appropriate offsets for
@@ -148,7 +149,8 @@ public:
         auto const no_product_total = amrex::Scan::PrefixSum<index_type>(n_total_pairs,
             [=] AMREX_GPU_DEVICE (index_type i) -> index_type {
                 if (selected_process[i] == 0) { return 0; }
-                const auto type = processes[selected_process[i] - 1].m_type;
+                auto const& scattering_process = scattering_processes[selected_process[i] - 1];
+                const auto type = scattering_process.m_type;
                 return ((type != ScatteringProcessType::IONIZATION) &&
                         (type != ScatteringProcessType::TWOPRODUCT_REACTION) &&
                         (type != ScatteringProcessType::CHARGE_EXCHANGE)) ? 1 : 0;
@@ -175,7 +177,8 @@ public:
         auto const with_product_total = amrex::Scan::PrefixSum<index_type>(n_total_pairs,
             [=] AMREX_GPU_DEVICE (index_type i) -> index_type {
                 if (selected_process[i] == 0) { return 0; }
-                const auto type = processes[selected_process[i] - 1].m_type;
+                auto const& scattering_process = scattering_processes[selected_process[i] - 1];
+                const auto type = scattering_process.m_type;
                 return ((type == ScatteringProcessType::IONIZATION) ||
                         (type == ScatteringProcessType::TWOPRODUCT_REACTION) ||
                         (type == ScatteringProcessType::CHARGE_EXCHANGE)) ? 1 : 0;
@@ -246,13 +249,14 @@ public:
         amrex::ParallelForRNG(n_total_pairs,
         [=] AMREX_GPU_DEVICE (int i, amrex::RandomEngine const& engine) noexcept
         {
-            // Look up the type of the scattering process selected for this pair
-            // (INVALID if no collision occurred, i.e. selected_process[i] == 0).
-            const auto type = (selected_process[i] > 0)
-                ? processes[selected_process[i] - 1].m_type : ScatteringProcessType::INVALID;
+            // Skip pairs for which no collision occurred.
+            if (selected_process[i] == 0) { return; }
 
-            if ((type != ScatteringProcessType::INVALID) &&
-                (type != ScatteringProcessType::IONIZATION) &&
+            // The scattering process selected for this pair, and its type.
+            auto const& scattering_process = scattering_processes[selected_process[i] - 1];
+            const auto type = scattering_process.m_type;
+
+            if ((type != ScatteringProcessType::IONIZATION) &&
                 (type != ScatteringProcessType::TWOPRODUCT_REACTION) &&
                 (type != ScatteringProcessType::CHARGE_EXCHANGE))
             {
@@ -387,7 +391,7 @@ public:
                     soa_products_data[3].m_rdata[PIdx::ux][slot3_idx],
                     soa_products_data[3].m_rdata[PIdx::uy][slot3_idx],
                     soa_products_data[3].m_rdata[PIdx::uz][slot3_idx], mass_slot3,
-                    -processes[selected_process[i] - 1].m_energy_penalty*PhysConst::q_e,
+                    -scattering_process.m_energy_penalty*PhysConst::q_e,
                     // TwoProductComputeProductMomenta expects the *released* energy here, hence the negative sign
                     // We also convert from eV to Joules
                     ScatteringAngleModel::Forward,
@@ -475,7 +479,7 @@ public:
                 const amrex::ParticleReal E_coll = 0.5_prt * p_non_target_in * p_non_target_in * (1.0_prt/m0 + 1.0_prt/m1);
                 // subtract the energy cost for ionization (converted from eV to J)
                 const amrex::ParticleReal E_out =
-                    E_coll - processes[selected_process[i] - 1].m_energy_penalty * PhysConst::q_e;
+                    E_coll - scattering_process.m_energy_penalty * PhysConst::q_e;
 
                 // The kinematics of the ionization event (i.e. how the energy and momentum are
                 // distributed among the products) depend on the nature of the incident particle

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -148,11 +148,12 @@ public:
         auto const no_product_total = amrex::Scan::PrefixSum<index_type>(n_total_pairs,
             [=] AMREX_GPU_DEVICE (index_type i) -> index_type {
                 if (mask[i] == 0) { return 0; }
-                auto const& scattering_process = scattering_processes[mask[i] - 1];
-                const auto type = scattering_process.m_type;
-                return ((type != ScatteringProcessType::IONIZATION) &&
-                        (type != ScatteringProcessType::TWOPRODUCT_REACTION) &&
-                        (type != ScatteringProcessType::CHARGE_EXCHANGE)) ? 1 : 0;
+                const auto selected_process_index = mask[i] - 1;
+                auto const& scattering_process = scattering_processes[selected_process_index];
+                const auto process_type = scattering_process.m_type;
+                return ((process_type != ScatteringProcessType::IONIZATION) &&
+                        (process_type != ScatteringProcessType::TWOPRODUCT_REACTION) &&
+                        (process_type != ScatteringProcessType::CHARGE_EXCHANGE)) ? 1 : 0;
             },
             [=] AMREX_GPU_DEVICE (index_type i, index_type s) { no_product_offsets_data[i] = s; },
             amrex::Scan::Type::exclusive, amrex::Scan::retSum
@@ -176,11 +177,12 @@ public:
         auto const with_product_total = amrex::Scan::PrefixSum<index_type>(n_total_pairs,
             [=] AMREX_GPU_DEVICE (index_type i) -> index_type {
                 if (mask[i] == 0) { return 0; }
-                auto const& scattering_process = scattering_processes[mask[i] - 1];
-                const auto type = scattering_process.m_type;
-                return ((type == ScatteringProcessType::IONIZATION) ||
-                        (type == ScatteringProcessType::TWOPRODUCT_REACTION) ||
-                        (type == ScatteringProcessType::CHARGE_EXCHANGE)) ? 1 : 0;
+                const auto selected_process_index = mask[i] - 1;
+                auto const& scattering_process = scattering_processes[selected_process_index];
+                const auto process_type = scattering_process.m_type;
+                return ((process_type == ScatteringProcessType::IONIZATION) ||
+                        (process_type == ScatteringProcessType::TWOPRODUCT_REACTION) ||
+                        (process_type == ScatteringProcessType::CHARGE_EXCHANGE)) ? 1 : 0;
             },
             [=] AMREX_GPU_DEVICE (index_type i, index_type s) { with_product_offsets_data[i] = s; },
             amrex::Scan::Type::exclusive, amrex::Scan::retSum
@@ -252,12 +254,13 @@ public:
             if (mask[i] == 0) { return; }
 
             // The scattering process selected for this pair, and its type.
-            auto const& scattering_process = scattering_processes[mask[i] - 1];
-            const auto type = scattering_process.m_type;
+            const auto selected_process_index = mask[i] - 1;
+            auto const& scattering_process = scattering_processes[selected_process_index];
+            const auto process_type = scattering_process.m_type;
 
-            if ((type != ScatteringProcessType::IONIZATION) &&
-                (type != ScatteringProcessType::TWOPRODUCT_REACTION) &&
-                (type != ScatteringProcessType::CHARGE_EXCHANGE))
+            if ((process_type != ScatteringProcessType::IONIZATION) &&
+                (process_type != ScatteringProcessType::TWOPRODUCT_REACTION) &&
+                (process_type != ScatteringProcessType::CHARGE_EXCHANGE))
             {
                 const auto slot0_idx = products_np_data[0] + no_product_offsets_data[i];
                 // Make a copy of the particle from the first reactant species
@@ -297,7 +300,7 @@ public:
                 uy1 -= uCOM_y;
                 uz1 -= uCOM_z;
 
-                if (type == ScatteringProcessType::ELASTIC) {
+                if (process_type == ScatteringProcessType::ELASTIC) {
                     // randomly rotate the velocity vector for the first particle
                     ParticleUtils::RandomizeVelocity(
                         ux0, uy0, uz0, std::sqrt(ux0*ux0 + uy0*uy0 + uz0*uz0), engine
@@ -307,7 +310,7 @@ public:
                     ux1 = -ux0 * m0 / m1;
                     uy1 = -uy0 * m0 / m1;
                     uz1 = -uz0 * m0 / m1;
-                } else if (type == ScatteringProcessType::BACK) {
+                } else if (process_type == ScatteringProcessType::BACK) {
                     // reverse the velocity vectors of both particles
                     ux0 *= -1.0_prt;
                     uy0 *= -1.0_prt;
@@ -315,7 +318,7 @@ public:
                     ux1 *= -1.0_prt;
                     uy1 *= -1.0_prt;
                     uz1 *= -1.0_prt;
-                } else if (type == ScatteringProcessType::FORWARD) {
+                } else if (process_type == ScatteringProcessType::FORWARD) {
                     amrex::Abort("Forward scattering with DSMC not implemented yet.");
                 }
                 else {
@@ -332,8 +335,8 @@ public:
             }
 
             // Next perform all product-producing collisions
-            else if ((type == ScatteringProcessType::TWOPRODUCT_REACTION) ||
-                     (type == ScatteringProcessType::CHARGE_EXCHANGE))
+            else if ((process_type == ScatteringProcessType::TWOPRODUCT_REACTION) ||
+                     (process_type == ScatteringProcessType::CHARGE_EXCHANGE))
             {
                 // create a copy of the first product species at the location of the first reactant species
                 const auto src0_idx = static_cast<int>(p_pair_indices_0[i]);
@@ -354,7 +357,7 @@ public:
                 // For charge exchange, swap positions at which the products are created
                 // to ensure local charge conservation. For instance in the reaction
                 // `A+ + B -> A + B+`, B+ will be created at the position of A+, instead of that of B.
-                if (type == ScatteringProcessType::CHARGE_EXCHANGE) {
+                if (process_type == ScatteringProcessType::CHARGE_EXCHANGE) {
                     // The SoA components that define the positions depend on the geometry.
 #if defined(WARPX_DIM_1D_Z)
                     constexpr std::array<int, 1> position_indices = {PIdx::z};
@@ -398,7 +401,7 @@ public:
                     // as that of the reactant particle, in the center-of-mass frame
                     engine);
             }
-            else if (type == ScatteringProcessType::IONIZATION)
+            else if (process_type == ScatteringProcessType::IONIZATION)
             {
                 const auto slot0_idx = products_np_data[0] + no_product_total + with_product_offsets_data[i];
                 // Make a copy of the particle from the first reactant species (slot 0)

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.cpp
@@ -36,7 +36,6 @@ SplitAndScatterFunc::SplitAndScatterFunc (const std::string& collision_name,
             m_scattering_processes_exe.push_back(p.executor());
         }
 #endif
-        m_scattering_processes_data = m_scattering_processes_exe.data();
 
         // Check if the scattering processes include reactions that produce macroparticles in new species
         // (i.e. not in the incident species list), i.e. if it contains ionization, charge exchange or two-product reaction

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.cpp
@@ -18,9 +18,9 @@ SplitAndScatterFunc::SplitAndScatterFunc (const std::string& collision_name,
         const amrex::ParmParse pp_collision_name(collision_name);
 
         // Build the ScatteringProcess objects using the same shared helper as DSMCFunc, so
-        // that the process ordering matches the indices stored in the per-pair selected-process
-        // array. The scatter kernel uses these to look up, for each colliding pair, the process
-        // type and its energy penalty.
+        // that the process ordering matches the indices encoded in the per-pair mask. The
+        // scatter kernel uses these to look up, for each colliding pair, the process type and
+        // its energy penalty.
         m_scattering_processes = BinaryCollisionUtils::parse_scattering_processes(collision_name);
 #ifdef AMREX_USE_GPU
         amrex::Gpu::HostVector<ScatteringProcess::Executor> h_scattering_processes_exe;

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.cpp
@@ -17,6 +17,27 @@ SplitAndScatterFunc::SplitAndScatterFunc (const std::string& collision_name,
     {
         const amrex::ParmParse pp_collision_name(collision_name);
 
+        // Build the ScatteringProcess objects using the same shared helper as DSMCFunc, so
+        // that the process ordering matches the indices stored in the per-pair selected-process
+        // array. The scatter kernel uses these to look up, for each colliding pair, the process
+        // type and its energy penalty.
+        m_scattering_processes = BinaryCollisionUtils::parse_scattering_processes(collision_name);
+#ifdef AMREX_USE_GPU
+        amrex::Gpu::HostVector<ScatteringProcess::Executor> h_scattering_processes_exe;
+        for (auto const& p : m_scattering_processes) {
+            h_scattering_processes_exe.push_back(p.executor());
+        }
+        m_scattering_processes_exe.resize(h_scattering_processes_exe.size());
+        amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, h_scattering_processes_exe.begin(),
+                              h_scattering_processes_exe.end(), m_scattering_processes_exe.begin());
+        amrex::Gpu::streamSynchronize();
+#else
+        for (auto const& p : m_scattering_processes) {
+            m_scattering_processes_exe.push_back(p.executor());
+        }
+#endif
+        m_scattering_processes_data = m_scattering_processes_exe.data();
+
         // Check if the scattering processes include reactions that produce macroparticles in new species
         // (i.e. not in the incident species list), i.e. if it contains ionization, charge exchange or two-product reaction
         amrex::Vector<std::string> scattering_processes;
@@ -39,9 +60,6 @@ SplitAndScatterFunc::SplitAndScatterFunc (const std::string& collision_name,
                 m_num_products_host.push_back(0); // slot 1: other reactant (target) species; consumed by reaction, no new reaction-produced particle
                 m_num_products_host.push_back(1); // slot 2: first true product species (e.g. ejected electron)
                 m_num_products_host.push_back(1); // slot 3: second true product species (e.g. resulting ion)
-
-                // get the reaction energy
-                pp_collision_name.get("ionization_energy", m_reaction_energy);
             }
 
             // For charge exchange or two-product reaction:
@@ -52,9 +70,6 @@ SplitAndScatterFunc::SplitAndScatterFunc (const std::string& collision_name,
                 m_num_products_host.push_back(0); // slot 1: other reactant species; consumed by reaction, no new reaction-produced particles
                 m_num_products_host.push_back(1); // slot 2: first true product species
                 m_num_products_host.push_back(1); // slot 3: second true product species
-
-                // get the reaction energy, assuming zero energy for charge exchange
-                pp_collision_name.query("two_product_reaction_energy", m_reaction_energy);
             }
 
         } else {


### PR DESCRIPTION
## Overview

This is a **pure refactoring** PR for DSMC collisions, in preparation for #6948.

In the current code, `SplitAndScatterFunc` extracts the `ScatteringProcessType` (an `enum` that can be e.g. ELASTIC, CHARGE_EXCHANGE, etc.) for each pair of colliding particles. 

Instead, this PR refactors the code so that it extracts the `ScatteringProcess::Executor` for each pair.

## Advantages

- The `ScatteringProcess::Executor` contains the type of reaction, the reaction energy (and will contain the angular scattering model, as part of #6948), and thus all information needed in `SplitAndScatterFunc` now comes from that single object.

- This, in fact, avoids the need to store `reaction_energy` as a separate attribute of `SplitAndScatterFunc`, since this number is now extracted from the `ScatteringProcess::Executor` object instead. The fact that `reaction_energy` was stored as a **single** number in `SplitAndScatterFunc` (despite the fact that this object can handle **multiple** reactions) was a significant limitation.

- This also makes the DSMC code more similar to the **background MCC** code (`BackgroundMCCCollision`), which already builds a `ScatteringProcess::Executor` device array and dispatches at runtime on `scattering_process.m_type` while reading the per-process energy via `getEnergyPenalty()`. After this PR, `SplitAndScatterFunc` follows the same pattern (look up the `ScatteringProcess` and branch on `m_type` / read `m_energy_penalty`) instead of comparing an int-cast type stored in the mask.

## Changes

- **`SplitAndScatterFunc`**: build an array of `ScatteringProcess::Executor`, in its constructor (reusing the shared `BinaryCollisionUtils::parse_scattering_processes` helper, same as `DSMCFunc` and `BackgroundMCCCollision`).

- The elements of this array are then accessed in `SplitAndScatterFunc`. In order to be able to access them, **the meaning of `mask` changes**: `mask` used to store the **type** of process directly (e.g., elastic, charge exchange, ...) ; it now encodes the index of the selected process in the array of `ScatteringProcess::Executor`.

- Drop the collision-level `m_reaction_energy` scalar and use the per-process `m_energy_penalty` instead (the same quantity background MCC already uses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)