### PR TITLE
Add docs on coarsening interpolation helpers

### DIFF
--- a/Docs/source/developers/fields.rst
+++ b/Docs/source/developers/fields.rst
@@ -109,6 +109,72 @@ This is mostly implemented in ``Source/Parallelization``, see the following func
 
 .. doxygenfunction:: WarpX::AddCurrentFromFineLevelandSumBoundary
 
+.. _developers-fields-coarsening-interpolation-helpers:
+
+Coarsening interpolation helpers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The fine-to-coarse helpers in ``Source/ablastr/coarsen`` implement two different
+operators. In the formulas below, ``i_c`` is the coarse-grid index, ``i_f`` is a
+fine-grid index, ``c_r`` is the integer coarsening ratio, and ``s_f`` and ``s_c``
+are the fine and coarse staggering flags in one direction (``0`` for cell-centered,
+``1`` for nodal). In multiple dimensions, WarpX applies the corresponding 1D
+weights as a tensor product.
+
+``ablastr::coarsen::sample`` is the I/O downsampling operator used by coarsened
+diagnostics. It can map between different fine and coarse staggering. For each
+coarse point, it samples one or two nearby fine points with equal weights:
+
+.. math::
+
+   g_c(i_c) = \frac{1}{n_p} \sum_{i_r=0}^{n_p-1} g_f(i_m+i_r).
+
+For ``c_r = 1``, this reduces to recentering without coarsening:
+
+.. math::
+
+   n_p = 1 + |s_f-s_c|,\qquad
+   i_m = i_c - s_c(1-s_f).
+
+For ``c_r > 1``, the implemented sampling stencil is:
+
+.. math::
+
+   n_p = 2 - s_f,\qquad
+   i_m = i_c c_r + \left\lfloor \frac{c_r}{2} \right\rfloor (1-s_c) - (1-s_f).
+
+Thus nodal-to-nodal selects the coincident fine node, nodal-to-cell-centered
+selects the fine node at the coarse-cell center, cell-centered-to-nodal averages
+the two fine cell centers adjacent to the coarse node, and
+cell-centered-to-cell-centered averages the two fine cell centers closest to the
+coarse-cell center.
+
+``ablastr::coarsen::average`` is the conservative fine-to-coarse operator used for
+mesh refinement data transfers. It requires identical fine and coarse staggering
+and treats values outside the grown fine domain as zero. Its implemented 1D stencil is:
+
+.. math::
+
+   n_p = c_r(1-s_f)(1-s_c) + \left[2(c_r-1)+1\right]s_f s_c,
+
+.. math::
+
+   i_m = i_c c_r(1-s_f)(1-s_c) + (i_c c_r-c_r+1)s_f s_c,
+
+.. math::
+
+   w_f(i_c,i_f) =
+      \frac{1}{c_r}(1-s_f)(1-s_c)
+      + \frac{\left|c_r-\left|i_f-i_c c_r\right|\right|}{c_r^2}s_f s_c,
+
+.. math::
+
+   g_c(i_c) = \sum_{i_r=0}^{n_p-1} w_f(i_c,i_m+i_r) g_f(i_m+i_r).
+
+For cell-centered data this is the average over the ``c_r`` fine cells covered by
+the coarse cell. For nodal data it is the triangular, charge-conserving stencil
+over ``2 c_r - 1`` fine nodes.
+
 Filter
 ------
 

--- a/Docs/source/developers/fields.rst
+++ b/Docs/source/developers/fields.rst
@@ -143,11 +143,11 @@ For ``c_r > 1``, the implemented sampling stencil is:
    n_p = 2 - s_f,\qquad
    i_m = i_c c_r + \left\lfloor \frac{c_r}{2} \right\rfloor (1-s_c) - (1-s_f).
 
-Thus nodal-to-nodal selects the coincident fine node, nodal-to-cell-centered
-selects the fine node at the coarse-cell center, cell-centered-to-nodal averages
+Thus nodal to nodal selects the coincident fine node, nodal to cell-centered
+selects the fine node at the coarse cell center, cell-centered to nodal averages
 the two fine cell centers adjacent to the coarse node, and
