### PR TITLE
EB: Add specular particle reflection option (<species>.reflect_at_eb)

### DIFF
--- a/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
+++ b/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
@@ -56,7 +56,7 @@ struct Reflect {
         amrex::ParticleReal& ux = ptd.m_rdata[PIdx::ux][i];
         amrex::ParticleReal& uy = ptd.m_rdata[PIdx::uy][i];
         amrex::ParticleReal& uz = ptd.m_rdata[PIdx::uz][i];
-#if (defined WARPX_DIM_RZ)
+#if defined(WARPX_DIM_RZ)
         // momentum (ux,uy,uz) is Cartesian; the EB normal is (n_r, n_z). Rotate
         // the normal to the particle's azimuth to build the Cartesian normal.
         amrex::ParticleReal const theta = ptd.m_rdata[PIdx::theta][i];
@@ -65,25 +65,25 @@ struct Reflect {
         amrex::Real const nx = normal[0]*ct;
         amrex::Real const ny = normal[0]*st;
         amrex::Real const nz = normal[1];
-#elif (defined WARPX_DIM_3D)
+#elif defined(WARPX_DIM_3D)
         amrex::Real const nx = normal[0];
         amrex::Real const ny = normal[1];
         amrex::Real const nz = normal[2];
-#elif (defined WARPX_DIM_XZ)
+#elif defined(WARPX_DIM_XZ)
         amrex::Real const nx = normal[0];
         amrex::Real const ny = 0._rt;
         amrex::Real const nz = normal[1];
-#elif (defined WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_1D_Z)
         amrex::Real const nx = 0._rt;
         amrex::Real const ny = 0._rt;
         amrex::Real const nz = normal[0];
-#elif (defined WARPX_DIM_RCYLINDER)
+#elif defined(WARPX_DIM_RCYLINDER)
         // 1D radial: only a radial normal; rotate to the particle's azimuth.
         amrex::ParticleReal const theta = ptd.m_rdata[PIdx::theta][i];
         amrex::Real const nx = normal[0]*std::cos(theta);
         amrex::Real const ny = normal[0]*std::sin(theta);
         amrex::Real const nz = 0._rt;
-#elif (defined WARPX_DIM_RSPHERE)
+#elif defined(WARPX_DIM_RSPHERE)
         // 1D radial (spherical): radial unit vector uses azimuth theta and polar phi.
         amrex::ParticleReal const theta = ptd.m_rdata[PIdx::theta][i];
         amrex::ParticleReal const phi   = ptd.m_rdata[PIdx::phi][i];

--- a/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
+++ b/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
@@ -7,10 +7,14 @@
 #ifndef WARPX_PARTICLEBOUNDARYPROCESS_H_
 #define WARPX_PARTICLEBOUNDARYPROCESS_H_
 
+#include "Particles/WarpXParticleContainer.H"
+
 #include <AMReX_Particle.H>
 #include <AMReX_REAL.H>
 #include <AMReX_RealVect.H>
 #include <AMReX_Random.H>
+
+#include <cmath>
 
 
 namespace ParticleBoundaryProcess {
@@ -32,6 +36,68 @@ struct Absorb {
                      amrex::RandomEngine const& /*engine*/) const noexcept
     {
         amrex::ParticleIDWrapper{ptd.m_idcpu[i]}.make_invalid();
+    }
+};
+
+// Specular reflection of a particle off the embedded-boundary surface: the
+// particle is kept, and the component of its velocity along the EB surface
+// normal is reversed (u -> u - 2 (u.n) n), but only when it is moving INTO the
+// conductor (u.n < 0; the signed-distance normal points into the fluid). This
+// gives a conducting-for-fields / reflecting-for-particles wall, avoiding the
+// charge depletion + sheath E-field that absorption creates at a dense surface.
+struct Reflect {
+    template <typename PData>
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void operator() (PData& ptd, int i,
+                     const amrex::RealVect& /*pos*/, const amrex::RealVect& normal,
+                     amrex::RandomEngine const& /*engine*/) const noexcept
+    {
+        using namespace amrex::literals;
+        amrex::ParticleReal& ux = ptd.m_rdata[PIdx::ux][i];
+        amrex::ParticleReal& uy = ptd.m_rdata[PIdx::uy][i];
+        amrex::ParticleReal& uz = ptd.m_rdata[PIdx::uz][i];
+#if (defined WARPX_DIM_RZ)
+        // momentum (ux,uy,uz) is Cartesian; the EB normal is (n_r, n_z). Rotate
+        // the normal to the particle's azimuth to build the Cartesian normal.
+        amrex::ParticleReal const theta = ptd.m_rdata[PIdx::theta][i];
+        amrex::Real const ct = std::cos(theta);
+        amrex::Real const st = std::sin(theta);
+        amrex::Real const nx = normal[0]*ct;
+        amrex::Real const ny = normal[0]*st;
+        amrex::Real const nz = normal[1];
+#elif (defined WARPX_DIM_3D)
+        amrex::Real const nx = normal[0];
+        amrex::Real const ny = normal[1];
+        amrex::Real const nz = normal[2];
+#elif (defined WARPX_DIM_XZ)
+        amrex::Real const nx = normal[0];
+        amrex::Real const ny = 0._rt;
+        amrex::Real const nz = normal[1];
+#elif (defined WARPX_DIM_1D_Z)
+        amrex::Real const nx = 0._rt;
+        amrex::Real const ny = 0._rt;
+        amrex::Real const nz = normal[0];
+#elif (defined WARPX_DIM_RCYLINDER)
+        // 1D radial: only a radial normal; rotate to the particle's azimuth.
+        amrex::ParticleReal const theta = ptd.m_rdata[PIdx::theta][i];
+        amrex::Real const nx = normal[0]*std::cos(theta);
+        amrex::Real const ny = normal[0]*std::sin(theta);
+        amrex::Real const nz = 0._rt;
+#elif (defined WARPX_DIM_RSPHERE)
+        // 1D radial (spherical): radial unit vector uses azimuth theta and polar phi.
+        amrex::ParticleReal const theta = ptd.m_rdata[PIdx::theta][i];
+        amrex::ParticleReal const phi   = ptd.m_rdata[PIdx::phi][i];
+        amrex::Real const cphi = std::cos(phi);
+        amrex::Real const nx = normal[0]*cphi*std::cos(theta);
+        amrex::Real const ny = normal[0]*cphi*std::sin(theta);
+        amrex::Real const nz = normal[0]*std::sin(phi);
+#endif
+        amrex::ParticleReal const vn = ux*nx + uy*ny + uz*nz;
+        if (vn < 0._prt) {
+            ux -= 2._prt*vn*nx;
+            uy -= 2._prt*vn*ny;
+            uz -= 2._prt*vn*nz;
+        }
     }
 };
 }

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -1242,7 +1242,12 @@ void MultiParticleContainer::ScrapeParticlesAtEB (
     ablastr::fields::MultiLevelScalarField const& distance_to_eb)
 {
     for (auto& pc : allcontainers) {
-        scrapeParticlesAtEB(*pc, distance_to_eb, ParticleBoundaryProcess::Absorb());
+        if (pc->getReflectAtEBFlag()) {
+            // conducting-for-fields / reflecting-for-particles EB
+            scrapeParticlesAtEB(*pc, distance_to_eb, ParticleBoundaryProcess::Reflect());
+        } else {
+            scrapeParticlesAtEB(*pc, distance_to_eb, ParticleBoundaryProcess::Absorb());
+        }
     }
 }
 

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -559,7 +559,7 @@ void ParticleBoundaryBuffer::gatherParticlesFromEmbeddedBoundaries (
                     if (np == 0) { continue; }
 
                     using SrcData = WarpXParticleContainer::ParticleTileType::ConstParticleTileDataType;
-                    auto predicate = [=] AMREX_GPU_HOST_DEVICE(const SrcData & /*src*/, const int ip)
+                    auto predicate = [=] AMREX_GPU_HOST_DEVICE(const SrcData & src, const int ip)
                             /* NVCC 11.3.109 chokes in C++17 on this: noexcept */
                     {
                         amrex::ParticleReal xp, yp, zp;
@@ -568,7 +568,7 @@ void ParticleBoundaryBuffer::gatherParticlesFromEmbeddedBoundaries (
                         amrex::Real const phi_value = ablastr::particles::doGatherScalarFieldNodal(
                             xp, yp, zp, phiarr, dxi, plo
                         );
-                        return phi_value < 0.0 ? 1 : 0;
+                        return (phi_value < 0.0 && !amrex::ParticleIDWrapper{src.m_idcpu[ip]}.is_valid()) ? 1 : 0;
                     };
 
                     const auto ptile_data = ptile.getConstParticleTileData();

--- a/Source/Particles/PhysicalParticleContainer.H
+++ b/Source/Particles/PhysicalParticleContainer.H
@@ -441,6 +441,9 @@ public:
     // By default this returns false; overridden here to return runtime value
     bool getTemperatureDepositionFlag () const noexcept override {return m_do_temperature_deposition;}
 
+    // By default this returns false; overridden here to return runtime value
+    bool getReflectAtEBFlag () const noexcept override {return m_reflect_at_eb;}
+
     void AccumulateVelocitiesAndComputeTemperature (
         ablastr::fields::MultiLevelVectorField const & T_vf,
         amrex::Real relative_time) override;
@@ -497,6 +500,9 @@ protected:
 
     // Flag controlling whether or not variance and then temperatures are computed per species
     bool m_do_temperature_deposition = false;
+
+    // Flag: specularly reflect (true) vs absorb (false, default) at the EB surface
+    bool m_reflect_at_eb = false;
 
     std::unique_ptr<warpx::particles::deposition::VarianceAccumulationBuffer> local_temperature_arrays;
 

--- a/Source/Particles/PhysicalParticleContainer.cpp
+++ b/Source/Particles/PhysicalParticleContainer.cpp
@@ -205,6 +205,9 @@ PhysicalParticleContainer::PhysicalParticleContainer (AmrCore* amr_core, int isp
 
     utils::parser::queryWithParser(pp_species_name, "do_temperature_deposition", m_do_temperature_deposition);
 
+    // Specularly reflect this species at the embedded boundary instead of absorbing.
+    pp_species_name.query("reflect_at_eb", m_reflect_at_eb);
+
     pp_species_name.query("boost_adjust_transverse_positions", boost_adjust_transverse_positions);
     pp_species_name.query("do_backward_propagation", do_backward_propagation);
 #if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -741,6 +741,11 @@ public:
     // By default this returns false, can be overridden in PysicalParticleContainer
     virtual bool getTemperatureDepositionFlag () const noexcept {return false;}
 
+    // If true, particles of this species are specularly REFLECTED at the embedded
+    // boundary instead of absorbed. By default false (absorb); overridden in
+    // PhysicalParticleContainer via the <species>.reflect_at_eb input flag.
+    virtual bool getReflectAtEBFlag () const noexcept {return false;}
+
 private:
     void particlePostLocate(ParticleType& p, const amrex::ParticleLocData& pld, int lev) override;
 


### PR DESCRIPTION
## Description
Currently, WarpX hardcodes embedded-boundary (EB) particle interactions to **Absorb**. 

This PR adds a **Reflect** option (`<species>.reflect_at_eb = 1`) so that a particle species can be specularly reflected off the EB surface instead. This is critical for physical applications (e.g., conducting walls, dense plasmas) to prevent surface charge depletion and artificial sheath E-fields created by absorption.


## Proposed Changes
1. **Particle Reflection Off EB (`Source/EmbeddedBoundary/ParticleBoundaryProcess.H`):**
   - Implemented `struct Reflect` functor executing specular reflection: $\vec{u} \to \vec{u} - 2(\vec{u} \cdot \vec{n})\vec{n}$.
   - Handled dimension-specific normals (1D, 2D XZ, 2D RZ, 3D). In RZ/rcylinder, the normal $(n_r, n_z)$ is rotated to the particle's azimuth ($\theta$) to map it to the Cartesian momentum $(u_x, u_y, u_z)$.
2. **User Input Config (`Source/Particles/WarpXParticleContainer.cpp` & `Source/Particles/PhysicalParticleContainer.cpp`):**
   - Added the per-species parameter `<species>.reflect_at_eb` (default `0` = absorb, `1` = reflect).
3. **Scrape Dispatcher (`Source/Particles/MultiParticleContainer.cpp`):**
   - Dispatched the `Reflect` vs `Absorb` boundary process per species in `ScrapeParticlesAtEB`.
4. **NVCC Compilation Fix (`Source/EmbeddedBoundary/ParticleBoundaryProcess.H`):**
   - Corrected `#elif (defined MACRO)` to `#elif defined(MACRO)` to resolve parsing issues on NVCC C++17 compilers.
5. **Scraping Diagnostic Fix (`Source/Particles/ParticleBoundaryBuffer.cpp`):**
   - Updated the predicate in `gatherParticlesFromEmbeddedBoundaries` to check `!amrex::ParticleIDWrapper{src.m_idcpu[ip]}.is_valid()`. This ensures only absorbed (invalidated) particles are gathered into the boundary scraping buffer, and reflected (still active) particles are excluded.

## Verification
A 3D simulation test case (modified from `Examples/Tests/particle_boundary_process/inputs_test_3d_particle_absorption`) was run on CPU to verify correctness:
- **Particle Conservation:** 612/612 particles were conserved at step 60 (whereas 100% were absorbed in the default test case).
- **Specular Reflection:** Z-momentum ($u_z$) successfully flipped from $+2000.0$ to $\approx -1988.0$ for all 612 particles upon hitting the EB surface at $z = -86.5\,\mu\text{m}$.
- **Diagnostic Buffer:** The boundary scraping diagnostic buffer recorded exactly `0` particles, confirming that reflected particles are not counted as lost.
