### PR TITLE
[WIP] Generalize MCC impact ionization to allow non-electron incident species

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3067,11 +3067,22 @@ Details about the collision models can be found in the :ref:`theory section <mul
     ``excitationX``, ``ionization`` or ``twoproduct_reaction``, the energy cost of that process must be given in eV.
 
 .. pp:param:: <collision_name>.ionization_species
-    :type: ``float``
+    :type: ``string``
 
     Only for ``background_mcc``. If the scattering process is ``ionization`` the
     produced species must also be given. For example if argon properties is used
     for the background gas, a species of argon ions should be specified here.
+
+.. pp:param:: <collision_name>.ionization_electron_species
+    :type: ``string``, optional
+
+    Only for ``background_mcc``. If the scattering process is ``ionization``,
+    this specifies which species collects the electrons freed by the
+    ionization reaction. If not given, the colliding species itself is used,
+    which is correct when the colliding species is the electron species (i.e.
+    for electron-impact ionization). A different species must be given here
+    when the colliding species (``<collision_name>.species``) is not an
+    electron species, for instance for ion-impact ionization.
 
 .. pp:param:: <collision_name>.ionization_target_species
     :type: ``string``

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -3239,7 +3239,7 @@ class MCCCollisions(picmistandard.base._ClassWithInit):
         collision.scattering_processes = self.scattering_processes.keys()
         for process, kw in self.scattering_processes.items():
             for key, val in kw.items():
-                if key == "species":
+                if "species" in key:
                     val = val.name
                 collision.add_new_attr(process + "_" + key, val)
 

--- a/Source/Particles/Collision/BackgroundMCC/BackgroundMCCCollision.H
+++ b/Source/Particles/Collision/BackgroundMCC/BackgroundMCCCollision.H
@@ -55,8 +55,10 @@ public:
      *
      * @param[in] lev the mesh-refinement level
      * @param[in,out] cost pointer to (load balancing) cost corresponding to box where present particles are ionized.
-     * @param[in,out] species1,species2 reference to species container used to inject
-     * new particles
+     * @param[in,out] species1 reference to the colliding (incident) species container
+     * @param[in,out] species2 reference to the newly created ion species container
+     * @param[in,out] species3 reference to the species container that collects the
+     * freed electrons (may be the same as species1, for electron-impact ionization)
      * @param t current time
      *
      */
@@ -65,6 +67,7 @@ public:
                                  amrex::LayoutData<amrex::Real>* cost,
                                  WarpXParticleContainer& species1,
                                  WarpXParticleContainer& species2,
+                                 WarpXParticleContainer& species3,
                                  amrex::Real t
                                  );
 

--- a/Source/Particles/Collision/BackgroundMCC/BackgroundMCCCollision.cpp
+++ b/Source/Particles/Collision/BackgroundMCC/BackgroundMCCCollision.cpp
@@ -110,6 +110,16 @@ BackgroundMCCCollision::BackgroundMCCCollision (std::string const& collision_nam
             pp_collision_name.get("ionization_species", secondary_species);
             m_species_names.push_back(secondary_species);
 
+            // The species that collects the freed electrons defaults to the
+            // colliding species itself, which is correct for electron-impact
+            // ionization. A different species must be specified here when the
+            // colliding species is not an electron (e.g. for ion-impact
+            // ionization), since the freed electrons cannot be added to the
+            // (ion) colliding species.
+            std::string electron_species = m_species_names[0];
+            pp_collision_name.query("ionization_electron_species", electron_species);
+            m_species_names.push_back(electron_species);
+
             m_ionization_processes.push_back(std::move(process));
         } else {
             m_scattering_processes.push_back(std::move(process));
@@ -194,11 +204,19 @@ BackgroundMCCCollision::doCollisions (amrex::Real cur_time, amrex::Real dt, Mult
     using namespace amrex::literals;
 
     auto& species1 = mypc->GetParticleContainerFromName(m_species_names[0]);
-    // this is a very ugly hack to have species2 be a reference and be
-    // defined in the scope of doCollisions
+    // this is a very ugly hack to have species2/species3 be references and
+    // be defined in the scope of doCollisions
     auto& species2 = (
-                      (m_species_names.size() == 2) ?
+                      (m_species_names.size() >= 2) ?
                       mypc->GetParticleContainerFromName(m_species_names[1]) :
+                      mypc->GetParticleContainerFromName(m_species_names[0])
+                      );
+    // species3 collects the freed electrons produced by ionization; it is
+    // only relevant (and only present in m_species_names) when the
+    // ionization process is included
+    auto& species3 = (
+                      (m_species_names.size() == 3) ?
+                      mypc->GetParticleContainerFromName(m_species_names[2]) :
                       mypc->GetParticleContainerFromName(m_species_names[0])
                       );
 
@@ -240,6 +258,14 @@ BackgroundMCCCollision::doCollisions (amrex::Real cur_time, amrex::Real dt, Mult
             // if an ionization process is included the secondary species mass
             // is taken as the background mass
             m_background_mass = species2.getMass();
+
+            // the species that collects the freed electrons must have a
+            // negative charge
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+                species3.getCharge() < 0._prt,
+                "The species given as " + m_collision_name + ".ionization_electron_species ("
+                + m_species_names[2] + ") must have a negative charge."
+            );
         }
         // if no neutral species mass was specified and ionization is not
         // included assume that the collisions will be with neutrals of the
@@ -289,7 +315,7 @@ BackgroundMCCCollision::doCollisions (amrex::Real cur_time, amrex::Real dt, Mult
 
         // secondly perform ionization through the SmartCopyFactory if needed
         if (ionization_flag) {
-            doBackgroundIonization(lev, cost, species1, species2, cur_time);
+            doBackgroundIonization(lev, cost, species1, species2, species3, cur_time);
         }
     }
 }
@@ -448,11 +474,15 @@ void BackgroundMCCCollision::doBackgroundCollisionsWithinTile
 
 void BackgroundMCCCollision::doBackgroundIonization
 ( int lev, amrex::LayoutData<amrex::Real>* cost,
-  WarpXParticleContainer& species1, WarpXParticleContainer& species2, amrex::Real t)
+  WarpXParticleContainer& species1, WarpXParticleContainer& species2,
+  WarpXParticleContainer& species3, amrex::Real t)
 {
     ABLASTR_PROFILE("BackgroundMCCCollision::doBackgroundIonization()");
 
-    const SmartCopyFactory copy_factory_elec(species1, species1);
+    // species1 is the colliding (incident) species; species2 collects the
+    // newly created ions; species3 collects the freed electrons (species3
+    // is the same as species1 for electron-impact ionization)
+    const SmartCopyFactory copy_factory_elec(species1, species3);
     const SmartCopyFactory copy_factory_ion(species1, species2);
     const auto CopyElec = copy_factory_elec.getSmartCopy();
     const auto CopyIon = copy_factory_ion.getSmartCopy();
@@ -476,7 +506,8 @@ void BackgroundMCCCollision::doBackgroundIonization
         }
         auto wt = static_cast<amrex::Real>(amrex::second());
 
-        auto& elec_tile = species1.ParticlesAt(lev, pti);
+        auto& incident_tile = species1.ParticlesAt(lev, pti);
+        auto& elec_tile = species3.ParticlesAt(lev, pti);
         auto& ion_tile = species2.ParticlesAt(lev, pti);
 
         const auto np_elec = elec_tile.numParticles();
@@ -484,11 +515,11 @@ void BackgroundMCCCollision::doBackgroundIonization
 
         auto Transform = ImpactIonizationTransformFunc(
                                                        m_ionization_processes[0].getEnergyPenalty(),
-                                                       m_mass1, sqrt_kb_m, m_background_temperature_func, t
+                                                       m_mass1, m_background_mass, sqrt_kb_m, m_background_temperature_func, t
                                                        );
 
-        const auto num_added = filterCopyTransformParticles<1>(species1, species2,
-                                                               elec_tile, ion_tile, elec_tile, np_elec, np_ion,
+        const auto num_added = filterCopyTransformParticles<1>(species3, species2,
+                                                               elec_tile, ion_tile, incident_tile, np_elec, np_ion,
                                                                Filter, CopyElec, CopyIon, Transform
                                                                );
 

--- a/Source/Particles/Collision/BackgroundMCC/ImpactIonization.H
+++ b/Source/Particles/Collision/BackgroundMCC/ImpactIonization.H
@@ -60,8 +60,8 @@ public:
         m_nu_max(nu_max), m_n_a_func(n_a_func), m_t(t) { }
 
     /**
-    * \brief Functor call. This method determines if a given (electron) particle
-    * should undergo an ionization collision.
+    * \brief Functor call. This method determines if a given (colliding species)
+    * particle should undergo an ionization collision.
     *
     * @param[in] ptd particle tile data
     * @param[in] i particle index
@@ -133,14 +133,17 @@ public:
     * energy of the colliding particle and assigning appropriate velocities
     * to the two newly created particles. To this end the energy cost of
     * ionization is passed to the constructor as well as the mass of the
-    * colliding species and the standard deviation of the ion velocity
-    * (normalized temperature).
+    * colliding species, the mass of the background/target species, and the
+    * standard deviation of the background velocity (normalized temperature).
     * Note that the mass and energy quantities have to be stored as doubles to
     * ensure accurate energy calculations (otherwise errors occur with single
     * or mixed precision builds of WarpX).
     *
     * @param[in] energy_cost energy cost of ionization
-    * @param[in] mass1 mass of the colliding species
+    * @param[in] mass1 mass of the colliding (incident) species
+    * @param[in] mass2 mass of the background/target species that gets ionized
+                 (approximately equal to the mass of the newly created ion,
+                 since the electron mass is negligible in comparison)
     * @param[in] sqrt_kb_m value of sqrt(kB/m), where kB is Boltzmann's constant
                  and m is the background neutral mass
     * @param[in] T_a_func ParserExecutor<4> function to get the background
@@ -148,9 +151,9 @@ public:
     * @param[in] t the current simulation time
     */
     ImpactIonizationTransformFunc(
-        amrex::ParticleReal energy_cost, double mass1, amrex::ParticleReal sqrt_kb_m,
+        amrex::ParticleReal energy_cost, double mass1, double mass2, amrex::ParticleReal sqrt_kb_m,
         amrex::ParserExecutor<4> const& T_a_func, amrex::Real t
-    ) :  m_energy_cost(energy_cost), m_mass1(mass1),
+    ) :  m_energy_cost(energy_cost), m_mass1(mass1), m_mass2(mass2),
          m_sqrt_kb_m(sqrt_kb_m), m_T_a_func(T_a_func), m_t(t) { }
 
     /**
@@ -159,9 +162,22 @@ public:
     * standard from the FilterCopyTransfrom::filterCopyTransformParticles
     * function.
     *
-    * @param[in,out] dst1 target species 1 (electrons)
-    * @param[in,out] dst2 target species 2 (ions)
-    * @param[in] src source species (electrons)
+    * The kinematics of the ionization event depend on the nature of the
+    * incident (colliding) particle. If the incident particle is an electron,
+    * the incident and freed electrons are assumed to isotropically share the
+    * available energy equally, while the newly created ion simply inherits a
+    * velocity drawn from the background Maxwellian distribution (since its
+    * recoil, due to the large mass ratio with the electron, is negligible).
+    * If the incident particle is much heavier than an electron (e.g. an ion),
+    * the same collinear model as used for ion-impact ionization in the DSMC
+    * module is used instead (see SplitAndScatterFunc.H): in the center-of-mass
+    * frame, the two products (freed electron and newly created ion) are
+    * assumed to have equal velocity, aligned with the outgoing velocity of the
+    * incident particle.
+    *
+    * @param[in,out] dst1 target species 1 (freed electrons)
+    * @param[in,out] dst2 target species 2 (newly created ions)
+    * @param[in] src source species (the colliding/incident species)
     * @param[in] i_src particle index of the source species
     * @param[in] i_dst1 particle index of target species 1
     * @param[in] i_dst2 particle index of target species 2
@@ -174,6 +190,7 @@ public:
         amrex::RandomEngine const& engine) const noexcept
     {
         using namespace amrex;
+        using namespace amrex::literals;
         using std::sqrt;
 
         // get references to the particle to get its position
@@ -184,7 +201,7 @@ public:
 
         // calculate standard deviation in neutral velocity distribution using
         // the local temperature
-        const ParticleReal ion_vel_std = m_sqrt_kb_m * std::sqrt(m_T_a_func(x, y, z, m_t));
+        const ParticleReal background_vel_std = m_sqrt_kb_m * std::sqrt(m_T_a_func(x, y, z, m_t));
 
         // get references to the original particle's velocity
         auto& ux = src.m_rdata[PIdx::ux][i_src];
@@ -199,32 +216,100 @@ public:
         auto& i_uy = dst2.m_rdata[PIdx::uy][i_dst2];
         auto& i_uz = dst2.m_rdata[PIdx::uz][i_dst2];
 
-        // calculate kinetic energy
         constexpr auto eV = PhysConst::q_e;
-        E_coll = Algorithms::KineticEnergy<double>(ux, uy, uz, m_mass1)/eV;
 
-        // each electron gets half the energy (could change this later)
-        const auto E_out = static_cast<amrex::ParticleReal>((E_coll - m_energy_cost) / 2.0_prt * eV);
+        if (m_mass1 > 2.0_prt * PhysConst::m_e)
+        {
+            // Ion-impact ionization (the incident particle is heavier than an
+            // electron): use the same collinear, momentum-conserving model as
+            // for ion-impact ionization in the DSMC module. Since the
+            // background/target species is not tracked as actual macroparticles
+            // in the MCC module, its velocity (prior to the collision) is first
+            // sampled from a Maxwellian distribution at the local background
+            // temperature.
+            const ParticleReal ua_x = background_vel_std * RandomNormal(0_prt, 1.0_prt, engine);
+            const ParticleReal ua_y = background_vel_std * RandomNormal(0_prt, 1.0_prt, engine);
+            const ParticleReal ua_z = background_vel_std * RandomNormal(0_prt, 1.0_prt, engine);
 
-        // precalculate often used value
-        constexpr auto c2 = PhysConst::c2;
-        const auto mc2 = m_mass1*c2;
+            // for simplicity (for now) we assume non-relativistic particles
+            // and simply calculate the center-of-momentum velocity from the
+            // rest masses
+            const auto uCOM_x = static_cast<ParticleReal>((m_mass1*ux + m_mass2*ua_x) / (m_mass1 + m_mass2));
+            const auto uCOM_y = static_cast<ParticleReal>((m_mass1*uy + m_mass2*ua_y) / (m_mass1 + m_mass2));
+            const auto uCOM_z = static_cast<ParticleReal>((m_mass1*uz + m_mass2*ua_z) / (m_mass1 + m_mass2));
 
-        const amrex::ParticleReal up = sqrt(E_out * (E_out + 2.0_prt*mc2) / c2) / m_mass1;
+            // velocity of the incident particle, in the center-of-mass frame
+            ParticleReal vx0 = ux - uCOM_x;
+            ParticleReal vy0 = uy - uCOM_y;
+            ParticleReal vz0 = uz - uCOM_z;
 
-        // isotropically scatter electrons
-        ParticleUtils::RandomizeVelocity(ux, uy, uz, up, engine);
-        ParticleUtils::RandomizeVelocity(e_ux, e_uy, e_uz, up, engine);
+            // calculate kinetic energy of the collision, in the center-of-mass frame
+            const auto p_non_target_in = static_cast<ParticleReal>(m_mass1 * sqrt(vx0*vx0 + vy0*vy0 + vz0*vz0));
+            E_coll = 0.5 * p_non_target_in * p_non_target_in * (1.0/m_mass1 + 1.0/m_mass2);
+            // subtract the energy cost for ionization
+            const auto E_out = static_cast<ParticleReal>(E_coll - m_energy_cost * eV);
 
-        // get velocities for the ion from a Maxwellian distribution
-        i_ux = ion_vel_std * RandomNormal(0_prt, 1.0_prt, engine);
-        i_uy = ion_vel_std * RandomNormal(0_prt, 1.0_prt, engine);
-        i_uz = ion_vel_std * RandomNormal(0_prt, 1.0_prt, engine);
+            // amplitude of the momentum of the non-target particle, obtained
+            // from conservation of energy
+            const ParticleReal p_non_target_out = sqrt(2.0_prt * E_out / (1.0_prt/m_mass1 + 1.0_prt/m_mass2));
+
+            // reduce the velocity of the incident particle, to reflect the
+            // loss of energy due to ionization
+            const ParticleReal reduce_factor = p_non_target_out / p_non_target_in;
+            vx0 *= reduce_factor;
+            vy0 *= reduce_factor;
+            vz0 *= reduce_factor;
+
+            // obtain the velocities of the freed electron and the newly
+            // created ion by conservation of momentum; both products are
+            // assumed to share the same velocity (collinear model)
+            const ParticleReal mass_ratio = static_cast<ParticleReal>(m_mass1 / m_mass2);
+            e_ux = i_ux = -mass_ratio * vx0;
+            e_uy = i_uy = -mass_ratio * vy0;
+            e_uz = i_uz = -mass_ratio * vz0;
+
+            // transform back to the lab frame
+            ux = vx0 + uCOM_x;
+            uy = vy0 + uCOM_y;
+            uz = vz0 + uCOM_z;
+            e_ux += uCOM_x; e_uy += uCOM_y; e_uz += uCOM_z;
+            i_ux += uCOM_x; i_uy += uCOM_y; i_uz += uCOM_z;
+        }
+        else
+        {
+            // Electron-impact ionization (the incident particle is an
+            // electron): the incident and freed electrons isotropically share
+            // the available energy equally, while the newly created ion
+            // simply inherits a velocity from the background Maxwellian
+            // distribution.
+
+            // calculate kinetic energy
+            E_coll = Algorithms::KineticEnergy<double>(ux, uy, uz, m_mass1)/eV;
+
+            // each electron gets half the energy (could change this later)
+            const auto E_out = static_cast<amrex::ParticleReal>((E_coll - m_energy_cost) / 2.0_prt * eV);
+
+            // precalculate often used value
+            constexpr auto c2 = PhysConst::c2;
+            const auto mc2 = m_mass1*c2;
+
+            const amrex::ParticleReal up = sqrt(E_out * (E_out + 2.0_prt*mc2) / c2) / m_mass1;
+
+            // isotropically scatter electrons
+            ParticleUtils::RandomizeVelocity(ux, uy, uz, up, engine);
+            ParticleUtils::RandomizeVelocity(e_ux, e_uy, e_uz, up, engine);
+
+            // get velocities for the ion from a Maxwellian distribution
+            i_ux = background_vel_std * RandomNormal(0_prt, 1.0_prt, engine);
+            i_uy = background_vel_std * RandomNormal(0_prt, 1.0_prt, engine);
+            i_uz = background_vel_std * RandomNormal(0_prt, 1.0_prt, engine);
+        }
     }
 
 private:
     amrex::ParticleReal m_energy_cost;
     double m_mass1;
+    double m_mass2;
     amrex::ParticleReal m_sqrt_kb_m;
     amrex::ParserExecutor<4> m_T_a_func;
     amrex::Real m_t;


### PR DESCRIPTION
The background MCC ionization model previously assumed the colliding (incident) species was always an electron, both for bookkeeping (the freed electron reused the incident species container) and for the collision kinematics (isotropic, equal-energy electron scattering).

This adds support for ionization by heavier incident species (e.g. ions), following the same physics already used for ion-impact ionization in the DSMC module: a collinear, momentum-conserving model is used when the incident particle is much heavier than an electron, while electron-impact ionization keeps its existing kinematics.

A new optional `<collision_name>.ionization_electron_species` parameter lets the freed electrons be collected in a species distinct from the incident species, which is required once the incident species is not itself an electron.

Fixes #4698