### PR TITLE
[WIP] Use local Redistribute with mesh refinement simulations

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -731,66 +731,58 @@ void WarpX::HandleParticlesAtBoundaries (int step, amrex::Real cur_time, int num
     mypc->ApplyBoundaryConditions();
     m_particle_boundary_buffer->gatherParticlesFromDomainBoundaries(*mypc, cur_time);
 
-    // Without mesh refinement, use a local redistribute when particles can only
-    // have moved by a small number of cells; otherwise fall back to a global one.
-    if (finest_level == 0) {
-        // Estimate, per direction, the maximum distance a particle may have
-        // travelled during this step, expressed in number of cells.
-        // (Geom().CellSizeArray() is indexed by active dimension 0..SPACEDIM-1.)
-        const amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> dx = Geom(0).CellSizeArray();
+    // Redistribute: Estimate the maximum distance a particle may have
+    // travelled during this step, expressed in number of cells.
+    // (Geom().CellSizeArray() is indexed by active dimension 0..SPACEDIM-1.)
+    const amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> dx = Geom(0).CellSizeArray();
 
-        // Particles cannot travel faster than the speed of light, so c * dt / dx
-        // is a physical upper bound on the number of cells crossed per direction.
-        amrex::RealVect max_distance_relative_to_grid;
-        for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-            max_distance_relative_to_grid[d] = PhysConst::c * dt[0] / dx[d];
-        }
-
-        // Moving window: particles can additionally move by the number of cells
-        // that the window was shifted, along the moving-window direction.
-        if (moving_window_dir >= 0) {
-            max_distance_relative_to_grid[moving_window_dir] += static_cast<amrex::Real>(num_moved);
-        }
-
-
-        // Galilean algorithm: account for the extra grid shift due to the moving
-        // Galilean frame. m_v_galilean is indexed by x/y/z, so map its components
-        // onto the active simulation dimensions.
-#if defined(WARPX_DIM_3D)
-        const amrex::RealVect v_galilean = {m_v_galilean[0], m_v_galilean[1], m_v_galilean[2]};
-#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
-        const amrex::RealVect v_galilean = {m_v_galilean[0], m_v_galilean[2]};
-#elif defined(WARPX_DIM_1D_Z)
-        const amrex::RealVect v_galilean(m_v_galilean[2]);
-#else // WARPX_DIM_RCYLINDER, WARPX_DIM_RSPHERE: no Galilean shift
-        const amrex::RealVect v_galilean = amrex::RealVect::TheZeroVector();
-#endif
-        for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-            max_distance_relative_to_grid[d] += std::abs(v_galilean[d]) * dt[0] / dx[d];
-        }
-
-        // Convert to an integer number of cells (rounding up), per direction.
-        amrex::IntVect max_cells_travelled;
-        for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-            max_cells_travelled[d] =
-                static_cast<int>(std::ceil(max_distance_relative_to_grid[d]));
-        }
-
-        // If, in any direction, max_cells_travelled reaches the domain size, the
-        // local search is no longer more efficient than (and may crash in lieu
-        // of) a full redistribute, so fall back in that case.
-        const amrex::IntVect domain_length = Geom(0).Domain().length();
-        bool use_local_redistribute = true;
-        for (int d = 0; d < AMREX_SPACEDIM; ++d) {
-            if (max_cells_travelled[d] >= domain_length[d]) { use_local_redistribute = false; }
-        }
-        if (use_local_redistribute) {
-            mypc->RedistributeLocal(max_cells_travelled);
-        } else {
-            mypc->Redistribute();
-        }
+    // Particles cannot travel faster than the speed of light, so c * dt / dx
+    // is a physical upper bound on the number of cells crossed per direction.
+    amrex::RealVect max_distance_relative_to_grid;
+    for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+        max_distance_relative_to_grid[d] = PhysConst::c * dt[0] / dx[d];
     }
