### PR TITLE
Fix name of FFT compile option in error message.

### DIFF
--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -759,7 +759,7 @@ WarpX::ReadParameters ()
 #ifndef WARPX_USE_FFT
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         poisson_solver_id!=PoissonSolverAlgo::IntegratedGreenFunction,
-        "To use the FFT Poisson solver, compile with WARPX_USE_FFT=ON.");
+        "To use the FFT Poisson solver, compile with -DWarpX_FFT=ON.");
 #endif
         // Read magnetostatic solver parameters
         // First use self_fields_* as defaults for backward compatibility,


### PR DESCRIPTION
This is no compile option set using `WARPX_USE_FFT=ON`. In CMake, you use `-DWarpX_FFT=ON`, and in GNUMake, you do `USE_FFT=TRUE`. This changes the error message to use the CMake option. 