### PR TITLE
Fix missing radial-geometry inverse-volume scaling of rho in implicit residual evaluations

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -1432,21 +1432,29 @@ WarpX::PushParticlesandDeposit (
         implicit_options
     );
 
-    if (!skip_deposition && !implicit_options) {
+    if (!skip_deposition) {
 #if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
         // This is called after all particles have deposited their current and charge.
-        ApplyInverseVolumeScalingToCurrentDensity(
-            m_fields.get(FieldType::current_fp, Direction{0}, lev),
-            m_fields.get(FieldType::current_fp, Direction{1}, lev),
-            m_fields.get(FieldType::current_fp, Direction{2}, lev),
-            lev);
-        if (m_fields.has_vector(FieldType::current_buf, lev)) {
+        if (!implicit_options) {
+            // Skip scaling J here for the implicit solvers: the total current is
+            // accumulated from multiple containers after this call (see CumulateJ()
+            // and ComputeJfromMassMatrices()), and is scaled in PreRHSOp().
             ApplyInverseVolumeScalingToCurrentDensity(
-                m_fields.get(FieldType::current_buf, Direction{0}, lev),
-                m_fields.get(FieldType::current_buf, Direction{1}, lev),
-                m_fields.get(FieldType::current_buf, Direction{2}, lev),
-                lev-1);
+                m_fields.get(FieldType::current_fp, Direction{0}, lev),
+                m_fields.get(FieldType::current_fp, Direction{1}, lev),
+                m_fields.get(FieldType::current_fp, Direction{2}, lev),
+                lev);
+            if (m_fields.has_vector(FieldType::current_buf, lev)) {
+                ApplyInverseVolumeScalingToCurrentDensity(
+                    m_fields.get(FieldType::current_buf, Direction{0}, lev),
+                    m_fields.get(FieldType::current_buf, Direction{1}, lev),
+                    m_fields.get(FieldType::current_buf, Direction{2}, lev),
+                    lev-1);
+            }
         }
+        // Unlike J, the charge density has no post-deposition accumulation step:
+        // rho is reset and fully deposited within this call on both the explicit
+        // and implicit paths, so it is scaled here in all cases.
         if (m_fields.has(FieldType::rho_fp, lev)) {
             ApplyInverseVolumeScalingToChargeDensity(m_fields.get(FieldType::rho_fp, lev), lev);
             if (m_fields.has(FieldType::rho_buf, lev)) {
@@ -1461,7 +1469,7 @@ WarpX::PushParticlesandDeposit (
         // of the filter to avoid incorrect results (moved to `SyncCurrentAndRho()`).
         // Might this be related to issue #1943?
 #endif
-        if (do_fluid_species) {
+        if (do_fluid_species && !implicit_options) {
             myfl->Evolve(m_fields,
                          lev,
                          current_fp_string,

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -832,16 +832,13 @@ void ImplicitSolver::PreRHSOp ( const amrex::Real  a_cur_time,
     }
 
 #if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+    // Apply the inverse volume scaling for radial geometries after the total
+    // current has been accumulated from all containers above. The charge
+    // density needs no such treatment here: rho is deposited directly and is
+    // scaled inside WarpX::PushParticlesandDeposit(), on the implicit path too.
     for (int lev = 0; lev < m_num_amr_levels; ++lev) {
         ablastr::fields::VectorField J = m_WarpX->m_fields.get_alldirs(FieldType::current_fp, lev);
         m_WarpX->ApplyInverseVolumeScalingToCurrentDensity(J[0], J[1], J[2], lev);
-        // The particle evolve applies the radial-geometry volume scaling only on the
-        // explicit path; charge density deposited during implicit residual evaluations
-        // must be scaled here or solvers that divide by rho (e.g. the hybrid Ohm's law)
-        // see an unscaled density.
-        if (m_WarpX->m_fields.has(FieldType::rho_fp, lev)) {
-            m_WarpX->ApplyInverseVolumeScalingToChargeDensity(m_WarpX->m_fields.get(FieldType::rho_fp, lev), lev);
-        }
     }
 #endif
 

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -835,6 +835,13 @@ void ImplicitSolver::PreRHSOp ( const amrex::Real  a_cur_time,
     for (int lev = 0; lev < m_num_amr_levels; ++lev) {
         ablastr::fields::VectorField J = m_WarpX->m_fields.get_alldirs(FieldType::current_fp, lev);
         m_WarpX->ApplyInverseVolumeScalingToCurrentDensity(J[0], J[1], J[2], lev);
+        // The particle evolve applies the radial-geometry volume scaling only on the
+        // explicit path; charge density deposited during implicit residual evaluations
+        // must be scaled here or solvers that divide by rho (e.g. the hybrid Ohm's law)
+        // see an unscaled density.
+        if (m_WarpX->m_fields.has(FieldType::rho_fp, lev)) {
+            m_WarpX->ApplyInverseVolumeScalingToChargeDensity(m_WarpX->m_fields.get(FieldType::rho_fp, lev), lev);
+        }
     }
 #endif
 


### PR DESCRIPTION
## Problem

Since #6589, `WarpX::PushParticlesandDeposit` skips the radial-geometry (RZ/RCYLINDER/RSPHERE) inverse-volume scaling block whenever it is called with `implicit_options != nullptr`, and `ImplicitSolver::PreRHSOp` re-applies the scaling **for the current density only**. Charge density deposited during implicit residual evaluations (`rho_fp`, and `rho_buf` with mesh refinement) is therefore never volume-scaled in the radial geometries.

The merged EM implicit solvers do not read `rho_fp` in their residuals, and the full-diagnostics `rho` field is a separate, freshly deposited quantity that applies its own scaling (`MultiParticleContainer::DepositCharge`), so it is unaffected. Solvers whose residual divides by `rho` are broken outright: the theta-implicit hybrid-PIC scheme proposed in #6514 diverges at the first Newton iteration of the first step in RZ, because Ohm's law sees a density that is wrong by an r-dependent ring-volume factor (see the analysis in [this comment](https://github.com/BLAST-WarpX/warpx/pull/6514#issuecomment-4964520665)). Cartesian dimensionalities are unaffected.

## Fix

Scale `rho` inside `WarpX::PushParticlesandDeposit`, next to the deposition itself, on the implicit path as well — restoring the pre-#6589 behavior for the charge density. Unlike **J**, which the implicit solvers accumulate from multiple containers after that call (`CumulateJ` / `ComputeJfromMassMatrices`) and which therefore keeps its scaling in `PreRHSOp`, `rho` has no post-deposition accumulation step: it is reset and fully deposited within every non-skipped `PushParticlesandDeposit` call. Since the mass-matrices Jacobian linear stage without particle suborbits never calls `PushParticlesandDeposit`, `rho_fp` retains its already-scaled values there and the scaling is applied exactly once per deposit by construction — no special-case guard needed (thanks @prkkumar-he for flagging the double-application hazard of scaling unconditionally in `PreRHSOp`, and @JustinRayAngus for suggesting this placement).

The fluid-species `myfl->Evolve` keeps the `!implicit_options` behavior introduced by #6589, so this PR does not change implicit behavior for fluids.

## Testing

No merged test allocates `rho_fp` in an implicit radial-geometry run, so no existing checksums change. The RZ hybrid-PIC test added in #6514 (`test_rz_ohm_solver_em_modes_implicit_picmi`) diverges without this fix and passes with it, and will serve as the regression test once that PR merges. Verified locally on a rebase of #6514 onto current development: Newton diverged at step 0 before, converges through all 50 steps after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyFeNNpr5jir3ygSakbZCm
