### PR TITLE
Fix Load Balancing with RZ PML

### DIFF
--- a/Source/BoundaryConditions/PML_RZ.cpp
+++ b/Source/BoundaryConditions/PML_RZ.cpp
@@ -45,26 +45,19 @@ PML_RZ::PML_RZ (int lev, amrex::BoxArray const& grid_ba, amrex::DistributionMapp
 {
     using ablastr::fields::Direction;
 
-    bool const remake = false;
-    bool const redistribute_on_remake = false;
-
     amrex::MultiFab const& Er_fp = *fields.get(FieldType::Efield_fp, Direction{0}, lev);
     amrex::MultiFab const& Et_fp = *fields.get(FieldType::Efield_fp, Direction{1}, lev);
     amrex::BoxArray const ba_Er = amrex::convert(grid_ba, Er_fp.ixType().toIntVect());
     amrex::BoxArray const ba_Et = amrex::convert(grid_ba, Et_fp.ixType().toIntVect());
-    fields.alloc_init(FieldType::pml_E_fp, Direction{0}, lev, ba_Er, grid_dm, Er_fp.nComp(), Er_fp.nGrowVect(), 0.0_rt,
-                              remake, redistribute_on_remake);
-    fields.alloc_init(FieldType::pml_E_fp, Direction{1}, lev, ba_Et, grid_dm, Et_fp.nComp(), Et_fp.nGrowVect(), 0.0_rt,
-                              remake, redistribute_on_remake);
+    fields.alloc_init(FieldType::pml_E_fp, Direction{0}, lev, ba_Er, grid_dm, Er_fp.nComp(), Er_fp.nGrowVect(), 0.0_rt);
+    fields.alloc_init(FieldType::pml_E_fp, Direction{1}, lev, ba_Et, grid_dm, Et_fp.nComp(), Et_fp.nGrowVect(), 0.0_rt);
 
     amrex::MultiFab const& Br_fp = *fields.get(FieldType::Bfield_fp,Direction{0},lev);
     amrex::MultiFab const& Bt_fp = *fields.get(FieldType::Bfield_fp,Direction{1},lev);
     amrex::BoxArray const ba_Br = amrex::convert(grid_ba, Br_fp.ixType().toIntVect());
     amrex::BoxArray const ba_Bt = amrex::convert(grid_ba, Bt_fp.ixType().toIntVect());
-    fields.alloc_init(FieldType::pml_B_fp, Direction{0}, lev, ba_Br, grid_dm, Br_fp.nComp(), Br_fp.nGrowVect(), 0.0_rt,
-                              remake, redistribute_on_remake);
-    fields.alloc_init(FieldType::pml_B_fp, Direction{1}, lev, ba_Bt, grid_dm, Bt_fp.nComp(), Bt_fp.nGrowVect(), 0.0_rt,
-                              remake, redistribute_on_remake);
+    fields.alloc_init(FieldType::pml_B_fp, Direction{0}, lev, ba_Br, grid_dm, Br_fp.nComp(), Br_fp.nGrowVect(), 0.0_rt);
+    fields.alloc_init(FieldType::pml_B_fp, Direction{1}, lev, ba_Bt, grid_dm, Bt_fp.nComp(), Bt_fp.nGrowVect(), 0.0_rt);
 
 }
 

--- a/Source/Parallelization/WarpXRegrid.cpp
+++ b/Source/Parallelization/WarpXRegrid.cpp
@@ -234,6 +234,11 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
                 if ( !fft_periodic_single_box ) {
                     realspace_ba.grow(1, ngEB[1]); // add guard cells only in z
                 }
+                if (field_boundary_hi[0] == FieldBoundaryType::PML && !do_pml_in_domain) {
+                    // Extend region that is solved for to include the guard cells
+                    // which is where the PML boundary is applied.
+                    realspace_ba.growHi(0, pml_ncell);
+                }
                 AllocLevelSpectralSolverRZ(spectral_solver_fp,
                                            lev,
                                            realspace_ba,
@@ -273,6 +278,11 @@ WarpX::RemakeLevel (int lev, Real /*time*/, const BoxArray& ba, const Distributi
 
 #   ifdef WARPX_DIM_RZ
                     c_realspace_ba.grow(1, ngEB[1]); // add guard cells only in z
+                    if (field_boundary_hi[0] == FieldBoundaryType::PML && !do_pml_in_domain) {
+                        // Extend region that is solved for to include the guard cells
+                        // which is where the PML boundary is applied.
+                        c_realspace_ba.growHi(0, pml_ncell);
+                    }
                     AllocLevelSpectralSolverRZ(spectral_solver_cp,
                                                lev,
                                                c_realspace_ba,


### PR DESCRIPTION
This PR fixes the regrid triggered by load-balancing when using PML in RZ geometry. This is done by not disabling `remake` and `redistribute_on_remake` which caused the PML MultiFabs to have a different distribution mapping than the other MultiFabs, which caused a segfault after the first regrid. Additionally, the growHi in regrid was missing when comparing to `WarpX::AllocLevelMFs`.

For my test case in RZ this fixes a segfault after load balancing and produces correct results.

I did not yet test load balancing in 3D with PML but `remake` and `redistribute_on_remake` are also set to false there.