### PR TITLE
setup.py: honor CMAKE_GENERATOR_PLATFORM for the Windows -A flag

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -187,7 +187,10 @@ class CMakeBuild(build_ext):
                     cfg.upper(), os.path.join(extdir, "pywarpx")
                 )
             ]
-            if sys.maxsize > 2**32:
+            generator_platform = os.environ.get("CMAKE_GENERATOR_PLATFORM")
+            if generator_platform:
+                cmake_args += ["-A", generator_platform]
+            elif sys.maxsize > 2**32:
                 cmake_args += ["-A", "x64"]
         else:
             cmake_args += ["-DCMAKE_BUILD_TYPE=" + cfg]


### PR DESCRIPTION
The Windows build hardcoded the Visual Studio target architecture to x64 for any 64-bit interpreter (`if sys.maxsize > 2**32: -A x64`). On win-arm64 the interpreter is 64-bit but the architecture is ARM, so this mis-targeted the build and find_package(Python) then failed. Honor an explicit CMAKE_GENERATOR_PLATFORM (e.g. "ARM64") from the environment, falling back to the previous behavior otherwise.

Same as https://github.com/openPMD/openPMD-api/pull/1910