### PR TITLE
Fix Examples/CMakeLists.txt for no-MPI builds

### DIFF
--- a/Examples/CMakeLists.txt
+++ b/Examples/CMakeLists.txt
@@ -109,13 +109,17 @@ function(add_warpx_test
     endif()
 
     # set MPI executable
-    set(THIS_MPI_TEST_EXE
-        ${MPIEXEC_EXECUTABLE}
-        ${MPI_ALLOW_ROOT}
-        ${MPIEXEC_NUMPROC_FLAG} ${nprocs}
-        ${MPIEXEC_POSTFLAGS}
-        ${MPIEXEC_PREFLAGS}
-    )
+    if(WarpX_MPI)
+        set(THIS_MPI_TEST_EXE
+            ${MPIEXEC_EXECUTABLE}
+            ${MPI_ALLOW_ROOT}
+            ${MPIEXEC_NUMPROC_FLAG} ${nprocs}
+            ${MPIEXEC_POSTFLAGS}
+            ${MPIEXEC_PREFLAGS}
+        )
+    else()
+        set(THIS_MPI_TEST_EXE "")
+    endif()
 
     # set Python executable
     if(python)


### PR DESCRIPTION
## Overview

Extract one bug fix from #6980. Our Examples/CMakeLists.txt was not robust with respect to builds with `WarpX_MPI=OFF`, as it would retain the number of MPI processes passed through the command line and erroneously identify that as the executable, resulting in errors like `Unable to find executable: 1`.

## Notes

First observed and debugged in https://github.com/BLAST-WarpX/warpx/pull/6980#issuecomment-4908639552.