-    else {
+
+    // Moving window: particles can additionally move by the number of cells
+    // that the window was shifted, along the moving-window direction.
+    if (moving_window_dir >= 0) {
+        max_distance_relative_to_grid[moving_window_dir] += static_cast<amrex::Real>(num_moved);
+    }
+
+    // Galilean algorithm: account for the extra grid shift due to the moving
+    // Galilean frame. m_v_galilean is indexed by x/y/z, so map its components
+    // onto the active simulation dimensions.
+#if defined(WARPX_DIM_3D)
+    const amrex::RealVect v_galilean = {m_v_galilean[0], m_v_galilean[1], m_v_galilean[2]};
+#elif defined(WARPX_DIM_XZ) || defined(WARPX_DIM_RZ)
+    const amrex::RealVect v_galilean = {m_v_galilean[0], m_v_galilean[2]};
+#elif defined(WARPX_DIM_1D_Z)
+    const amrex::RealVect v_galilean(m_v_galilean[2]);
+#else // WARPX_DIM_RCYLINDER, WARPX_DIM_RSPHERE: no Galilean shift
+    const amrex::RealVect v_galilean = amrex::RealVect::TheZeroVector();
+#endif
+    for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+        max_distance_relative_to_grid[d] += std::abs(v_galilean[d]) * dt[0] / dx[d];
+    }
+
+    // Convert to an integer number of cells (rounding up), per direction.
+    amrex::IntVect max_cells_travelled;
+    for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+        max_cells_travelled[d] =
+            static_cast<int>(std::ceil(max_distance_relative_to_grid[d]));
+    }
+
+    // If, in any direction, max_cells_travelled reaches the domain size, the
+    // local search is no longer more efficient than (and may crash in lieu
+    // of) a full redistribute, so fall back in that case.
+    const amrex::IntVect domain_length = Geom(0).Domain().length();
+    bool use_local_redistribute = true;
+    for (int d = 0; d < AMREX_SPACEDIM; ++d) {
+        if (max_cells_travelled[d] >= domain_length[d]) { use_local_redistribute = false; }
+    }
+    if (use_local_redistribute) {
+        mypc->RedistributeLocal(max_cells_travelled);
+    } else {
         mypc->Redistribute();
     }
 

--- a/dependencies.json
+++ b/dependencies.json
@@ -5,8 +5,8 @@
     "version_picsar": "26.05",
     "version_pybind11_min": "v3.0.0",
     "version_picmi": "0.34.0",
-    "commit_amrex": "8addf4d92318ea3adf7f51cdb37fe4b8c952f05e",
-    "commit_pyamrex": "32aa49a4bd22060c7b45f7d0e46dc1d0dc580025",
+    "commit_amrex": "5ca2c5e2326770403418a63714b9db2f88ef1796",
+    "commit_pyamrex": "36a4576b90ccf99d0daf78e3aeba3b4f7f1b613b",
     "commit_picsar": "26.05",
     "commit_pybind11": "v3.0.4",
     "commit_picmi": "a2fc467f3125d57ea0183562e69f414b84abe675"

--- a/dependencies.json
+++ b/dependencies.json
@@ -5,7 +5,7 @@
     "version_picsar": "26.05",
     "version_pybind11_min": "v3.0.0",
     "version_picmi": "0.34.0",
-    "commit_amrex": "5ca2c5e2326770403418a63714b9db2f88ef1796",
+    "commit_amrex": "525c31011b65d589902f92ac0cd35d49f4b3e37b",
     "commit_pyamrex": "36a4576b90ccf99d0daf78e3aeba3b4f7f1b613b",
     "commit_picsar": "26.05",
     "commit_pybind11": "v3.0.4",


### PR DESCRIPTION
This PR addresses [this comment](https://github.com/BLAST-WarpX/warpx/pull/6988/changes#r3515158122). It enables the local version of `Redistribute` even for simulations with mesh refinement, since this is supported in AMReX.

I would recommend reviewing with `Hide whitespaces` since most of the changes are just indentation changes.