### PR TITLE
Share hankel transformer between boxes

### DIFF
--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmGalileanRZ.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmGalileanRZ.cpp
@@ -79,7 +79,7 @@ PsatdAlgorithmGalileanRZ::pushSpectralFields (SpectralFieldDataRZ & f)
         amrex::Array4<const Complex> const& T_rho_arr = T_rho_coef[mfi].array();
 
         // Extract pointers for the k vectors
-        auto const & kr_modes = f.getKrArray(mfi);
+        auto const & kr_modes = f.getKrArray();
         amrex::Real const* kr_arr = kr_modes.dataPtr();
         amrex::Real const* modified_kz_arr = modified_kz_vec[mfi].dataPtr();
         int const nr = bx.length(0);
@@ -198,7 +198,7 @@ void PsatdAlgorithmGalileanRZ::InitializeSpectralCoefficients (SpectralFieldData
         // Extract real (for portability on GPU)
         const amrex::Real vz = m_v_galilean[2];
 
-        auto const & kr_modes = f.getKrArray(mfi);
+        auto const & kr_modes = f.getKrArray();
         amrex::Real const* kr_arr = kr_modes.dataPtr();
         int const nr = bx.length(0);
         amrex::Real const dt = m_dt;
@@ -303,7 +303,7 @@ PsatdAlgorithmGalileanRZ::CurrentCorrection (SpectralFieldDataRZ& field_data)
         const amrex::Array4<Complex> fields = field_data.fields[mfi].array();
 
         // Extract pointers for the k vectors
-        auto const & kr_modes = field_data.getKrArray(mfi);
+        auto const & kr_modes = field_data.getKrArray();
         amrex::Real const* kr_arr = kr_modes.dataPtr();
         amrex::Real const* modified_kz_arr = modified_kz_vec[mfi].dataPtr();
         int const nr = bx.length(0);

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmPmlRZ.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmPmlRZ.cpp
@@ -60,7 +60,7 @@ PsatdAlgorithmPmlRZ::pushSpectralFields (SpectralFieldDataRZ & f)
         amrex::Array4<const amrex::Real> const& S_ck_arr = S_ck_coef[mfi].array();
 
         // Extract pointers for the k vectors
-        HankelTransform::RealVector const & kr_modes = f.getKrArray(mfi);
+        HankelTransform::RealVector const & kr_modes = f.getKrArray();
         amrex::Real const* kr_arr = kr_modes.dataPtr();
         int const nr = bx.length(0);
 
@@ -129,7 +129,7 @@ void PsatdAlgorithmPmlRZ::InitializeSpectralCoefficients (SpectralFieldDataRZ co
         amrex::Array4<amrex::Real> const& C = C_coef[mfi].array();
         amrex::Array4<amrex::Real> const& S_ck = S_ck_coef[mfi].array();
 
-        HankelTransform::RealVector const & kr_modes = f.getKrArray(mfi);
+        HankelTransform::RealVector const & kr_modes = f.getKrArray();
         amrex::Real const* kr_arr = kr_modes.dataPtr();
         int const nr = bx.length(0);
         amrex::Real const dt = m_dt;

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmRZ.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/PsatdAlgorithmRZ.cpp
@@ -117,7 +117,7 @@ PsatdAlgorithmRZ::pushSpectralFields(SpectralFieldDataRZ & f)
         }
 
         // Extract pointers for the k vectors
-        auto const & kr_modes = f.getKrArray(mfi);
+        auto const & kr_modes = f.getKrArray();
         amrex::Real const* kr_arr = kr_modes.dataPtr();
         amrex::Real const* modified_kz_arr = modified_kz_vec[mfi].dataPtr();
         int const nr = bx.length(0);
@@ -363,7 +363,7 @@ void PsatdAlgorithmRZ::InitializeSpectralCoefficients (SpectralFieldDataRZ const
             X6 = X6_coef[mfi].array();
         }
 
-        auto const & kr_modes = f.getKrArray(mfi);
+        auto const & kr_modes = f.getKrArray();
         amrex::Real const* kr_arr = kr_modes.dataPtr();
         int const nr = bx.length(0);
         amrex::Real const dt = m_dt;
@@ -437,7 +437,7 @@ PsatdAlgorithmRZ::CurrentCorrection (SpectralFieldDataRZ& field_data)
         const amrex::Array4<Complex> fields = field_data.fields[mfi].array();
 
         // Extract pointers for the k vectors
-        auto const & kr_modes = field_data.getKrArray(mfi);
+        auto const & kr_modes = field_data.getKrArray();
         amrex::Real const* kr_arr = kr_modes.dataPtr();
         amrex::Real const* modified_kz_arr = modified_kz_vec[mfi].dataPtr();
         int const nr = bx.length(0);

--- a/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/SpectralBaseAlgorithmRZ.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralAlgorithms/SpectralBaseAlgorithmRZ.cpp
@@ -43,7 +43,7 @@ SpectralBaseAlgorithmRZ::ComputeSpectralDivE (
         const Array4<Complex> fields = field_data.fields[mfi].array();
 
         // Extract pointers for the k vectors
-        Real const * kr_arr = field_data.getKrArray(mfi).dataPtr();
+        Real const * kr_arr = field_data.getKrArray().dataPtr();
         Real const * modified_kz_arr = modified_kz_vec[mfi].dataPtr();
 
         int const nr = bx.length(0);

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.H
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.H
@@ -29,9 +29,6 @@ class SpectralFieldDataRZ
         // the local MPI rank)
         using FFTplans = amrex::LayoutData<ablastr::math::anyfft::VendorFFTPlan>;
 
-        // Similarly, define the Hankel transformers and filter for each box.
-        using MultiSpectralHankelTransformer = amrex::LayoutData<SpectralHankelTransformer>;
-
         using BinomialFilter = amrex::LayoutData<SpectralBinomialFilter>;
 
         SpectralFieldDataRZ (int lev,
@@ -102,8 +99,8 @@ class SpectralFieldDataRZ
                           int field_index2, int field_index3);
 
         // Returns an array that holds the kr for all of the modes
-        HankelTransform::RealVector const & getKrArray (amrex::MFIter const & mfi) const {
-            return multi_spectral_hankel_transformer[mfi].getKrArray();
+        HankelTransform::RealVector const & getKrArray () const {
+            return spectral_hankel_transformer.getKrArray();
         }
 
         //! `fields` stores fields in spectral space, as multicomponent FabArray
@@ -127,7 +124,7 @@ class SpectralFieldDataRZ
         // Correcting "shift" factors when performing FFT from/to
         // a cell-centered grid in real space, instead of a nodal grid
         SpectralShiftFactor zshift_FFTfromCell, zshift_FFTtoCell;
-        MultiSpectralHankelTransformer multi_spectral_hankel_transformer;
+        SpectralHankelTransformer spectral_hankel_transformer;
         BinomialFilter binomialfilter;
 
 };

--- a/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralFieldDataRZ.cpp
@@ -66,7 +66,10 @@ SpectralFieldDataRZ::SpectralFieldDataRZ (const int lev,
     // as the forward plan anyway.
     backward_plan = FFTplans(spectralspace_ba, dm);
 #endif
-    multi_spectral_hankel_transformer = MultiSpectralHankelTransformer(spectralspace_ba, dm);
+
+    bool has_box = false;
+    int nr = 0;
+    amrex::Real rmax = 0._rt;
 
     // Loop over boxes and allocate the corresponding plan
     // for each box owned by the local MPI proc.
@@ -198,9 +201,20 @@ SpectralFieldDataRZ::SpectralFieldDataRZ (const int lev,
                                FFTW_ESTIMATE); // unsigned flags
 #endif
 
-        // Create the Hankel transformer for each box.
+        // Assert that all boxes have the same r-axis so that they can share one Hankel transformer.
         amrex::XDim3 const xyzmax = WarpX::UpperCorner(mfi.tilebox(), lev, 0._rt);
-        multi_spectral_hankel_transformer[mfi] = SpectralHankelTransformer(grid_size[0], n_rz_azimuthal_modes, xyzmax.x);
+        if (has_box) {
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(nr == grid_size[0] && rmax == xyzmax.x,
+                "All boxes should have the same r axis");
+        } else {
+            has_box = true;
+            nr = grid_size[0];
+            rmax = xyzmax.x;
+        }
+    }
+
+    if (has_box) {
+        spectral_hankel_transformer = SpectralHankelTransformer(nr, n_rz_azimuthal_modes, rmax);
     }
 }
 
@@ -491,7 +505,7 @@ SpectralFieldDataRZ::ForwardTransform (const int lev,
             field_mf_copy[mfi].setVal<amrex::RunOn::Device>(0._rt, realspace_bx, 0, m_ncomps);
             }
         field_mf_copy[mfi].copy<amrex::RunOn::Device>(field_mf[mfi], i_comp*m_ncomps, 0, m_ncomps);
-        multi_spectral_hankel_transformer[mfi].PhysicalToSpectral_Scalar(field_mf_copy[mfi], tempHTransformedSplit[mfi]);
+        spectral_hankel_transformer.PhysicalToSpectral_Scalar(field_mf_copy[mfi], tempHTransformedSplit[mfi]);
 
         FABZForwardTransform(mfi, realspace_bx, tempHTransformedSplit, field_index, is_nodal_z);
 
@@ -554,9 +568,9 @@ SpectralFieldDataRZ::ForwardTransform (const int lev,
         field_mf_t_copy[mfi].copy<amrex::RunOn::Device>(field_mf_t[mfi], 1, 2, ncomps_left);
 
         // Perform the Hankel transform first.
-        multi_spectral_hankel_transformer[mfi].PhysicalToSpectral_Vector(realspace_bx,
-                                                           field_mf_r_copy[mfi], field_mf_t_copy[mfi],
-                                                           tempHTransformedSplit_p[mfi], tempHTransformedSplit_m[mfi]);
+        spectral_hankel_transformer.PhysicalToSpectral_Vector(realspace_bx,
+            field_mf_r_copy[mfi], field_mf_t_copy[mfi],
+            tempHTransformedSplit_p[mfi], tempHTransformedSplit_m[mfi]);
 
         FABZForwardTransform(mfi, realspace_bx, tempHTransformedSplit_p, field_index_r, is_nodal_z);
         FABZForwardTransform(mfi, realspace_bx, tempHTransformedSplit_m, field_index_t, is_nodal_z);
@@ -606,7 +620,7 @@ SpectralFieldDataRZ::BackwardTransform (const int lev,
         // Perform the Hankel inverse transform last.
         // tempHTransformedSplit includes the imaginary component of mode 0.
         // field_mf does not.
-        multi_spectral_hankel_transformer[mfi].SpectralToPhysical_Scalar(tempHTransformedSplit[mfi], field_mf_copy[mfi]);
+        spectral_hankel_transformer.SpectralToPhysical_Scalar(tempHTransformedSplit[mfi], field_mf_copy[mfi]);
 
         amrex::Array4<amrex::Real> const & field_mf_array = field_mf[mfi].array();
         amrex::Array4<amrex::Real> const & field_mf_copy_array = field_mf_copy[mfi].array();
@@ -692,7 +706,7 @@ SpectralFieldDataRZ::BackwardTransform (const int lev,
         // Perform the Hankel inverse transform last.
         // tempHTransformedSplit includes the imaginary component of mode 0.
         // field_mf_[ri] do not.
-        multi_spectral_hankel_transformer[mfi].SpectralToPhysical_Vector(realspace_bx,
+        spectral_hankel_transformer.SpectralToPhysical_Vector(realspace_bx,
                                                            tempHTransformedSplit_p[mfi], tempHTransformedSplit_m[mfi],
                                                            field_mf_r_copy[mfi], field_mf_t_copy[mfi]);
 
@@ -800,14 +814,14 @@ void
 SpectralFieldDataRZ::InitFilter (amrex::IntVect const & filter_npass_each_dir, bool const compensation,
                                  SpectralKSpaceRZ const & k_space)
 {
-    binomialfilter = BinomialFilter(multi_spectral_hankel_transformer.boxArray(),
-                                    multi_spectral_hankel_transformer.DistributionMap());
+    binomialfilter = BinomialFilter(forward_plan.boxArray(),
+                                    forward_plan.DistributionMap());
 
     auto const & dx = k_space.getCellSize();
     auto const & kz = k_space.getKzArray();
 
     for (amrex::MFIter mfi(binomialfilter); mfi.isValid(); ++mfi){
-        binomialfilter[mfi].InitFilterArray(multi_spectral_hankel_transformer[mfi].getKrArray(),
+        binomialfilter[mfi].InitFilterArray(spectral_hankel_transformer.getKrArray(),
                                             kz[mfi], dx, filter_npass_each_dir, compensation);
     }
 }

--- a/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/HankelTransform.cpp
@@ -196,6 +196,11 @@ HankelTransform::HankelForwardTransform (amrex::FArrayBox const& F, int const F_
 {
     ABLASTR_PROFILE("HankelTransform::HankelForwardTransform");
 
+#ifdef AMREX_USE_GPU
+    blas::Queue::stream_t stream_id = amrex::Gpu::gpuStream();
+    m_queue->set_stream(stream_id);
+#endif
+
     amrex::Box const& F_box = F.box();
     amrex::Box const& G_box = G.box();
 
@@ -207,10 +212,6 @@ HankelTransform::HankelForwardTransform (amrex::FArrayBox const& F, int const F_
     AMREX_ALWAYS_ASSERT(nz == G_box.length(1));
     AMREX_ALWAYS_ASSERT(ngr >= 0);
     AMREX_ALWAYS_ASSERT(F_box.bigEnd(0)+1 >= m_nr);
-
-    // We perform stream synchronization since `gemm` may be running
-    // on a different stream.
-    amrex::Gpu::streamSynchronize();
 
     // Note that M is flagged to be transposed since it has dimensions (m_nr, m_nk)
     blas::gemm(blas::Layout::ColMajor, blas::Op::Trans, blas::Op::NoTrans,
@@ -222,11 +223,6 @@ HankelTransform::HankelForwardTransform (amrex::FArrayBox const& F, int const F_
                , *m_queue // Calls the GPU version of blas::gemm
 #endif
            );
-
-    // We perform stream synchronization since `gemm` may be running
-    // on a different stream.
-    amrex::Gpu::streamSynchronize();
-
 }
 
 void
@@ -234,6 +230,11 @@ HankelTransform::HankelInverseTransform (amrex::FArrayBox const& G, int const G_
                                          amrex::FArrayBox      & F, int const F_icomp)
 {
     ABLASTR_PROFILE("HankelTransform::HankelInverseTransform");
+
+#ifdef AMREX_USE_GPU
+    blas::Queue::stream_t stream_id = amrex::Gpu::gpuStream();
+    m_queue->set_stream(stream_id);
+#endif
 
     amrex::Box const& G_box = G.box();
     amrex::Box const& F_box = F.box();
@@ -247,10 +248,6 @@ HankelTransform::HankelInverseTransform (amrex::FArrayBox const& G, int const G_
     AMREX_ALWAYS_ASSERT(ngr >= 0);
     AMREX_ALWAYS_ASSERT(F_box.bigEnd(0)+1 >= m_nr);
 
-    // We perform stream synchronization since `gemm` may be running
-    // on a different stream.
-    amrex::Gpu::streamSynchronize();
-
     // Note that m_invM is flagged to be transposed since it has dimensions (m_nk, m_nr)
     blas::gemm(blas::Layout::ColMajor, blas::Op::Trans, blas::Op::NoTrans,
                m_nr, nz, m_nk, 1._rt,
@@ -261,8 +258,4 @@ HankelTransform::HankelInverseTransform (amrex::FArrayBox const& G, int const G_
                , *m_queue // Calls the GPU version of blas::gemm
 #endif
            );
-
-    // We perform stream synchronization since `gemm` may be running
-    // on a different stream.
-    amrex::Gpu::streamSynchronize();
 }

--- a/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/SpectralHankelTransformer.cpp
+++ b/Source/FieldSolver/SpectralSolver/SpectralHankelTransform/SpectralHankelTransformer.cpp
@@ -52,7 +52,6 @@ SpectralHankelTransformer::ExtractKrArray ()
             kr_array[ii] = kr_m_array[ir];
         });
     }
-    amrex::Gpu::synchronize();
 }
 
 /* \brief Converts a scalar field from the physical to the spectral space for all modes */
@@ -117,8 +116,6 @@ SpectralHankelTransformer::PhysicalToSpectral_Vector (amrex::Box const & box,
             F_t_physical_array(i,j,k,mode_i) = 0.5_rt*(r_imag + t_real);
         });
 
-        amrex::Gpu::streamSynchronize();
-
         dhtp[mode]->HankelForwardTransform(F_r_physical, mode_r, G_p_spectral, mode_r);
         dhtp[mode]->HankelForwardTransform(F_r_physical, mode_i, G_p_spectral, mode_i);
         dhtm[mode]->HankelForwardTransform(F_t_physical, mode_r, G_m_spectral, mode_r);
@@ -137,8 +134,6 @@ SpectralHankelTransformer::SpectralToPhysical_Scalar (amrex::FArrayBox const & G
     // can be done.
     // Note that F_physical does not include the imaginary part of mode 0,
     // but G_spectral does.
-
-    amrex::Gpu::streamSynchronize();
 
     for (int mode=0 ; mode < m_n_rz_azimuthal_modes ; mode++) {
         int const mode_r = 2*mode;
@@ -172,14 +167,10 @@ SpectralHankelTransformer::SpectralToPhysical_Vector (amrex::Box const & box,
         int const mode_r = 2*mode;
         int const mode_i = 2*mode + 1;
 
-        amrex::Gpu::streamSynchronize();
-
         dhtp[mode]->HankelInverseTransform(G_p_spectral, mode_r, F_r_physical, mode_r);
         dhtp[mode]->HankelInverseTransform(G_p_spectral, mode_i, F_r_physical, mode_i);
         dhtm[mode]->HankelInverseTransform(G_m_spectral, mode_r, F_t_physical, mode_r);
         dhtm[mode]->HankelInverseTransform(G_m_spectral, mode_i, F_t_physical, mode_i);
-
-        amrex::Gpu::streamSynchronize();
 
         amrex::ParallelFor(box,
         [=] AMREX_GPU_DEVICE (int i, int j, int k)


### PR DESCRIPTION
In RZ geometry, there is no domain decomposition in r, which means we can reuse the SpectralHankelTransformer for all boxes. The SpectralHankelTransformer takes a while to initialize since it has to invert a matrix on the CPU, this is also done when doing a regrid.

Additionally, all the excess stream synchronizations are removed since blas::gemm uses the same stream as the other amrex kernels. If not it would still be broken with all the syncs because after the blas::gemm, it should sync the blas stream not the amrex stream.

Works on GPU with (and without) `warpx.do_device_synchronize = 0`