### PR TITLE
[WIP] DSMC: skip impact ionization of already fully-ionized target species

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3079,6 +3079,14 @@ Details about the collision models can be found in the :ref:`theory section <mul
     Only for ``dsmc`` with impact ionization. This specifies which one of the
     colliding particles is ionized.
 
+    If the target species also undergoes field ionization (i.e. it has
+    :pp:param:`<species_name>.do_field_ionization` ``= 1``), then DSMC impact ionization is
+    automatically skipped for target macroparticles that are already fully ionized (i.e. whose
+    ionization level has reached the atomic number of the element). This avoids unphysically
+    ionizing a fully-stripped ion that has no bound electron left to remove. Note, however, that
+    the impact-ionization cross section is still assumed to correspond to the transition specified
+    by the provided cross-section file, regardless of the target's current ionization level.
+
 .. pp:param:: <collision_name>.decay_rate(x,y,z,t)
     :type: `string`
 

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -59,6 +59,7 @@
 
 #include <cmath>
 #include <string>
+#include <type_traits>
 
 /**
  * \brief This class performs generic binary collisions.
@@ -181,6 +182,15 @@ public:
 
         auto& species1 = mypc->GetParticleContainerFromName(m_species_names[0]);
         auto& species2 = mypc->GetParticleContainerFromName(m_species_names[1]);
+
+        // For DSMC impact ionization, register the target species (species 2) so that impact
+        // ionization of already fully-ionized particles is skipped. This is done here rather than
+        // at construction because the target's "ionizationLevel" attribute (present when the target
+        // also undergoes field ionization) is only added once the ionization module is initialized.
+        // See WarpX discussion #6220.
+        if constexpr (std::is_same_v<CollisionFunctor, DSMCFunc>) {
+            m_binary_collision_functor.setIonizationTarget(species2);
+        }
 
         // In case of particle creation, create the necessary vectors
         const int n_product_species = m_product_species.size();

--- a/Source/Particles/Collision/BinaryCollision/DSMC/CollisionFilterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/CollisionFilterFunc.H
@@ -33,6 +33,12 @@
  *            account for all other possible binary collision partners.
  * @param[in] process_count number of scattering processes to consider.
  * @param[in] scattering_processes an array of scattering processes included for consideration.
+ * @param[in] target_ion_lev current ionization level of the target particle (species 2), or -1
+ *            if the target species does not undergo field ionization (in which case the gate below
+ *            is disabled). This is used to prevent impact ionization of an already fully-ionized
+ *            target, which can occur when field ionization and DSMC impact ionization act on the
+ *            same species (see WarpX discussion #6220).
+ * @param[in] target_max_ion_lev maximum ionization level (atomic number) of the target species.
  * @param[in] engine the random engine.
  */
 template <int max_process_count, typename index_type>
@@ -48,6 +54,8 @@ void CollisionPairFilter (const amrex::ParticleReal u1x, const amrex::ParticleRe
                           const int multiplier,
                           const int process_count,
                           const ScatteringProcess::Executor* scattering_processes,
+                          const int target_ion_lev,
+                          const int target_max_ion_lev,
                           const amrex::RandomEngine& engine)
 {
     amrex::ParticleReal E_coll, v_coll, lab_to_COM_factor;
@@ -80,7 +88,17 @@ void CollisionPairFilter (const amrex::ParticleReal u1x, const amrex::ParticleRe
     amrex::ParticleReal sigma_sums[max_process_count] = {0._prt};
     for (int ii = 0; ii < process_count; ii++) {
         auto const& scattering_process = scattering_processes[ii];
-        const amrex::ParticleReal sigma = scattering_process.getCrossSection(E_coll);
+        amrex::ParticleReal sigma = scattering_process.getCrossSection(E_coll);
+        // Disable impact ionization of a target that is already fully ionized. This
+        // situation arises when the target species undergoes both field ionization and
+        // DSMC impact ionization: once field ionization has stripped all electrons, the
+        // target has no bound electron left for impact ionization (see WarpX discussion
+        // #6220). target_ion_lev < 0 means the target does not carry an ionization level,
+        // in which case this gate is disabled.
+        if (scattering_process.m_type == ScatteringProcessType::IONIZATION &&
+            target_ion_lev >= 0 && target_ion_lev >= target_max_ion_lev) {
+            sigma = 0._prt;
+        }
         sigma_sums[ii] = sigma + ((ii == 0) ? 0._prt : sigma_sums[ii-1]);
     }
     const auto sigma_tot = sigma_sums[process_count-1];

--- a/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.H
@@ -150,13 +150,22 @@ public:
                     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
                         (m_process_count < max_process_count), "Too many scattering processes in DSMC routine (hardcoded to only allow 4). Update the max_process_count value in source code to allow more scattering processes."
                     );
+
+                    // If the target species (species 2) undergoes field ionization, retrieve its
+                    // current ionization level so that impact ionization of an already fully-ionized
+                    // target can be disabled (see WarpX discussion #6220). A negative value disables
+                    // this gate for target species that do not carry an ionization level.
+                    const int target_ion_lev = (m_target_ion_lev_comp >= 0) ?
+                        soa_2.m_runtime_idata[m_target_ion_lev_comp][ I2[i2] ] : -1;
+
                     CollisionPairFilter<max_process_count>(
                         u1x[ I1[i1] ], u1y[ I1[i1] ], u1z[ I1[i1] ],
                         u2x[ I2[i2] ], u2y[ I2[i2] ], u2z[ I2[i2] ],
                         m1, m2, w1[ I1[i1] ], w2[ I2[i2] ],
                         dt, dV, static_cast<int>(pair_index), p_mask,
                         p_pair_reaction_weight, multiplier_ratio,
-                        m_process_count, m_scattering_processes_data, engine);
+                        m_process_count, m_scattering_processes_data,
+                        target_ion_lev, m_target_max_ion_lev, engine);
 
                     // Remove pair reaction weight from the colliding particles' weights
                     if (p_mask[pair_index]) {
@@ -181,9 +190,25 @@ public:
         bool m_need_product_data = false;
         bool m_isSameSpecies = false;
         ScatteringProcess::Executor* m_scattering_processes_data;
+        /** Runtime int component index of the "ionizationLevel" attribute on the target
+         *  species (species 2), or -1 if the target species does not undergo field ionization. */
+        int m_target_ion_lev_comp = -1;
+        /** Maximum ionization level (atomic number) of the target species. */
+        int m_target_max_ion_lev = 0;
     };
 
     [[nodiscard]] Executor const& executor () const { return m_exe; }
+
+    /**
+     * \brief Register the target species of DSMC impact ionization so that impact ionization
+     * of already fully-ionized particles can be skipped (relevant when the target species also
+     * undergoes field ionization, see WarpX discussion #6220). This must be called after the
+     * ionization module has been initialized (i.e. once collisions are performed), since the
+     * "ionizationLevel" runtime attribute does not exist at construction time.
+     *
+     * @param[in] target the target species of the collision (species 2)
+     */
+    void setIonizationTarget (WarpXParticleContainer& target);
 
     bool use_global_debye_length() { return false; }
 
@@ -192,6 +217,8 @@ private:
     amrex::Gpu::DeviceVector<ScatteringProcess::Executor> m_scattering_processes_exe;
 
     bool m_isSameSpecies;
+    //! Whether this collision set includes an impact ionization process.
+    bool m_has_ionization_process = false;
 
     Executor m_exe;
 };

--- a/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/DSMCFunc.cpp
@@ -52,6 +52,7 @@ DSMCFunc::DSMCFunc (
         }
 
         if (process.type() == ScatteringProcessType::IONIZATION) {
+            m_has_ionization_process = true;
             // Ensure that the first product species is always an electron (which is assumed
             // during the scattering operation).
             amrex::Vector<std::string> product_species_names;
@@ -110,4 +111,17 @@ DSMCFunc::DSMCFunc (
     m_exe.m_scattering_processes_data = m_scattering_processes_exe.data();
     m_exe.m_process_count = static_cast<int>(m_scattering_processes_exe.size());
     m_exe.m_isSameSpecies = m_isSameSpecies;
+}
+
+void DSMCFunc::setIonizationTarget (WarpXParticleContainer& target)
+{
+    // The gate is only relevant if this collision set performs impact ionization and the
+    // target species also undergoes field ionization (in which case it carries a per-particle
+    // "ionizationLevel" attribute). In all other cases we disable the gate (m_target_ion_lev_comp < 0).
+    if (m_has_ionization_process && target.DoFieldIonization() && target.HasiAttrib("ionizationLevel")) {
+        m_exe.m_target_ion_lev_comp = target.GetIntCompIndex("ionizationLevel");
+        m_exe.m_target_max_ion_lev = target.getIonizationMaxLevel();
+    } else {
+        m_exe.m_target_ion_lev_comp = -1;
+    }
 }

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -584,6 +584,10 @@ public:
 
     int DoFieldIonization() const { return do_field_ionization; }
 
+    /** Maximum ionization level (i.e. atomic number) of this species.
+     *  Only meaningful when field ionization is enabled for this species. */
+    int getIonizationMaxLevel() const { return ion_atomic_number; }
+
 #ifdef WARPX_QED
     //Species for which QED effects are relevant should override these methods
     virtual bool has_quantum_sync() const {return false;}
@@ -685,7 +689,7 @@ protected:
     int do_adk_correction = 0;
     int ionization_product;
     std::string ionization_product_name;
-    int ion_atomic_number;
+    int ion_atomic_number = 0;
     int ionization_initial_level = 0;
     amrex::Gpu::DeviceVector<amrex::Real> ionization_energies;
     amrex::Gpu::DeviceVector<amrex::Real> adk_power;


### PR DESCRIPTION
When a species undergoes both field ionization and DSMC impact ionization (e.g. a neutral reservoir that is field-ionized and also collisionally ionized by electrons), the DSMC collision path had no knowledge of the per-particle field-ionization level. As a result, target macroparticles that had already been fully stripped by field ionization could still be selected for impact ionization, unphysically creating electrons/ions from a target with no bound electron left (see WarpX discussion #6220).

This adds a gate in the DSMC collision filter: when the target species (species 2) carries an "ionizationLevel" attribute (i.e. it undergoes field ionization), the impact-ionization cross section is set to zero for target particles whose ionization level has reached the element's atomic number. For target species without field ionization, the gate is disabled and behavior is unchanged.

The target's ionization-level runtime component index and maximum level are resolved at collision time (via DSMCFunc::setIonizationTarget), since the "ionizationLevel" attribute does not exist yet when collisions are constructed.