### PR TITLE
Fix XDim3 uninitialized warning

### DIFF
--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2853,8 +2853,8 @@ WarpXParticleContainer::ApplyBoundaryConditions (){
         {
             auto GetPosition = GetParticlePosition<PIdx>(pti);
             auto SetPosition = SetParticlePosition<PIdx>(pti);
-            amrex::XDim3 gridmin;
-            amrex::XDim3 gridmax;
+            amrex::XDim3 gridmin{};
+            amrex::XDim3 gridmax{};
 #ifndef WARPX_DIM_1D_Z
             gridmin.x = Geom(lev).ProbLo(0);
             gridmax.x = Geom(lev).ProbHi(0);


### PR DESCRIPTION
The change gets rid of this compilation warning when compiling for RZ
```
[ 49%] Building CUDA object CMakeFiles/lib_rz.dir/Source/Particles/WarpXParticleContainer.cpp.o
/home/asinn/warpx/Source/Particles/WarpXParticleContainer.cpp: In member function ‘void WarpXParticleContainer::ApplyBoundaryConditions()’:
/home/asinn/warpx/Source/Particles/WarpXParticleContainer.cpp:2856:14: warning: ‘gridmin.amrex::XDim3::y’ may be used uninitialized [-Wmaybe-uninitialized]
 2856 |             amrex::XDim3 gridmin;
      |              ^~~~~~~
/home/asinn/warpx/Source/Particles/WarpXParticleContainer.cpp:2857:14: warning: ‘gridmax.amrex::XDim3::y’ may be used uninitialized [-Wmaybe-uninitialized]
 2857 |             amrex::XDim3 gridmax;
      |              ^~~~~~~
```