-cell-centered-to-cell-centered averages the two fine cell centers closest to the
-coarse-cell center.
+cell-centered to cell-centered averages the two fine cell centers closest to the
+coarse cell center.
 
 ``ablastr::coarsen::average`` is the conservative fine-to-coarse operator used for
 mesh refinement data transfers. It requires identical fine and coarse staggering

--- a/Docs/source/developers/fields.rst
+++ b/Docs/source/developers/fields.rst
@@ -115,10 +115,10 @@ Coarsening interpolation helpers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The fine-to-coarse helpers in ``Source/ablastr/coarsen`` implement two different
-operators. In the formulas below, ``i_c`` is the coarse-grid index, ``i_f`` is a
-fine-grid index, ``c_r`` is the integer coarsening ratio, and ``s_f`` and ``s_c``
-are the fine and coarse staggering flags in one direction (``0`` for cell-centered,
-``1`` for nodal). In multiple dimensions, WarpX applies the corresponding 1D
+operators. In the formulas below, :math:`i_c` is the coarse-grid index, :math:`i_f` is a
+fine-grid index, :math:`c_r` is the integer coarsening ratio, and :math:`s_f` and :math:`s_c`
+are the fine and coarse staggering flags in one direction (:math:`0` for cell-centered,
+:math:`1` for nodal). In multiple dimensions, WarpX applies the corresponding 1D
 weights as a tensor product.
 
 ``ablastr::coarsen::sample`` is the I/O downsampling operator used by coarsened
@@ -129,14 +129,14 @@ coarse point, it samples one or two nearby fine points with equal weights:
 
    g_c(i_c) = \frac{1}{n_p} \sum_{i_r=0}^{n_p-1} g_f(i_m+i_r).
 
-For ``c_r = 1``, this reduces to recentering without coarsening:
+For :math:`c_r = 1`, this reduces to recentering without coarsening:
 
 .. math::
 
    n_p = 1 + |s_f-s_c|,\qquad
    i_m = i_c - s_c(1-s_f).
 
-For ``c_r > 1``, the implemented sampling stencil is:
+For :math:`c_r > 1`, the implemented sampling stencil is:
 
 .. math::
 
@@ -171,9 +171,9 @@ and treats values outside the grown fine domain as zero. Its implemented 1D sten
 
    g_c(i_c) = \sum_{i_r=0}^{n_p-1} w_f(i_c,i_m+i_r) g_f(i_m+i_r).
 
-For cell-centered data this is the average over the ``c_r`` fine cells covered by
+For cell-centered data this is the average over the :math:`c_r` fine cells covered by
 the coarse cell. For nodal data it is the triangular, charge-conserving stencil
-over ``2 c_r - 1`` fine nodes.
+over :math:`(2 c_r - 1)` fine nodes.
 
 Filter
 ------

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -4365,7 +4365,8 @@ In-situ capabilities can be used by turning on Sensei or Ascent (provided they a
     :optional:
 
     Reduce size of the selected diagnostic fields output by this ratio in each dimension.
-    (For a ratio of N, this is done by averaging the fields over N or (N+1) points depending on the staggering).
+    Coarsening uses ``ablastr::coarsen::sample``, which samples one or two nearby source points per dimension, depending on the field staggering.
+    See :ref:`developers-fields-coarsening-interpolation-helpers`.
     If ``blocking_factor`` and ``max_grid_size`` are used for the domain decomposition, as detailed in
     the :ref:`domain decomposition <usage_domain_decomposition>` section, ``coarsening_ratio`` should be an integer
     divisor of ``blocking_factor``. If :pp:param:`warpx.numprocs` is used instead, the total number of cells in a given


### PR DESCRIPTION
## Overview

Add documentation on the coarsening interpolation helpers currently available through ABLASTR, namely `ablastr::coarsen:sample` and `ablastr::coarsen::average`.

<p align="center">
<img width="1057" height="1030" alt="Screenshot from 2026-07-01 16-34-58" src="https://github.com/user-attachments/assets/b164f61c-df81-48ff-97c0-db440e82ba2c" />
</p>

## To do

- [x] Add review comments to help reviewers match the formulas in the documentation with the underlying code.

## Notes

Close #3556, long overdue.