### PR TITLE
Linear Compton: fix typo sampling of Klein-Nishina formula

### DIFF
--- a/Regression/Checksum/benchmarks_json/test_3d_linear_compton_bunch_laser.json
+++ b/Regression/Checksum/benchmarks_json/test_3d_linear_compton_bunch_laser.json
@@ -1,41 +1,41 @@
 {
-  "lev=0": {
-    "rho": 399055.3249141113
-  },
   "electron1": {
-    "particle_position_x": 0.03010223055173614,
-    "particle_position_y": 0.030198676328252634,
-    "particle_position_z": 0.029874839839011652,
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
-    "particle_momentum_z": 3.1079804850737784e-16,
-    "particle_weight": 4702977.2901465455
+    "particle_momentum_z": 3.176659564689683e-16,
+    "particle_position_x": 0.03080160760367571,
+    "particle_position_y": 0.03078645129531337,
+    "particle_position_z": 0.03012776047142848,
+    "particle_weight": 4807584.986739586
   },
   "electron2": {
-    "particle_position_x": 0.36840819213734566,
-    "particle_position_y": 0.36846303361615884,
-    "particle_position_z": 0.369300496712629,
-    "particle_momentum_x": 6.991092562775283e-21,
-    "particle_momentum_y": 6.995173435713479e-21,
-    "particle_momentum_z": 3.8130936300105336e-15,
-    "particle_weight": 57709120.21797049
+    "particle_momentum_x": 6.980641257019345e-21,
+    "particle_momentum_y": 6.982082063448416e-21,
+    "particle_momentum_z": 3.80622797602821e-15,
+    "particle_position_x": 0.3677088150854061,
+    "particle_position_y": 0.3678752586490981,
+    "particle_position_z": 0.3690475760802122,
+    "particle_weight": 57604512.521377444
+  },
+  "lev=0": {
+    "rho": 399055.32491410995
   },
   "photon1": {
+    "particle_momentum_x": 0.0,
+    "particle_momentum_y": 0.0,
+    "particle_momentum_z": 0.0,
     "particle_position_x": 0.0,
     "particle_position_y": 0.0,
     "particle_position_z": 0.0,
-    "particle_momentum_x": 0.0,
-    "particle_momentum_y": 0.0,
-    "particle_momentum_z": 0.0,
     "particle_weight": 0.0
   },
   "photon2": {
-    "particle_position_x": 1.1267541906876057,
-    "particle_position_y": 1.1389324800722762,
-    "particle_position_z": 0.39619133651691985,
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 0.0,
-    "particle_weight": 57709120.21797049
+    "particle_position_x": 1.218889020273211,
+    "particle_position_y": 1.1146245979707592,
+    "particle_position_z": 0.38316378251355415,
+    "particle_weight": 57604512.521377444
   }
 }

--- a/Regression/Checksum/benchmarks_json/test_3d_linear_compton_two_particles.json
+++ b/Regression/Checksum/benchmarks_json/test_3d_linear_compton_two_particles.json
@@ -1,41 +1,41 @@
 {
-  "lev=0": {
-    "rho": 8203144366079999.0
-  },
   "electron1": {
-    "particle_position_x": 0.0,
-    "particle_position_y": 0.0,
-    "particle_position_z": 0.0,
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 0.0,
+    "particle_position_x": 0.0,
+    "particle_position_y": 0.0,
+    "particle_position_z": 0.0,
     "particle_weight": 0.0
   },
   "electron2": {
+    "particle_momentum_x": 2.6763896243574446e-22,
+    "particle_momentum_y": 6.83295273515175e-22,
+    "particle_momentum_z": 2.1489565353605063e-22,
     "particle_position_x": 0.0,
     "particle_position_y": 0.0,
     "particle_position_z": 0.0,
-    "particle_momentum_x": 1.2347117388095943e-22,
-    "particle_momentum_y": 5.056742998960243e-22,
-    "particle_momentum_z": 5.601353038112042e-22,
     "particle_weight": 100000000000000.0
   },
+  "lev=0": {
+    "rho": 8203144366079999.0
+  },
   "photon1": {
-    "particle_position_x": 0.0,
-    "particle_position_y": 0.0,
-    "particle_position_z": 0.0,
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 0.0,
+    "particle_position_x": 0.0,
+    "particle_position_y": 0.0,
+    "particle_position_z": 0.0,
     "particle_weight": 0.0
   },
   "photon2": {
-    "particle_position_x": 0.0,
-    "particle_position_y": 0.0,
-    "particle_position_z": 0.0,
     "particle_momentum_x": 0.0,
     "particle_momentum_y": 0.0,
     "particle_momentum_z": 0.0,
+    "particle_position_x": 0.0,
+    "particle_position_y": 0.0,
+    "particle_position_z": 0.0,
     "particle_weight": 100000000000000.0
   }
 }

--- a/Source/Particles/Collision/BinaryCollision/LinearCompton/LinearComptonInitializeMomentum.H
+++ b/Source/Particles/Collision/BinaryCollision/LinearCompton/LinearComptonInitializeMomentum.H
@@ -139,7 +139,7 @@ namespace {
         // By convention, in WarpX, the photon momentum u is normalized by the electron mass m_e, so k corresponds to p/(m_e*c)
         amrex::ParticleReal const c0 = 2._prt * (2._prt*k*k + 2._prt*k + 1._prt) / amrex::Math::powi<3>(2._prt*k + 1._prt);
         amrex::ParticleReal const b = (2._prt + c0) / (2._prt - c0);
-        amrex::ParticleReal const a = 2._prt*b - 1._prt;
+        amrex::ParticleReal const a = 2._prt*( b - 1._prt );
         // Use rejection method to draw x
         bool reject = true;
         amrex::ParticleReal x = 0;


### PR DESCRIPTION
The formula published in Ozmutlu, E. N. "Sampling of Angular Distribution in Compton Scattering" Appl. Radiat. Isot. 43, 6, pp. 713-715 (1992) is:
$a(k) = 2[b(k) - 1]$

This affects the efficiency (but not the accuracy) of this rejection sampling method.

<img width="1098" height="796" alt="Screenshot 2026-07-07 at 8 42 37 PM" src="https://github.com/user-attachments/assets/862d2c74-e475-4050-8eae-f42b07716e98" />
