### PR TITLE
fix: resolve strict NVCC parsing errors for '#elif (defined MACRO)'

### DIFF
--- a/Source/BoundaryConditions/PEC_Insulator.cpp
+++ b/Source/BoundaryConditions/PEC_Insulator.cpp
@@ -643,11 +643,11 @@ PEC_Insulator::ApplyPEC_InsulatortoField (
 
             amrex::IntVectND<3> is_normal_to_boundary{0, 0, 0};
 
-#if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
+#if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
             // For 2D : for icomp==1, (Fy in XZ, Ftheta in RZ),
             //          icomp=1 is not normal to x or z boundary
             is_normal_to_boundary[2*idim] = 1;
-#elif (defined WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_1D_Z)
             // For 1D : icomp=0 and icomp=1 (Fx and Fy are not normal to the z boundary)
             is_normal_to_boundary[2] = 1;
 #else

--- a/Source/BoundaryConditions/WarpXEvolvePML.cpp
+++ b/Source/BoundaryConditions/WarpXEvolvePML.cpp
@@ -8,7 +8,7 @@
 #include "WarpX.H"
 
 #include "BoundaryConditions/PML.H"
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
+#if defined(WARPX_DIM_RZ) && defined(WARPX_USE_FFT)
 #   include "BoundaryConditions/PML_RZ.H"
 #endif
 #include "EmbeddedBoundary/Enabled.H"
@@ -63,7 +63,7 @@ WarpX::DampPML (const int lev, PatchType patch_type)
     if (!do_pml) { return; }
 
     ABLASTR_PROFILE("WarpX::DampPML()");
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
+#if defined(WARPX_DIM_RZ) && defined(WARPX_USE_FFT)
     if (pml_rz[lev]) {
         using ablastr::fields::Direction;
         using warpx::fields::FieldType;

--- a/Source/BoundaryConditions/WarpX_PEC.cpp
+++ b/Source/BoundaryConditions/WarpX_PEC.cpp
@@ -153,12 +153,12 @@ namespace
                 const bool isPECBoundary = ( (iside == 0)
                     ? fbndry_lo[idim] == bc_type
                     : fbndry_hi[idim] == bc_type );
-#if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
+#if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
                 // For 2D : for icomp==1, (Ey in XZ, Etheta in RZ),
                 //          icomp=1 is tangential to both x and z boundaries
                 //          The logic below ensures that the flags are set right for 2D
                 const bool is_tangent_to_PEC = (icomp != AMREX_SPACEDIM*idim);
-#elif (defined WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_1D_Z)
                 // For 1D : icomp=0 and icomp=1 (Ex and Ey are tangential to the z boundary)
                 //          The logic below ensures that the flags are set right for 1D
                 const bool is_tangent_to_PEC = (icomp != idim+2);
@@ -294,12 +294,12 @@ namespace
                     ? fbndry_lo[idim] == bc_type
                     : fbndry_hi[idim] == bc_type );
                 if (isPECBoundary) {
-#if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
+#if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
                     // For 2D : for icomp==1, (By in XZ, Btheta in RZ),
                     //          icomp=1 is not normal to x or z boundary
                     //          The logic below ensures that the flags are set right for 2D
                     const bool is_normal_to_PEC = (icomp == (AMREX_SPACEDIM*idim));
-#elif (defined WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_1D_Z)
                     // For 1D : icomp=0 and icomp=1 (Bx and By are not normal to the z boundary)
                     //          The logic below ensures that the flags are set right for 1D
                     const bool is_normal_to_PEC = (icomp == (idim+2));
@@ -394,7 +394,7 @@ namespace
             if (fabbox.contains(ijk_mirror)) {
                 // Note that this includes the cells on the boundary
                 amrex::Real rscale = 1._rt; // NOLINT(misc-const-correctness)
-#if (defined WARPX_DIM_RZ) || (defined WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
                 amrex::Real const rshift = (is_nodal_r ? 0.0_rt : 0.5_rt);
                 const amrex::Real rvalid = ijk_vec[idim] + rshift;
                 if (idim == 0 && iside == 1) {
@@ -414,7 +414,7 @@ namespace
                     amrex::IntVect ijk_guard = ijk_vec;
                     for (int ig = 0 ; ig < nguards ; ig++) {
                         ijk_guard[idim] += isign;
-#if (defined WARPX_DIM_RZ) || (defined WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
                         if (idim == 0 && iside == 1) {
                             rscale = (rvalid + ig + 1)/rvalid;
 #if defined(WARPX_DIM_RSPHERE)
@@ -485,7 +485,7 @@ namespace
             // This assumes that the nodal boundary cells are not included in the box.
             if (fabbox.contains(ijk_mirror)) {
                 auto inv_rscale = 1._rt; // NOLINT(misc-const-correctness)
-#if (defined WARPX_DIM_RZ) || (defined WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
                 if (idim == 0 && iside == 1) {
                     // Account for different dV at different radii
                     amrex::Real const rshift = (is_nodal_r ? 0.0_rt : 0.5_rt);
@@ -946,11 +946,11 @@ PEC::ApplyReflectiveBoundarytoJfield (
 
         for (int icomp = 0; icomp < 3; ++icomp) {
             // Set the psign value for each component of J for each direction
-#if (defined WARPX_DIM_1D_Z)
+#if defined(WARPX_DIM_1D_Z)
             // For 1D : icomp=0 and icomp=1 (Jx and Jy are tangential to the z boundary)
             //          The logic below ensures that the flags are set right for 1D
             is_tangent_to_bndy = (icomp != (idim+2));
-#elif (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
             // For 2D : for icomp==1, (Jy in XZ, Jtheta in RZ),
             //          icomp=1 is tangential to both x and z boundaries
             //          The logic below ensures that the flags are set right for 2D

--- a/Source/Diagnostics/ComputeDiagFunctors/EBCoveredFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/EBCoveredFunctor.cpp
@@ -27,7 +27,7 @@ EBCoveredFunctor::operator()(amrex::MultiFab& mf_dst, int dcomp, const int /*i_b
 
     if (EB::enabled()) {
         // If EB are enabled, fill the MultiFab with the volume fraction
-#if (defined AMREX_USE_EB)
+#if defined(AMREX_USE_EB)
         auto& warpx = WarpX::GetInstance();
         amrex::EBFArrayBoxFactory const& eb_fact = warpx.fieldEBFactory(m_lev);
         ablastr::coarsen::sample::Coarsen(mf_dst, eb_fact.getVolFrac(), dcomp, 0, nComp(), 0, m_crse_ratio);

--- a/Source/Diagnostics/ComputeDiagFunctors/RhoFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/RhoFunctor.cpp
@@ -1,7 +1,7 @@
 #include "RhoFunctor.H"
 
 #include "Diagnostics/ComputeDiagFunctors/ComputeDiagFunctor.H"
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
+#if defined(WARPX_DIM_RZ) && defined(WARPX_USE_FFT)
     #include "FieldSolver/SpectralSolver/SpectralFieldData.H"
     #include "FieldSolver/SpectralSolver/SpectralSolverRZ.H"
     #include "Utils/WarpXAlgorithmSelection.H"
@@ -60,7 +60,7 @@ RhoFunctor::operator() ( amrex::MultiFab& mf_dst, const int dcomp, const int /*i
     // apply the filtering if requested.
     warpx.ApplyFilterandSumBoundaryRho(m_lev, m_lev, *rho, 0, rho->nComp());
 
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
+#if defined(WARPX_DIM_RZ) && defined(WARPX_USE_FFT)
     // Apply k-space filtering when using the PSATD solver
     if (WarpX::electromagnetic_solver_id == ElectromagneticSolverAlgo::PSATD)
     {

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -1,7 +1,7 @@
 #include "FlushFormatCheckpoint.H"
 
 #include "BoundaryConditions/PML.H"
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
+#if defined(WARPX_DIM_RZ) && defined(WARPX_USE_FFT)
 #   include "BoundaryConditions/PML_RZ.H"
 #endif
 #include "Diagnostics/ParticleDiag/ParticleDiag.H"
@@ -177,7 +177,7 @@ FlushFormatCheckpoint::WriteToFile (
                     warpx.m_fields,
                     amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "pml"));
             }
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
+#if defined(WARPX_DIM_RZ) && defined(WARPX_USE_FFT)
             if (warpx.GetPML_RZ(lev)) {
                 warpx.GetPML_RZ(lev)->CheckPoint(
                     warpx.m_fields,

--- a/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
+++ b/Source/Diagnostics/ReducedDiags/BeamRelevant.cpp
@@ -76,7 +76,7 @@ BeamRelevant::BeamRelevant (const std::string& rd_name)
     //       12: beta-function x
     //       13: charge
     m_data.resize(14, 0.0_rt);
-#elif (defined WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_1D_Z)
     //       0 : mean z
     //   1,2,3 : mean px,py,pz
     //       4 : gamma
@@ -163,7 +163,7 @@ BeamRelevant::BeamRelevant (const std::string& rd_name)
             ofs << "[" << c++ << "]alpha_x()";        ofs << m_sep;
             ofs << "[" << c++ << "]beta_x(m)";        ofs << m_sep;
             ofs << "[" << c++ << "]charge(C)";        ofs << "\n";
-#elif (defined WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_1D_Z)
             int c = 0;
             ofs << "#";
             ofs << "[" << c++ << "]step()";           ofs << m_sep;
@@ -381,7 +381,7 @@ void BeamRelevant::ComputeDiags (int step)
         m_data[19] = (PhysConst::c * x_ms) / std::sqrt(x_ms*ux_ms-xux*xux);
         m_data[20] = (PhysConst::c * y_ms) / std::sqrt(y_ms*uy_ms-yuy*yuy);
         m_data[21] = charge;
-#elif (defined WARPX_DIM_XZ)
+#elif defined(WARPX_DIM_XZ)
         m_data[0]  = x_mean;
         m_data[1]  = z_mean;
         m_data[2]  = ux_mean * m;
@@ -416,7 +416,7 @@ void BeamRelevant::ComputeDiags (int step)
         m_data[12] = (PhysConst::c * x_ms) / std::sqrt(x_ms*ux_ms-xux*xux);
         m_data[13] = charge;
         amrex::ignore_unused(y_ms, yuy, z_mean, z_ms, zuz);
-#elif (defined WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_1D_Z)
         m_data[0]  = z_mean;
         m_data[1]  = ux_mean * m;
         m_data[2]  = uy_mean * m;

--- a/Source/Diagnostics/ReducedDiags/ChargeOnEB.cpp
+++ b/Source/Diagnostics/ReducedDiags/ChargeOnEB.cpp
@@ -36,12 +36,12 @@ ChargeOnEB::ChargeOnEB (const std::string& rd_name)
 : ReducedDiags{rd_name}
 {
     // Only 3D is working for now
-#if !(defined WARPX_DIM_3D)
+#if !defined(WARPX_DIM_3D)
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(false,
         "ChargeOnEB reduced diagnostics only works in 3D");
 #endif
 
-#if !(defined AMREX_USE_EB)
+#if !defined(AMREX_USE_EB)
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(false,
         "ChargeOnEB reduced diagnostics only works when compiling with EB support");
 #endif
@@ -95,7 +95,7 @@ void ChargeOnEB::ComputeDiags (const int step)
     if (!EB::enabled()) {
         throw std::runtime_error("ChargeOnEB::ComputeDiags only works when EBs are enabled at runtime");
     }
-#if ((defined WARPX_DIM_3D) && (defined AMREX_USE_EB))
+#if (defined(WARPX_DIM_3D) && defined(AMREX_USE_EB))
     using ablastr::fields::Direction;
 
     // get a reference to WarpX instance

--- a/Source/Diagnostics/ReducedDiags/ColliderRelevant.cpp
+++ b/Source/Diagnostics/ReducedDiags/ColliderRelevant.cpp
@@ -9,7 +9,7 @@
 
 #include "Diagnostics/ReducedDiags/ReducedDiags.H"
 #include "Fields.H"
-#if (defined WARPX_QED)
+#if defined(WARPX_QED)
 #   include "Particles/ElementaryProcess/QEDInternals/QedChiFunctions.H"
 #endif
 #include "Particles/Gather/FieldGather.H"
@@ -73,7 +73,7 @@ ColliderRelevant::ColliderRelevant (const std::string& rd_name)
         "Collider-relevant diagnostics must involve exactly two species");
 
     // RZ coordinate is not supported
-#if (defined WARPX_DIM_RZ) || (defined WARPX_DIM_RCYLINDER) || (defined WARPX_DIM_RSPHERE)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
     WARPX_ABORT_WITH_MESSAGE(
         "Collider-relevant diagnostics do not work in cylindrical and spherical geometry.");
 #endif
@@ -119,9 +119,9 @@ ColliderRelevant::ColliderRelevant (const std::string& rd_name)
         all_diag_names.push_back(name);
     };
 
-#if (defined WARPX_DIM_3D)
+#if defined(WARPX_DIM_3D)
     add_diag("dL_dt", "dL_dt(m^-2*s^-1)");
-#elif (defined WARPX_DIM_XZ)
+#elif defined(WARPX_DIM_XZ)
     add_diag("dL_dt", "dL_dt(m^-1*s^-1)");
 #else
     add_diag("dL_dt", "dL_dt(s^-1)");
@@ -138,7 +138,7 @@ ColliderRelevant::ColliderRelevant (const std::string& rd_name)
             add_diag("chiave_"+m_beam_name[i_s], "chi_ave_"+m_beam_name[i_s]+"()");
             add_diag("chimax_"+m_beam_name[i_s], "chi_max_"+m_beam_name[i_s]+"()");
         }
-#if (defined WARPX_DIM_3D)
+#if defined(WARPX_DIM_3D)
         add_diag("x_ave_"+m_beam_name[i_s], "x_ave_"+m_beam_name[i_s]+"(m)");
         add_diag("x_std_"+m_beam_name[i_s], "x_std_"+m_beam_name[i_s]+"(m)");
         add_diag("y_ave_"+m_beam_name[i_s], "y_ave_"+m_beam_name[i_s]+"(m)");
@@ -152,7 +152,7 @@ ColliderRelevant::ColliderRelevant (const std::string& rd_name)
         add_diag("thetay_max_"+m_beam_name[i_s], "theta_y_max_"+m_beam_name[i_s]+"(rad)");
         add_diag("thetay_std_"+m_beam_name[i_s], "theta_y_std_"+m_beam_name[i_s]+"(rad)");
 
-#elif (defined WARPX_DIM_XZ)
+#elif defined(WARPX_DIM_XZ)
         add_diag("x_ave_"+m_beam_name[i_s], "x_ave_"+m_beam_name[i_s]+"(m)");
         add_diag("x_std_"+m_beam_name[i_s], "x_std_"+m_beam_name[i_s]+"(m)");
         add_diag("thetax_min_"+m_beam_name[i_s], "theta_x_min_"+m_beam_name[i_s]+"(rad)");
@@ -190,7 +190,7 @@ ColliderRelevant::ColliderRelevant (const std::string& rd_name)
 
 void ColliderRelevant::ComputeDiags (int step)
 {
-#if (defined WARPX_DIM_RZ) || (defined WARPX_DIM_RCYLINDER) || (defined WARPX_DIM_RSPHERE)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
     amrex::ignore_unused(step);
 #else
 
@@ -416,7 +416,7 @@ void ColliderRelevant::ComputeDiags (int step)
         m_data[get_idx("thetay_std_"+m_beam_name[i_s])] = thetay_std;
 #endif
 
-#if (defined WARPX_QED)
+#if defined(WARPX_QED)
         // get mass
         amrex::ParticleReal m = myspc.getMass();
         const bool is_photon = myspc.AmIA<PhysicalSpecies::photon>();

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
@@ -70,7 +70,7 @@ DifferentialLuminosity::DifferentialLuminosity (const std::string& rd_name)
         "DifferentialLuminosity diagnostics must involve exactly two species");
 
     // RZ coordinate is not supported
-#if (defined WARPX_DIM_RZ) || (defined WARPX_DIM_RCYLINDER) || (defined WARPX_DIM_RSPHERE)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
     WARPX_ABORT_WITH_MESSAGE(
         "DifferentialLuminosity diagnostics do not work in cylindrical and spherical geometry.");
 #endif
@@ -120,7 +120,7 @@ DifferentialLuminosity::DifferentialLuminosity (const std::string& rd_name)
 
 void DifferentialLuminosity::ComputeDiags (int step)
 {
-#if (defined WARPX_DIM_RZ) || (defined WARPX_DIM_RCYLINDER) || (defined WARPX_DIM_RSPHERE)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
     amrex::ignore_unused(step);
 #else
     ABLASTR_PROFILE("DifferentialLuminosity::ComputeDiags");

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity2D.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity2D.cpp
@@ -70,7 +70,7 @@ DifferentialLuminosity2D::DifferentialLuminosity2D (const std::string& rd_name)
 : ReducedDiags{rd_name}
 {
     // RZ coordinate is not supported
-#if (defined WARPX_DIM_RZ)
+#if defined(WARPX_DIM_RZ)
     WARPX_ABORT_WITH_MESSAGE(
         "DifferentialLuminosity2D diagnostics does not work in RZ geometry.");
 #endif

--- a/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldMaximum.cpp
@@ -47,7 +47,7 @@ FieldMaximum::FieldMaximum (const std::string& rd_name)
 : ReducedDiags{rd_name}
 {
     // Non-Cartesian coordinates not working
-#if (defined WARPX_DIM_RZ)
+#if defined(WARPX_DIM_RZ)
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(false,
         "FieldMaximum reduced diagnostics does not work for RZ coordinate.");
 #endif

--- a/Source/Diagnostics/ReducedDiags/FieldMomentum.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldMomentum.cpp
@@ -45,7 +45,7 @@ FieldMomentum::FieldMomentum (const std::string& rd_name)
     : ReducedDiags{rd_name}
 {
     // RZ coordinate is not working
-#if (defined WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
         WARPX_ABORT_WITH_MESSAGE(
             "FieldMomentum reduced diagnostics not implemented in cylindrical or spherical geometry");
 #endif

--- a/Source/Diagnostics/ReducedDiags/FieldPoyntingFlux.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldPoyntingFlux.cpp
@@ -185,10 +185,10 @@ void FieldPoyntingFlux::ComputePoyntingFlux ()
 
         // Only calculate the ExB term that is normal to the surface.
         // normal_dir is the normal direction relative to the WarpX coordinates
-#if (defined WARPX_DIM_XZ) || (defined WARPX_DIM_RZ)
+#if defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
         // For 2D : it is either 0, or 2
         int const normal_dir = 2*face_dir;
-#elif (defined WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_1D_Z)
         // For 1D : it is always 2
         int const normal_dir = 2;
 #else

--- a/Source/Diagnostics/ReducedDiags/FieldReduction.cpp
+++ b/Source/Diagnostics/ReducedDiags/FieldReduction.cpp
@@ -28,7 +28,7 @@ FieldReduction::FieldReduction (const std::string& rd_name)
     using namespace amrex::literals;
 
     // Non-Cartesian coordinates not working
-#if (defined WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(false,
         "FieldReduction reduced diagnostics not implemented for cylindrical and spherical coordinates.");
 #endif

--- a/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleExtrema.cpp
@@ -8,7 +8,7 @@
 #include "ParticleExtrema.H"
 
 #include "Diagnostics/ReducedDiags/ReducedDiags.H"
-#if (defined WARPX_QED)
+#if defined(WARPX_QED)
 #   include "Particles/ElementaryProcess/QEDInternals/QedChiFunctions.H"
 #endif
 #include "Fields.H"
@@ -107,10 +107,10 @@ ParticleExtrema::ParticleExtrema (const std::string& rd_name)
         add_diag("gmin", "gmin()");
         add_diag("gmax", "gmax()");
 
-#if (defined WARPX_DIM_3D)
+#if defined(WARPX_DIM_3D)
         add_diag("wmin", "wmin()");
         add_diag("wmax", "wmax()");
-#elif (defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ))
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
         add_diag("wmin", "wmin(1/m)");
         add_diag("wmax", "wmax(1/m)");
 #else
@@ -240,7 +240,7 @@ void ParticleExtrema::ComputeDiags (int step)
         amrex::ParallelDescriptor::ReduceRealMin({xmin,ymin,zmin,uxmin,uymin,uzmin,gmin,wmin});
         amrex::ParallelDescriptor::ReduceRealMax({xmax,ymax,zmax,uxmax,uymax,uzmax,gmax,wmax});
 
-#if (defined WARPX_QED)
+#if defined(WARPX_QED)
         // get number of level (int)
         const auto level_number = WarpX::GetInstance().finestLevel();
 
@@ -385,7 +385,7 @@ void ParticleExtrema::ComputeDiags (int step)
         m_data[get_idx("gmax")] = gmax;
         m_data[get_idx("wmin")] = wmin;
         m_data[get_idx("wmax")] = wmax;
-#if (defined WARPX_QED)
+#if defined(WARPX_QED)
         if (myspc.DoQED())
         {
             m_data[get_idx("chimin")] = chimin_f;

--- a/Source/Diagnostics/ReducedDiags/RhoMaximum.cpp
+++ b/Source/Diagnostics/ReducedDiags/RhoMaximum.cpp
@@ -33,7 +33,7 @@ RhoMaximum::RhoMaximum (const std::string& rd_name)
 : ReducedDiags{rd_name}
 {
     // RZ coordinate is not working
-#if (defined WARPX_DIM_RZ)
+#if defined(WARPX_DIM_RZ)
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(false,
         "RhoMaximum reduced diagnostics does not work for RZ coordinate.");
 #endif

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -12,7 +12,7 @@
 
 
 #include "BoundaryConditions/PML.H"
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
+#if defined(WARPX_DIM_RZ) && defined(WARPX_USE_FFT)
 #    include "BoundaryConditions/PML_RZ.H"
 #endif
 #include "Diagnostics/Diagnostics.H"
@@ -407,7 +407,7 @@ WarpX::InitFromCheckpoint ()
             if (pml[lev]) {
                 pml[lev]->Restart(m_fields, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "pml"));
             }
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
+#if defined(WARPX_DIM_RZ) && defined(WARPX_USE_FFT)
             if (pml_rz[lev]) {
                 pml_rz[lev]->Restart(m_fields, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "pml_rz"));
             }

--- a/Source/EmbeddedBoundary/DistanceToEB.H
+++ b/Source/EmbeddedBoundary/DistanceToEB.H
@@ -47,7 +47,7 @@ amrex::RealVect interp_normal (int i, int j, int k, const amrex::Real W[AMREX_SP
 {
     using namespace amrex::literals;
 
-#if (defined WARPX_DIM_3D)
+#if defined(WARPX_DIM_3D)
     amrex::RealVect normal{0.0, 0.0, 0.0};
     for (int iic = 0; iic < 2; ++iic) {
         for (int kk = 0; kk < 2; ++kk) {

--- a/Source/EmbeddedBoundary/ParticleScraper.H
+++ b/Source/EmbeddedBoundary/ParticleScraper.H
@@ -196,17 +196,17 @@ scrapeParticlesAtEB (PC& pc, ablastr::fields::MultiLevelScalarField const& dista
                     amrex::RealVect normal = DistanceToEB::interp_normal(i, j, k, W, ic, jc, kc, Wc, phi, dxi);
                     DistanceToEB::normalize(normal);
                     amrex::RealVect pos;
-#if (defined WARPX_DIM_3D)
+#if defined(WARPX_DIM_3D)
                     pos[0] = xp;
                     pos[1] = yp;
                     pos[2] = zp;
-#elif (defined WARPX_DIM_XZ)
+#elif defined(WARPX_DIM_XZ)
                     pos[0] = xp;
                     pos[1] = zp;
-#elif (defined WARPX_DIM_RZ)
+#elif defined(WARPX_DIM_RZ)
                     pos[0] = std::sqrt(xp*xp + yp*yp);
                     pos[1] = zp;
-#elif (defined WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_1D_Z)
                     pos[0] = zp;
 #endif
                     f(ptd, ip, pos, normal, engine);

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianCKCAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianCKCAlgorithm.H
@@ -105,9 +105,9 @@ struct CartesianCKCAlgorithm {
      * Compute the maximum timestep, for which the scheme remains stable
      * (Courant-Friedrichs-Levy limit) */
     static amrex::Real ComputeMaxDt ( amrex::Real const * const dx ) {
-#if (defined WARPX_DIM_1D_Z)
+#if defined(WARPX_DIM_1D_Z)
             amrex::Real const delta_t = dx[0]/PhysConst::c;
-#elif (defined WARPX_DIM_XZ)
+#elif defined(WARPX_DIM_XZ)
             // - In Cartesian 2D geometry: determined by the minimum cell size in all direction
             amrex::Real const delta_t = std::min( dx[0], dx[1] )/PhysConst::c;
 #else
@@ -153,11 +153,11 @@ struct CartesianCKCAlgorithm {
                       +  F(i+1,j-1,k+1,ncomp) - F(i  ,j-1,k+1,ncomp)
                       +  F(i+1,j+1,k-1,ncomp) - F(i  ,j+1,k-1,ncomp)
                       +  F(i+1,j-1,k-1,ncomp) - F(i  ,j-1,k-1,ncomp));
-#elif (defined WARPX_DIM_XZ)
+#elif defined(WARPX_DIM_XZ)
         return alphax * (F(i+1,j  ,k  ,ncomp) - F(i,  j,  k  ,ncomp))
              + betaxz * (F(i+1,j+1,k  ,ncomp) - F(i  ,j+1,k  ,ncomp)
                       +  F(i+1,j-1,k  ,ncomp) - F(i  ,j-1,k  ,ncomp));
-#elif (defined WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_1D_Z)
         amrex::ignore_unused(F, coefs_x, i, j, k, ncomp);
         return 0._rt; // 1D Cartesian: derivative along x is 0
 #endif
@@ -173,7 +173,7 @@ struct CartesianCKCAlgorithm {
         int const i, int const j, int const k, int const ncomp=0 ) {
 
         using namespace amrex;
-#if (defined WARPX_DIM_1D_Z)
+#if defined(WARPX_DIM_1D_Z)
         amrex::ignore_unused(F, coefs_x, i, j, k, ncomp);
         return 0._rt; // 1D Cartesian: derivative along x is 0
 #else
@@ -206,7 +206,7 @@ struct CartesianCKCAlgorithm {
                       +  F(i-1,j+1,k+1,ncomp) - F(i-1,j  ,k+1,ncomp)
                       +  F(i+1,j+1,k-1,ncomp) - F(i+1,j  ,k-1,ncomp)
                        +  F(i-1,j+1,k-1,ncomp) - F(i-1,j  ,k-1,ncomp));
-#elif (defined WARPX_DIM_XZ || WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_1D_Z)
         amrex::ignore_unused(F, coefs_y, n_coefs_y,
             i, j, k, ncomp);
         return 0._rt; // 1D and 2D Cartesian: derivative along y is 0
@@ -230,7 +230,7 @@ struct CartesianCKCAlgorithm {
         amrex::Real const inv_dy = coefs_y[0];
         amrex::ignore_unused(n_coefs_y);
         return inv_dy*( F(i,j,k,ncomp) - F(i,j-1,k,ncomp) );
-#elif (defined WARPX_DIM_XZ || WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_1D_Z)
         amrex::ignore_unused(F, coefs_y, n_coefs_y,
             i, j, k, ncomp);
         return 0._rt; // 2D Cartesian: derivative along y is 0
@@ -270,11 +270,11 @@ struct CartesianCKCAlgorithm {
                       +  F(i-1,j+1,k+1,ncomp) - F(i-1,j+1,k  ,ncomp)
                       +  F(i+1,j-1,k+1,ncomp) - F(i+1,j-1,k  ,ncomp)
                       +  F(i-1,j-1,k+1,ncomp) - F(i-1,j-1,k  ,ncomp));
-#elif (defined WARPX_DIM_XZ)
+#elif defined(WARPX_DIM_XZ)
         return alphaz * (F(i  ,j+1,k  ,ncomp) - F(i  ,j  ,k  ,ncomp))
              + betazx * (F(i+1,j+1,k  ,ncomp) - F(i+1,j  ,k  ,ncomp)
                       +  F(i-1,j+1,k  ,ncomp) - F(i-1,j  ,k  ,ncomp));
-#elif (defined WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_1D_Z)
         return alphaz * (F(i+1  ,j,k  ,ncomp) - F(i  ,j  ,k  ,ncomp));
 #endif
     }
@@ -291,9 +291,9 @@ struct CartesianCKCAlgorithm {
         amrex::Real const inv_dz = coefs_z[0];
 #if defined WARPX_DIM_3D
         return inv_dz*( F(i,j,k,ncomp) - F(i,j,k-1,ncomp) );
-#elif (defined WARPX_DIM_XZ)
+#elif defined(WARPX_DIM_XZ)
         return inv_dz*( F(i,j,k,ncomp) - F(i,j-1,k,ncomp) );
-#elif (defined WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_1D_Z)
         return inv_dz*( F(i,j,k,ncomp) - F(i-1,j,k,ncomp) );
 #endif
     }

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianNodalAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianNodalAlgorithm.H
@@ -74,7 +74,7 @@ struct CartesianNodalAlgorithm {
         int const i, int const j, int const k, int const ncomp=0 ) {
 
         using namespace amrex;
-#if (defined WARPX_DIM_1D_Z)
+#if defined(WARPX_DIM_1D_Z)
         ignore_unused(i, j, k, coefs_x, ncomp, F);
         return 0._rt; // 1D Cartesian: derivative along x is 0
 #else
@@ -94,7 +94,7 @@ struct CartesianNodalAlgorithm {
         int const i, int const j, int const k, int const ncomp=0 ) {
 
         using namespace amrex;
-#if (defined WARPX_DIM_1D_Z)
+#if defined(WARPX_DIM_1D_Z)
         ignore_unused(i, j, k, coefs_x, n_coefs_x, ncomp, F);
         return 0._rt; // 1D Cartesian: derivative along x is 0
 #else
@@ -113,7 +113,7 @@ struct CartesianNodalAlgorithm {
         int const i, int const j, int const k, int const ncomp=0 ) {
 
         using namespace amrex;
-#if (defined WARPX_DIM_1D_Z)
+#if defined(WARPX_DIM_1D_Z)
         amrex::ignore_unused(F, coefs_x, i, j, k, ncomp);
         return 0._rt; // 1D Cartesian: derivative along x is 0
 #else
@@ -169,7 +169,7 @@ struct CartesianNodalAlgorithm {
 #if defined WARPX_DIM_3D
         Real const inv_dy2 = coefs_y[0]*coefs_y[0];
         return inv_dy2*( F(i,j-1,k,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i,j+1,k,ncomp) );
-#elif (defined WARPX_DIM_XZ || WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_1D_Z)
         amrex::ignore_unused(F, coefs_y, i, j, k, ncomp);
         return 0._rt; // 1D and 2D Cartesian: derivative along y is 0
 #endif
@@ -189,9 +189,9 @@ struct CartesianNodalAlgorithm {
         Real const inv_dz = coefs_z[0];
 #if defined WARPX_DIM_3D
         return 0.5_rt*inv_dz*( F(i,j,k+1,ncomp) - F(i,j,k-1,ncomp) );
-#elif (defined WARPX_DIM_XZ)
+#elif defined(WARPX_DIM_XZ)
         return 0.5_rt*inv_dz*( F(i,j+1,k,ncomp) - F(i,j-1,k,ncomp) );
-#elif (defined WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_1D_Z)
         return 0.5_rt*inv_dz*( F(i+1,j,k,ncomp) - F(i-1,j,k,ncomp) );
 #endif
     }
@@ -224,9 +224,9 @@ struct CartesianNodalAlgorithm {
         Real const inv_dz2 = coefs_z[0]*coefs_z[0];
 #if defined WARPX_DIM_3D
         return inv_dz2*( F(i,j,k-1,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i,j,k+1,ncomp) );
-#elif (defined WARPX_DIM_XZ)
+#elif defined(WARPX_DIM_XZ)
         return inv_dz2*( F(i,j-1,k,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i,j+1,k,ncomp) );
-#elif (defined WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_1D_Z)
         return inv_dz2*( F(i-1,j,k,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i+1,j,k,ncomp) );
 #endif
     }

--- a/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/FiniteDifferenceAlgorithms/CartesianYeeAlgorithm.H
@@ -72,7 +72,7 @@ struct CartesianYeeAlgorithm {
         int const i, int const j, int const k, int const ncomp=0 ) {
 
         using namespace amrex;
-#if (defined WARPX_DIM_1D_Z)
+#if defined(WARPX_DIM_1D_Z)
         amrex::ignore_unused(F, coefs_x, i, j, k, ncomp);
         return 0._rt; // 1D Cartesian: derivative along x is 0
 #else
@@ -91,7 +91,7 @@ struct CartesianYeeAlgorithm {
         int const i, int const j, int const k, int const ncomp=0 ) {
 
         using namespace amrex;
-#if (defined WARPX_DIM_1D_Z)
+#if defined(WARPX_DIM_1D_Z)
         amrex::ignore_unused(F, coefs_x, i, j, k, ncomp);
         return 0._rt; // 1D Cartesian: derivative along x is 0
 #else
@@ -110,7 +110,7 @@ struct CartesianYeeAlgorithm {
         int const i, int const j, int const k, int const ncomp=0 ) {
 
         using namespace amrex;
-#if (defined WARPX_DIM_1D_Z)
+#if defined(WARPX_DIM_1D_Z)
         amrex::ignore_unused(F, coefs_x, i, j, k, ncomp);
         return 0._rt; // 1D Cartesian: derivative along x is 0
 #else
@@ -132,7 +132,7 @@ struct CartesianYeeAlgorithm {
         Real const inv_dy = coefs_y[0];
         amrex::ignore_unused(n_coefs_y);
         return inv_dy*( F(i,j+1,k,ncomp) - F(i,j,k,ncomp) );
-#elif (defined WARPX_DIM_XZ || WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_1D_Z)
         amrex::ignore_unused(F, coefs_y, n_coefs_y,
             i, j, k, ncomp);
         return 0._rt; // 1D and 2D Cartesian: derivative along y is 0
@@ -156,7 +156,7 @@ struct CartesianYeeAlgorithm {
         Real const inv_dy = coefs_y[0];
         amrex::ignore_unused(n_coefs_y);
         return inv_dy*( F(i,j,k,ncomp) - F(i,j-1,k,ncomp) );
-#elif (defined WARPX_DIM_XZ || WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_1D_Z)
         amrex::ignore_unused(F, coefs_y, n_coefs_y,
             i, j, k, ncomp);
         return 0._rt; // 1D and 2D Cartesian: derivative along y is 0
@@ -179,7 +179,7 @@ struct CartesianYeeAlgorithm {
 #if defined WARPX_DIM_3D
         Real const inv_dy2 = coefs_y[0]*coefs_y[0];
         return inv_dy2*( F(i,j-1,k,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i,j+1,k,ncomp) );
-#elif (defined WARPX_DIM_XZ || WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_1D_Z)
         amrex::ignore_unused(F, coefs_y, i, j, k, ncomp);
         return 0._rt; // 1D and 2D Cartesian: derivative along y is 0
 #endif
@@ -197,9 +197,9 @@ struct CartesianYeeAlgorithm {
         Real const inv_dz = coefs_z[0];
 #if defined WARPX_DIM_3D
         return inv_dz*( F(i,j,k+1,ncomp) - F(i,j,k,ncomp) );
-#elif (defined WARPX_DIM_XZ)
+#elif defined(WARPX_DIM_XZ)
         return inv_dz*( F(i,j+1,k,ncomp) - F(i,j,k,ncomp) );
-#elif (defined WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_1D_Z)
         return inv_dz*( F(i+1,j,k,ncomp) - F(i,j,k,ncomp) );
 #endif
     }
@@ -217,9 +217,9 @@ struct CartesianYeeAlgorithm {
         Real const inv_dz = coefs_z[0];
 #if defined WARPX_DIM_3D
         return inv_dz*( F(i,j,k,ncomp) - F(i,j,k-1,ncomp) );
-#elif (defined WARPX_DIM_XZ)
+#elif defined(WARPX_DIM_XZ)
         return inv_dz*( F(i,j,k,ncomp) - F(i,j-1,k,ncomp) );
-#elif (defined WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_1D_Z)
         return inv_dz*( F(i,j,k,ncomp) - F(i-1,j,k,ncomp) );
 #endif
     }
@@ -237,9 +237,9 @@ struct CartesianYeeAlgorithm {
         Real const inv_dz2 = coefs_z[0]*coefs_z[0];
 #if defined WARPX_DIM_3D
         return inv_dz2*( F(i,j,k-1,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i,j,k+1,ncomp) );
-#elif (defined WARPX_DIM_XZ)
+#elif defined(WARPX_DIM_XZ)
         return inv_dz2*( F(i,j-1,k,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i,j+1,k,ncomp) );
-#elif (defined WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_1D_Z)
         return inv_dz2*( F(i-1,j,k,ncomp) - 2._rt*F(i,j,k,ncomp) + F(i+1,j,k,ncomp) );
 #endif
     }

--- a/Source/Initialization/InjectorPosition.H
+++ b/Source/Initialization/InjectorPosition.H
@@ -41,12 +41,12 @@ struct InjectorPositionRandomPlane
                         amrex::RandomEngine const& engine) const noexcept
     {
         using namespace amrex::literals;
-#if ((defined WARPX_DIM_3D) || (defined WARPX_DIM_RZ) || (defined WARPX_DIM_RCYLINDER) || (defined WARPX_DIM_RSPHERE))
+#if (defined(WARPX_DIM_3D) || defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE))
         // In RZ, the 3 components of the `XDim3` vector below correspond to r, theta, z respectively
         if (dir == 0)  { return amrex::XDim3{0._rt, amrex::Random(engine), amrex::Random(engine)}; }
         if (dir == 1)  { return amrex::XDim3{amrex::Random(engine), 0._rt, amrex::Random(engine)}; }
         else           { return amrex::XDim3{amrex::Random(engine), amrex::Random(engine), 0._rt}; }
-#elif (defined(WARPX_DIM_XZ))
+#elif defined(WARPX_DIM_XZ)
         // In 2D, the 2 first components of the `XDim3` vector below correspond to x and z
         if (dir == 0) { return amrex::XDim3{0._rt, amrex::Random(engine), 0._rt}; }
         if (dir == 1) { return amrex::XDim3{amrex::Random(engine), amrex::Random(engine), 0._rt}; }
@@ -81,27 +81,27 @@ struct InjectorPositionRegular
     {
         using namespace amrex;
 
-#if (defined WARPX_DIM_3D)
+#if defined(WARPX_DIM_3D)
         int const nx = ref_fac[0]*ppc.x;
         int const ny = ref_fac[1]*ppc.y;
         int const nz = ref_fac[2]*ppc.z;
-#elif (defined WARPX_DIM_RZ)
+#elif defined(WARPX_DIM_RZ)
         int const nx = ref_fac[0]*ppc.x;
         int const ny = ref_fac[1]*ppc.y;
         int const nz = ppc.z; // Number of particles in theta ; no refinement
-#elif (defined WARPX_DIM_RCYLINDER)
+#elif defined(WARPX_DIM_RCYLINDER)
         int const nx = ref_fac[0]*ppc.x;
         int const ny = ppc.y;
         int const nz = 1;
-#elif (defined WARPX_DIM_RSPHERE)
+#elif defined(WARPX_DIM_RSPHERE)
         int const nx = ref_fac[0]*ppc.x;
         int const ny = ppc.y; // Number of particles in theta ; no refinement
         int const nz = ppc.z; // Number of particles in phi ; no refinement
-#elif (defined WARPX_DIM_XZ)
+#elif defined(WARPX_DIM_XZ)
         int const nx = ref_fac[0]*ppc.x;
         int const ny = ref_fac[1]*ppc.y;
         int const nz = 1;
-#elif (defined WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_1D_Z)
         int const nx = ref_fac[0]*ppc.x;
         int const ny = 1;
         int const nz = 1;

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -11,7 +11,7 @@
 #include "WarpX.H"
 
 #include "BoundaryConditions/PML.H"
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
+#if defined(WARPX_DIM_RZ) && defined(WARPX_USE_FFT)
 #   include "BoundaryConditions/PML_RZ.H"
 #endif
 #include "Diagnostics/MultiDiagnostics.H"
@@ -427,7 +427,7 @@ WarpX::PostProcessBaseGrids (BoxArray& ba0) const
                 const auto x = 0.0_rt;
                 const auto y = 0.0_rt;
                 const auto z = problo[0] + (i+Real(0.5))*dx[0];
-#elif (defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ))
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
                 const auto x = problo[0] + (i+Real(0.5))*dx[0];
                 const auto y = 0.0_rt;
                 const auto z = problo[1] + (j+Real(0.5))*dx[1];
@@ -1033,7 +1033,7 @@ WarpX::InitPML ()
     if (do_pml)
     {
         bool const eb_enabled = EB::enabled();
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
+#if defined(WARPX_DIM_RZ) && defined(WARPX_USE_FFT)
         do_pml_Lo[0][0] = 0; // no PML at r=0, in cylindrical geometry
         pml_rz[0] = std::make_unique<PML_RZ>(0, boxArray(0), DistributionMap(0), &Geom(0), m_fields, pml_ncell, do_pml_in_domain);
 #else

--- a/Source/Laser/LaserProfilesImpl/LaserProfileFromFile.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileFromFile.cpp
@@ -255,7 +255,7 @@ WarpXLaserProfiles::FromFileLaserProfile::parse_binary_file (const std::string& 
         if(!inp) { WARPX_ABORT_WITH_MESSAGE("Failed to read sizes from binary file"); }
         if(m_params.nt <= 1) { WARPX_ABORT_WITH_MESSAGE("nt in binary file must be >=2"); }
         if(m_params.nx <= 1) { WARPX_ABORT_WITH_MESSAGE("nx in binary file must be >=2"); }
-#if (defined(WARPX_DIM_3D) || (defined WARPX_DIM_RZ))
+#if (defined(WARPX_DIM_3D) || defined(WARPX_DIM_RZ))
         if(m_params.ny <= 1) { WARPX_ABORT_WITH_MESSAGE("ny in binary file must be >=2 in 3D"); }
 #elif defined(WARPX_DIM_XZ)
         if(m_params.ny != 1) { WARPX_ABORT_WITH_MESSAGE("ny in binary file must be 1 in 2D"); }
@@ -264,7 +264,7 @@ WarpXLaserProfiles::FromFileLaserProfile::parse_binary_file (const std::string& 
         Vector<double> dbuf_t, dbuf_x, dbuf_y;
         dbuf_t.resize(2);
         dbuf_x.resize(2);
-#if (defined(WARPX_DIM_3D) || (defined WARPX_DIM_RZ))
+#if (defined(WARPX_DIM_3D) || defined(WARPX_DIM_RZ))
         dbuf_y.resize(2);
 #elif defined(WARPX_DIM_XZ)
         dbuf_y.resize(1);
@@ -281,7 +281,7 @@ WarpXLaserProfiles::FromFileLaserProfile::parse_binary_file (const std::string& 
         m_params.t_max = static_cast<amrex::Real>(dbuf_t[1]);
         m_params.x_min = static_cast<amrex::Real>(dbuf_x[0]);
         m_params.x_max = static_cast<amrex::Real>(dbuf_x[1]);
-#if (defined(WARPX_DIM_3D) || (defined WARPX_DIM_RZ))
+#if (defined(WARPX_DIM_3D) || defined(WARPX_DIM_RZ))
         m_params.y_min = static_cast<amrex::Real>(dbuf_y[0]);
         m_params.y_max = static_cast<amrex::Real>(dbuf_y[1]);
 #endif
@@ -386,7 +386,7 @@ WarpXLaserProfiles::FromFileLaserProfile::read_binary_data_t_chunk (int t_begin,
         std::ifstream inp(m_params.binary_file_name, std::ios::binary);
         if(!inp) { WARPX_ABORT_WITH_MESSAGE("Failed to open binary file"); }
         inp.exceptions(std::ios_base::failbit | std::ios_base::badbit);
-#if (defined(WARPX_DIM_3D))
+#if defined(WARPX_DIM_3D)
         auto skip_amount = 1 +
         3*sizeof(uint32_t) +
         2*sizeof(double) +
@@ -622,7 +622,7 @@ WarpXLaserProfiles::FromFileLaserProfile::internal_fill_amplitude_uniform_binary
     const auto tmp_e_max = m_common_params.e_max;
     const auto tmp_x_min = m_params.x_min;
     const auto tmp_x_max = m_params.x_max;
-#if (defined(WARPX_DIM_3D) || (defined WARPX_DIM_RZ))
+#if (defined(WARPX_DIM_3D) || defined(WARPX_DIM_RZ))
     const auto tmp_y_min = m_params.y_min;
     const auto tmp_y_max = m_params.y_max;
     const auto tmp_ny = m_params.ny;
@@ -638,7 +638,7 @@ WarpXLaserProfiles::FromFileLaserProfile::internal_fill_amplitude_uniform_binary
         (m_params.t_max-m_params.t_min)/(m_params.nt-1) +
         m_params.t_min;
 
-#if (defined WARPX_DIM_1D_Z) || (defined WARPX_DIM_RCYLINDER) || (defined WARPX_DIM_RSPHERE)
+#if defined(WARPX_DIM_1D_Z) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
     WARPX_ABORT_WITH_MESSAGE("WarpXLaserProfiles::FromFileLaserProfile Not implemented for 1D");
 #endif
 
@@ -651,7 +651,7 @@ WarpXLaserProfiles::FromFileLaserProfile::internal_fill_amplitude_uniform_binary
             amplitude[i] = 0.0_rt;
             return;
         }
-#if (defined(WARPX_DIM_3D) || (defined WARPX_DIM_RZ))
+#if (defined(WARPX_DIM_3D) || defined(WARPX_DIM_RZ))
         if (Yp[i] <= tmp_y_min || Yp[i] >= tmp_y_max){
             amplitude[i] = 0.0_rt;
             return;
@@ -668,7 +668,7 @@ WarpXLaserProfiles::FromFileLaserProfile::internal_fill_amplitude_uniform_binary
         const auto x_1 =
             idx_x_right*(tmp_x_max-tmp_x_min)/(tmp_nx-1) + tmp_x_min;
 
-#if (defined(WARPX_DIM_3D) || (defined WARPX_DIM_RZ))
+#if (defined(WARPX_DIM_3D) || defined(WARPX_DIM_RZ))
         //Find indices and coordinates along y
         const int temp_idx_y_right = static_cast<int>(
             std::ceil((tmp_ny-1)*(Yp[i]- tmp_y_min)/(tmp_y_max-tmp_y_min)));

--- a/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
+++ b/Source/Laser/LaserProfilesImpl/LaserProfileGaussian.cpp
@@ -128,7 +128,7 @@ WarpXLaserProfiles::GaussianLaserProfile::fill_amplitude (
     // Because diffract_factor is a complex, the code below takes into
     // account the impact of the dimensionality on both the Gouy phase
     // and the amplitude of the laser
-#if (defined(WARPX_DIM_3D) || (defined WARPX_DIM_RZ))
+#if (defined(WARPX_DIM_3D) || defined(WARPX_DIM_RZ))
     const Complex prefactor = t_prefactor / diffract_factor;
 #elif defined(WARPX_DIM_XZ)
     const Complex prefactor = t_prefactor / amrex::sqrt(diffract_factor);

--- a/Source/Parallelization/WarpXComm.cpp
+++ b/Source/Parallelization/WarpXComm.cpp
@@ -9,7 +9,7 @@
 #include "WarpX.H"
 
 #include "BoundaryConditions/PML.H"
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
+#if defined(WARPX_DIM_RZ) && defined(WARPX_USE_FFT)
 #   include "BoundaryConditions/PML_RZ.H"
 #endif
 #include "Fields.H"
@@ -799,7 +799,7 @@ WarpX::FillBoundaryE (const int lev, const PatchType patch_type, const amrex::In
             pml[lev]->FillBoundary(mf_pml, patch_type, nodal_sync);
         }
 
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
+#if defined(WARPX_DIM_RZ) && defined(WARPX_USE_FFT)
         if (pml_rz[lev])
         {
             pml_rz[lev]->FillBoundaryE(m_fields, patch_type, do_single_precision_comms, nodal_sync);
@@ -881,7 +881,7 @@ WarpX::FillBoundaryB (const int lev, const PatchType patch_type, const amrex::In
             pml[lev]->FillBoundary(mf_pml, patch_type, nodal_sync);
         }
 
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
+#if defined(WARPX_DIM_RZ) && defined(WARPX_USE_FFT)
         if (pml_rz[lev])
         {
             pml_rz[lev]->FillBoundaryB(m_fields, patch_type, do_single_precision_comms, nodal_sync);

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -131,7 +131,7 @@ struct FindEmbeddedBoundaryIntersection {
         amrex::RealVect normal = DistanceToEB::interp_normal(i, j, k, W, ic, jc, kc, Wc, phiarr, dxi);
         DistanceToEB::normalize(normal);
 
-#if (defined WARPX_DIM_3D)
+#if defined(WARPX_DIM_3D)
         dst.m_rdata[PIdx::x][dst_i] = x_temp;
         dst.m_rdata[PIdx::y][dst_i] = y_temp;
         dst.m_rdata[PIdx::z][dst_i] = z_temp;
@@ -139,7 +139,7 @@ struct FindEmbeddedBoundaryIntersection {
         dst.m_runtime_rdata[m_normal_index][dst_i] = normal[0];
         dst.m_runtime_rdata[m_normal_index+1][dst_i] = normal[1];
         dst.m_runtime_rdata[m_normal_index+2][dst_i] = normal[2];
-#elif (defined WARPX_DIM_XZ)
+#elif defined(WARPX_DIM_XZ)
         dst.m_rdata[PIdx::x][dst_i] = x_temp;
         dst.m_rdata[PIdx::z][dst_i] = z_temp;
         amrex::ignore_unused(y_temp);
@@ -147,7 +147,7 @@ struct FindEmbeddedBoundaryIntersection {
         dst.m_runtime_rdata[m_normal_index][dst_i] = normal[0];
         dst.m_runtime_rdata[m_normal_index+1][dst_i] = 0.0;
         dst.m_runtime_rdata[m_normal_index+2][dst_i] = normal[1];
-#elif (defined WARPX_DIM_RZ)
+#elif defined(WARPX_DIM_RZ)
         dst.m_rdata[PIdx::r][dst_i] = std::sqrt(x_temp*x_temp + y_temp*y_temp);
         dst.m_rdata[PIdx::z][dst_i] = z_temp;
         dst.m_rdata[PIdx::theta][dst_i] = std::atan2(y_temp, x_temp);
@@ -156,14 +156,14 @@ struct FindEmbeddedBoundaryIntersection {
         dst.m_runtime_rdata[m_normal_index][dst_i] = normal[0]*std::cos(theta);
         dst.m_runtime_rdata[m_normal_index+1][dst_i] = normal[0]*std::sin(theta);
         dst.m_runtime_rdata[m_normal_index+2][dst_i] = normal[1];
-#elif (defined WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_1D_Z)
         dst.m_rdata[PIdx::z][dst_i] = z_temp;
         amrex::ignore_unused(x_temp, y_temp);
         //normal not defined
         dst.m_runtime_rdata[m_normal_index][dst_i] = 0.0;
         dst.m_runtime_rdata[m_normal_index+1][dst_i] = 0.0;
         dst.m_runtime_rdata[m_normal_index+2][dst_i] = 0.0;
-#elif (defined WARPX_DIM_RCYLINDER) || (defined WARPX_DIM_RSPHERE)
+#elif defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
 #if defined(WARPX_DIM_RCYLINDER)
         amrex::ignore_unused(z_temp);
         dst.m_rdata[PIdx::r][dst_i] = std::sqrt(x_temp*x_temp + y_temp*y_temp);
@@ -244,7 +244,7 @@ ParticleBoundaryBuffer::ParticleBoundaryBuffer ()
 #if defined(WARPX_DIM_1D_Z)
     constexpr auto idx_zlo = 0;
     constexpr auto idx_zhi = 1;
-#elif (defined WARPX_DIM_RCYLINDER) || (defined WARPX_DIM_RSPHERE)
+#elif defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
     constexpr auto idx_xlo = 0;
     constexpr auto idx_xhi = 1;
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
@@ -269,7 +269,7 @@ ParticleBoundaryBuffer::ParticleBoundaryBuffer ()
 #if defined(WARPX_DIM_1D_Z)
         pp_species.query("save_particles_at_zlo", m_do_boundary_buffer[idx_zlo][ispecies]);
         pp_species.query("save_particles_at_zhi", m_do_boundary_buffer[idx_zhi][ispecies]);
-#elif (defined WARPX_DIM_RCYLINDER) || (defined WARPX_DIM_RSPHERE)
+#elif defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
         pp_species.query("save_particles_at_xlo", m_do_boundary_buffer[idx_xlo][ispecies]);
         pp_species.query("save_particles_at_xhi", m_do_boundary_buffer[idx_xhi][ispecies]);
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
@@ -297,7 +297,7 @@ ParticleBoundaryBuffer::ParticleBoundaryBuffer ()
 #if defined(WARPX_DIM_1D_Z)
     m_boundary_names[idx_zlo] = "zlo";
     m_boundary_names[idx_zhi] = "zhi";
-#elif (defined WARPX_DIM_RCYLINDER) || (defined WARPX_DIM_RSPHERE)
+#elif defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
     m_boundary_names[idx_xlo] = "xlo";
     m_boundary_names[idx_xhi] = "xhi";
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)

--- a/Source/Particles/ParticleCreation/AddPlasmaUtilities.cpp
+++ b/Source/Particles/ParticleCreation/AddPlasmaUtilities.cpp
@@ -52,7 +52,7 @@ bool find_overlap_flux (const amrex::RealBox& tile_realbox, const amrex::RealBox
 
     bool no_overlap = false;
     for (int dir=0; dir<AMREX_SPACEDIM; dir++) {
-#if (defined(WARPX_DIM_3D))
+#if defined(WARPX_DIM_3D)
         if (dir == plasma_injector.flux_normal_axis) {
 #elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
         if (2*dir == plasma_injector.flux_normal_axis) {

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -9,7 +9,7 @@
 #include "WarpX.H"
 
 #include "BoundaryConditions/PML.H"
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
+#if defined(WARPX_DIM_RZ) && defined(WARPX_USE_FFT)
 #   include "BoundaryConditions/PML_RZ.H"
 #endif
 #include "Initialization/ExternalField.H"
@@ -222,7 +222,7 @@ namespace
             }
         }
 
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
+#if defined(WARPX_DIM_RZ) && defined(WARPX_USE_FFT)
         if (PMLRZ_flag) {
             // This does the exchange of data in the corner guard cells, the cells that are in the
             // guard region both radially and longitudinally. These are the PML cells in the overlapping
@@ -482,7 +482,7 @@ WarpX::MoveWindow (const int step, bool move_j)
                 ::shiftMF(*pml_B, geom[lev], num_shift, dir, m_safe_guard_cells, do_single_precision_comms, no_cost);
                 ::shiftMF(*pml_E, geom[lev], num_shift, dir, m_safe_guard_cells, do_single_precision_comms, no_cost);
             }
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
+#if defined(WARPX_DIM_RZ) && defined(WARPX_USE_FFT)
             const bool PMLRZ_flag = pml_rz[0].get();
             if (pml_rz[lev] && dim < 2) {
                 amrex::MultiFab* pml_rz_B = m_fields.get(FieldType::pml_B_fp, Direction{dim}, lev);

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -631,7 +631,7 @@ public:
     static bool isAnyParticleBoundaryThermal();
 
     PML* GetPML (int lev);
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
+#if defined(WARPX_DIM_RZ) && defined(WARPX_USE_FFT)
     PML_RZ* GetPML_RZ (int lev);
 #endif
 
@@ -1264,7 +1264,7 @@ private:
     amrex::Vector<amrex::IntVect> do_pml_Lo;
     amrex::Vector<amrex::IntVect> do_pml_Hi;
     amrex::Vector<std::unique_ptr<PML> > pml;
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
+#if defined(WARPX_DIM_RZ) && defined(WARPX_USE_FFT)
     amrex::Vector<std::unique_ptr<PML_RZ> > pml_rz;
 #endif
     amrex::Real v_particle_pml;

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -420,7 +420,7 @@ WarpX::WarpX ()
     gather_buffer_masks.resize(nlevs_max);
 
     pml.resize(nlevs_max);
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
+#if defined(WARPX_DIM_RZ) && defined(WARPX_USE_FFT)
     pml_rz.resize(nlevs_max);
 #endif
 
@@ -3153,7 +3153,7 @@ void WarpX::AllocLevelSpectralSolver (amrex::Vector<std::unique_ptr<SpectralSolv
     const RealVect dx_vect(dx[0], dx[2]);
 #elif defined(WARPX_DIM_1D_Z)
     const RealVect dx_vect(dx[2]);
-#elif (defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE))
+#elif defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
     const RealVect dx_vect(dx[0]);
 #endif
 
@@ -3344,7 +3344,7 @@ WarpX::ComputeDivE(amrex::MultiFab& divE, const int lev)
     }
 }
 
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
+#if defined(WARPX_DIM_RZ) && defined(WARPX_USE_FFT)
 PML_RZ*
 WarpX::GetPML_RZ (int lev)
 {

--- a/Source/ablastr/parallelization/KernelTimer.H
+++ b/Source/ablastr/parallelization/KernelTimer.H
@@ -34,11 +34,11 @@ public:
     AMREX_GPU_DEVICE
     KernelTimer
     (const bool do_timing, amrex::Real* cost)
-#if (defined AMREX_USE_GPU)
+#if defined(AMREX_USE_GPU)
         : m_do_timing(do_timing)
 #endif
     {
-#if (defined AMREX_USE_GPU)
+#if defined(AMREX_USE_GPU)
     if (m_do_timing && cost) {
         m_cost = cost;
 #   if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
@@ -57,7 +57,7 @@ public:
     }
 
     //! Destructor.
-#if (defined AMREX_USE_GPU)
+#if defined(AMREX_USE_GPU)
 #   if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
         AMREX_GPU_DEVICE
         ~KernelTimer ()
@@ -83,7 +83,7 @@ public:
     KernelTimer ( KernelTimer&& )                  = default;
     KernelTimer& operator= ( KernelTimer&& )       = default;
 
-#if (defined AMREX_USE_GPU)
+#if defined(AMREX_USE_GPU)
 private:
     //! Stores whether kernel timer is active.
     bool m_do_timing;

--- a/Source/ablastr/particles/NodalFieldGather.H
+++ b/Source/ablastr/particles/NodalFieldGather.H
@@ -52,7 +52,7 @@ void compute_weights (const amrex::ParticleReal xp,
         }
     }();
 
-#if (defined WARPX_DIM_3D)
+#if defined(WARPX_DIM_3D)
     const amrex::Real x = (xp - plo[0]) * dxi[0] - half_if_cell_centered;
     const amrex::Real y = (yp - plo[1]) * dxi[1] - half_if_cell_centered;
     const amrex::Real z = (zp - plo[2]) * dxi[2] - half_if_cell_centered;
@@ -114,7 +114,7 @@ void compute_weights (const amrex::ParticleReal xp,
     j = 0;
     k = 0;
 
-#elif (defined WARPX_DIM_1D_Z)
+#elif defined(WARPX_DIM_1D_Z)
     const amrex::Real z = (zp - plo[0]) * dxi[0] - half_if_cell_centered;
     amrex::ignore_unused(xp, yp);
     i = static_cast<int>(amrex::Math::floor(z));


### PR DESCRIPTION
### Description
This PR resolves a strict preprocessor parsing issue that can cause compilation failures on certain NVCC versions. 
The NVCC preprocessor strictly adheres to the standard and frequently rejects parentheses around the `defined` operator when followed by a macro name without its own parentheses (e.g. `#elif (defined MACRO)`). This PR replaces all such occurrences with the compliant `#elif defined(MACRO)` or `#elif defined(MACRO1) || defined(MACRO2)` syntax across the codebase.
This fix was originally spotted in a recent development branch and has now been applied globally across `Source/` to ensure robust compilation on GPU builds.

### Related PR

#7021