### PR TITLE
Simplify DistanceToEB::interp_normal API and drop unused normal in EB scraper

### DIFF
--- a/Source/EmbeddedBoundary/DistanceToEB.H
+++ b/Source/EmbeddedBoundary/DistanceToEB.H
@@ -9,10 +9,13 @@
 
 #include "Utils/TextMsg.H"
 
+#include <ablastr/particles/NodalFieldGather.H>
+
 #include <AMReX.H>
+#include <AMReX_Array.H>
+#include <AMReX_Array4.H>
 #include <AMReX_REAL.H>
 #include <AMReX_RealVect.H>
-#include <AMReX_Array.H>
 
 namespace DistanceToEB
 {
@@ -23,29 +26,29 @@ amrex::Real dot_product (const amrex::RealVect& a, const amrex::RealVect& b) noe
     return AMREX_D_TERM(a[0]*b[0], + a[1]*b[1], + a[2]*b[2]);
 }
 
+// This function calculates the unit normal vector to the embedded boundary at
+// the particle position (xp, yp, zp), by interpolating the signed distance
+// function distance_to_eb. plo/dxi are the geometry data; the returned vector
+// is normalized to unit length.
 AMREX_GPU_HOST_DEVICE AMREX_INLINE
-void normalize (amrex::RealVect& a) noexcept
+amrex::RealVect interp_normal (amrex::ParticleReal xp, amrex::ParticleReal yp, amrex::ParticleReal zp,
+                               amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& plo,
+                               amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi,
+                               amrex::Array4<const amrex::Real> const& distance_to_eb) noexcept
 {
     using namespace amrex::literals;
-    amrex::Real const inv_norm = 1.0_rt / std::sqrt(dot_product(a, a));
-    AMREX_D_DECL(a[0] *= inv_norm,
-                 a[1] *= inv_norm,
-                 a[2] *= inv_norm);
-}
 
-
-
-// This function calculates the normal vector using the nodal and cell-centered data.
-// i,j,k are the index of the nearest node to the left of the point at which we interpolate.
-// W are the interpolation weight for the left and right nodes (for the 0th component and 1st component respectively)
-// ic,jc,kc are the index of the nearest cell-center to the left of the point at which we interpolate.
-AMREX_GPU_HOST_DEVICE AMREX_INLINE
-amrex::RealVect interp_normal (int i, int j, int k, const amrex::Real W[AMREX_SPACEDIM][2],
-                               int ic, int jc, int kc, const amrex::Real Wc[AMREX_SPACEDIM][2],
-                               amrex::Array4<const amrex::Real> const& phi,
-                               amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> const& dxi) noexcept
-{
-    using namespace amrex::literals;
+    // Compute the nodal and cell-centered interpolation weights at the position.
+    // i,j,k (ic,jc,kc) are the indices of the nearest node (cell-center) to the
+    // left of the point; W (Wc) are the corresponding interpolation weights.
+    int i, j, k;
+    amrex::Real W[AMREX_SPACEDIM][2];
+    ablastr::particles::compute_weights<amrex::IndexType::NODE>(
+        xp, yp, zp, plo, dxi, i, j, k, W);
+    int ic, jc, kc;
+    amrex::Real Wc[AMREX_SPACEDIM][2];
+    ablastr::particles::compute_weights<amrex::IndexType::CELL>(
+        xp, yp, zp, plo, dxi, ic, jc, kc, Wc);
 
 #if (defined WARPX_DIM_3D)
     amrex::RealVect normal{0.0, 0.0, 0.0};
@@ -58,7 +61,7 @@ amrex::RealVect interp_normal (int i, int j, int k, const amrex::Real W[AMREX_SP
                     int const wccomp = static_cast<int>(iic%2);
                     int const w1comp = static_cast<int>(jj%2);
                     int const w2comp = static_cast<int>(kk%2);
-                    normal[0] += sign * phi(icstart + ii, j + jj, k + kk) * dxi[0] * Wc[0][wccomp] * W[1][w1comp] * W[2][w2comp];
+                    normal[0] += sign * distance_to_eb(icstart + ii, j + jj, k + kk) * dxi[0] * Wc[0][wccomp] * W[1][w1comp] * W[2][w2comp];
                 }
             }
         }
@@ -72,7 +75,7 @@ amrex::RealVect interp_normal (int i, int j, int k, const amrex::Real W[AMREX_SP
                     int const wccomp = static_cast<int>(iic%2);
                     int const w1comp = static_cast<int>(ii%2);
                     int const w2comp = static_cast<int>(kk%2);
-                    normal[1] += sign * phi(i + ii, jcstart + jj, k + kk) * dxi[1] * W[0][w1comp] * Wc[1][wccomp] * W[2][w2comp];
+                    normal[1] += sign * distance_to_eb(i + ii, jcstart + jj, k + kk) * dxi[1] * W[0][w1comp] * Wc[1][wccomp] * W[2][w2comp];
                 }
             }
         }
@@ -86,7 +89,7 @@ amrex::RealVect interp_normal (int i, int j, int k, const amrex::Real W[AMREX_SP
                     int const wccomp = static_cast<int>(iic%2);
                     int const w1comp = static_cast<int>(ii%2);
                     int const w2comp = static_cast<int>(jj%2);
-                    normal[2] += sign * phi(i + ii, j + jj, kcstart + kk) * dxi[2] * W[0][w1comp] * W[1][w2comp] * Wc[2][wccomp];
+                    normal[2] += sign * distance_to_eb(i + ii, j + jj, kcstart + kk) * dxi[2] * W[0][w1comp] * W[1][w2comp] * Wc[2][wccomp];
                 }
             }
         }
@@ -101,7 +104,7 @@ amrex::RealVect interp_normal (int i, int j, int k, const amrex::Real W[AMREX_SP
                 amrex::Real const sign = (ii%2)*2._rt - 1._rt;
                 int const wccomp = static_cast<int>(iic%2);
                 int const w1comp = static_cast<int>(jj%2);
-                normal[0] += sign * phi(icstart + ii, j + jj, k) * dxi[0] * Wc[0][wccomp] * W[1][w1comp];
+                normal[0] += sign * distance_to_eb(icstart + ii, j + jj, k) * dxi[0] * Wc[0][wccomp] * W[1][w1comp];
             }
         }
     }
@@ -112,14 +115,14 @@ amrex::RealVect interp_normal (int i, int j, int k, const amrex::Real W[AMREX_SP
                 amrex::Real const sign = (jj%2)*2._rt - 1._rt;
                 int const wccomp = static_cast<int>(iic%2);
                 int const w1comp = static_cast<int>(ii%2);
-                normal[1] += sign * phi(i + ii, jcstart + jj, k) * dxi[1] * W[0][w1comp] * Wc[1][wccomp];
+                normal[1] += sign * distance_to_eb(i + ii, jcstart + jj, k) * dxi[1] * W[0][w1comp] * Wc[1][wccomp];
             }
         }
     }
     amrex::ignore_unused(kc);
 
 #else
-    amrex::ignore_unused(i, j, k, ic, jc, kc, W, Wc, phi, dxi);
+    amrex::ignore_unused(i, j, k, ic, jc, kc, W, Wc, distance_to_eb, dxi);
     amrex::RealVect normal(0.0);
 
     AMREX_IF_ON_DEVICE((
@@ -130,6 +133,12 @@ amrex::RealVect interp_normal (int i, int j, int k, const amrex::Real W[AMREX_SP
     ))
 
 #endif
+
+    // Normalize to unit length
+    amrex::Real const inv_norm = 1.0_rt / std::sqrt(dot_product(normal, normal));
+    AMREX_D_DECL(normal[0] *= inv_norm,
+                 normal[1] *= inv_norm,
+                 normal[2] *= inv_norm);
     return normal;
 }
 }

--- a/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
+++ b/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
@@ -19,7 +19,7 @@ struct NoOp {
     template <typename PData>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void operator() (const PData& /*ptd*/, int /*i*/,
-                     const amrex::RealVect& /*pos*/, const amrex::RealVect& /*normal*/,
+                     const amrex::RealVect& /*pos*/,
                      amrex::RandomEngine const& /*engine*/) const noexcept
     {}
 };
@@ -28,7 +28,7 @@ struct Absorb {
     template <typename PData>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void operator() (PData& ptd, int i,
-                     const amrex::RealVect& /*pos*/, const amrex::RealVect& /*normal*/,
+                     const amrex::RealVect& /*pos*/,
                      amrex::RandomEngine const& /*engine*/) const noexcept
     {
         amrex::ParticleIDWrapper{ptd.m_idcpu[i]}.make_invalid();

--- a/Source/EmbeddedBoundary/ParticleScraper.H
+++ b/Source/EmbeddedBoundary/ParticleScraper.H
@@ -126,7 +126,7 @@ scrapeParticlesAtEB (PC& pc, ablastr::fields::MultiLevelScalarField const& dista
  *  passed in to this function as an argument. This function can access the
  *  position at which the particle hit the boundary. Particles can be `absorbed`
  *  by setting their ids to negative
- *  to flag them for removal. Likewise, the can be reflected back into the domain
+ *  to flag them for removal. Likewise, they can be reflected back into the domain
  *  by modifying their data appropriately and leaving their ids alone.
  *
  *  This version operates only at the specified levels.

--- a/Source/EmbeddedBoundary/ParticleScraper.H
+++ b/Source/EmbeddedBoundary/ParticleScraper.H
@@ -37,8 +37,8 @@
  *
  *  The operation to be performed is specified by the callable function
  *  passed in to this function as an argument. This function can access the
- *  position at which the particle hit the boundary, and also the associated
- *  normal vector. Particles can be `absorbed` by setting their ids to negative
+ *  position at which the particle hit the boundary. Particles can be `absorbed`
+ *  by setting their ids to negative
  *  to flag them for removal. Likewise, they can be reflected back into the domain
  *  by modifying their data appropriately and leaving their ids alone.
  *
@@ -56,11 +56,11 @@
  *        template <typename PData>
  *        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
  *        void operator() (const PData& ptd, int i,
- *                         const amrex::RealVect& pos, const amrex::RealVect& normal,
+ *                         const amrex::RealVect& pos,
  *                         amrex::RandomEngine const& engine);
  *
  *        where ptd is the particle tile, i the index of the particle operated on,
- *        pos and normal the location of the collision and the boundary normal vector.
+ *        pos the location of the collision.
  *        engine is for random number generation, if needed.
  */
 template <class PC, class F, std::enable_if_t<amrex::IsParticleContainer<PC>::value, int> foo = 0>
@@ -81,8 +81,8 @@ scrapeParticlesAtEB (PC& pc, ablastr::fields::MultiLevelScalarField const& dista
  *
  *  The operation to be performed is specified by the callable function
  *  passed in to this function as an argument. This function can access the
- *  position at which the particle hit the boundary, and also the associated
- *  normal vector. Particles can be `absorbed` by setting their ids to negative
+ *  position at which the particle hit the boundary. Particles can be `absorbed`
+ *  by setting their ids to negative
  *  to flag them for removal. Likewise, they can be reflected back into the domain
  *  by modifying their data appropriately and leaving their ids alone.
  *
@@ -99,11 +99,11 @@ scrapeParticlesAtEB (PC& pc, ablastr::fields::MultiLevelScalarField const& dista
  *        template <typename PData>
  *        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
  *        void operator() (const PData& ptd, int i,
- *                         const amrex::RealVect& pos, const amrex::RealVect& normal,
+ *                         const amrex::RealVect& pos,
  *                         amrex::RandomEngine const& engine);
  *
  *        where ptd is the particle tile, i the index of the particle operated on,
- *        pos and normal the location of the collision and the boundary normal vector.
+ *        pos the location of the collision.
  *        engine is for random number generation, if needed.
  */
 template <class PC, class F, std::enable_if_t<amrex::IsParticleContainer<PC>::value, int> foo = 0>
@@ -124,8 +124,8 @@ scrapeParticlesAtEB (PC& pc, ablastr::fields::MultiLevelScalarField const& dista
  *
  *  The operation to be performed is specified by the callable function
  *  passed in to this function as an argument. This function can access the
- *  position at which the particle hit the boundary, and also the associated
- *  normal vector. Particles can be `absorbed` by setting their ids to negative
+ *  position at which the particle hit the boundary. Particles can be `absorbed`
+ *  by setting their ids to negative
  *  to flag them for removal. Likewise, the can be reflected back into the domain
  *  by modifying their data appropriately and leaving their ids alone.
  *
@@ -144,11 +144,11 @@ scrapeParticlesAtEB (PC& pc, ablastr::fields::MultiLevelScalarField const& dista
  *        template <typename PData>
  *        AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
  *        void operator() (const PData& ptd, int i,
- *                         const amrex::RealVect& pos, const amrex::RealVect& normal,
+ *                         const amrex::RealVect& pos,
  *                         amrex::RandomEngine const& engine);
  *
  *        where ptd is the particle tile, i the index of the particle operated on,
- *        pos and normal the location of the collision and the boundary normal vector.
+ *        pos the location of the collision.
  *        engine is for random number generation, if needed.
  */
 template <class PC, class F, std::enable_if_t<amrex::IsParticleContainer<PC>::value, int> foo = 0>
@@ -189,12 +189,6 @@ scrapeParticlesAtEB (PC& pc, ablastr::fields::MultiLevelScalarField const& dista
 
                 if (phi_value < 0.0)
                 {
-                    int ic, jc, kc; // Cell-centered indices
-                    amrex::Real Wc[AMREX_SPACEDIM][2]; // Cell-centered weights
-                    ablastr::particles::compute_weights<amrex::IndexType::CELL>(
-                        xp, yp, zp, plo, dxi, ic, jc, kc, Wc);
-                    amrex::RealVect normal = DistanceToEB::interp_normal(i, j, k, W, ic, jc, kc, Wc, phi, dxi);
-                    DistanceToEB::normalize(normal);
                     amrex::RealVect pos;
 #if (defined WARPX_DIM_3D)
                     pos[0] = xp;
@@ -209,8 +203,7 @@ scrapeParticlesAtEB (PC& pc, ablastr::fields::MultiLevelScalarField const& dista
 #elif (defined WARPX_DIM_1D_Z)
                     pos[0] = zp;
 #endif
-                    f(ptd, ip, pos, normal, engine);
-
+                    f(ptd, ip, pos, engine);
                 }
             });
         }

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -120,7 +120,7 @@ struct FindEmbeddedBoundaryIntersection {
         UpdatePosition(x_temp, y_temp, z_temp, ux, uy, uz, -dt_fraction*m_dt, m_mass);
 
         // record the components of the normal on the destination
-        amrex::RealVect normal = DistanceToEB::interp_normal(x_temp, y_temp, z_temp, plo, dxi, phiarr);
+        amrex::RealVect const normal = DistanceToEB::interp_normal(x_temp, y_temp, z_temp, plo, dxi, phiarr);
 
 #if (defined WARPX_DIM_3D)
         dst.m_rdata[PIdx::x][dst_i] = x_temp;
@@ -149,7 +149,7 @@ struct FindEmbeddedBoundaryIntersection {
         dst.m_runtime_rdata[m_normal_index+2][dst_i] = normal[1];
 #elif (defined WARPX_DIM_1D_Z)
         dst.m_rdata[PIdx::z][dst_i] = z_temp;
-        amrex::ignore_unused(x_temp, y_temp);
+        amrex::ignore_unused(x_temp, y_temp, normal);
         //normal not defined
         dst.m_runtime_rdata[m_normal_index][dst_i] = 0.0;
         dst.m_runtime_rdata[m_normal_index+1][dst_i] = 0.0;
@@ -162,6 +162,7 @@ struct FindEmbeddedBoundaryIntersection {
         dst.m_rdata[PIdx::r][dst_i] = std::sqrt(x_temp*x_temp + y_temp*y_temp + z_temp*z_temp);
 #endif
         //normal not defined
+        amrex::ignore_unused(normal);
         dst.m_runtime_rdata[m_normal_index][dst_i] = 0.0;
         dst.m_runtime_rdata[m_normal_index+1][dst_i] = 0.0;
         dst.m_runtime_rdata[m_normal_index+2][dst_i] = 0.0;

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -120,16 +120,7 @@ struct FindEmbeddedBoundaryIntersection {
         UpdatePosition(x_temp, y_temp, z_temp, ux, uy, uz, -dt_fraction*m_dt, m_mass);
 
         // record the components of the normal on the destination
-        int i, j, k;
-        amrex::Real W[AMREX_SPACEDIM][2];
-        ablastr::particles::compute_weights<amrex::IndexType::NODE>(
-            x_temp, y_temp, z_temp, plo, dxi, i, j, k, W);
-        int ic, jc, kc; // Cell-centered indices
-        amrex::Real Wc[AMREX_SPACEDIM][2]; // Cell-centered weight
-        ablastr::particles::compute_weights<amrex::IndexType::CELL>(
-            x_temp, y_temp, z_temp, plo, dxi, ic, jc, kc, Wc);
-        amrex::RealVect normal = DistanceToEB::interp_normal(i, j, k, W, ic, jc, kc, Wc, phiarr, dxi);
-        DistanceToEB::normalize(normal);
+        amrex::RealVect normal = DistanceToEB::interp_normal(x_temp, y_temp, z_temp, plo, dxi, phiarr);
 
 #if (defined WARPX_DIM_3D)
         dst.m_rdata[PIdx::x][dst_i] = x_temp;


### PR DESCRIPTION
# Changes

Two related cleanups to the embedded-boundary (EB) normal-vector code, extracted from #6588 so they can be reviewed independently. This is a pure refactor: no change in behavior.

## 1. Simpler `DistanceToEB::interp_normal` API

`interp_normal` now takes a **particle position** and the geometry (`plo`, `dxi`) and computes the nodal / cell-centered interpolation weights internally, returning a **unit** normal (normalization folded in). This replaces the previous form, which required the caller to precompute both sets of weights and then call `normalize()` separately.

As a result:
- the standalone `DistanceToEB::normalize()` helper is removed (folded into `interp_normal`);
- removes ~8 lines of boilerplate code at the calling site of `interp_normal`.

This is useful for #6588, since that PR will add another call to `interp_normal` and we don't want to add the same ~8 lines of boilerplate code.

## 2. Drop the unused normal in `scrapeParticlesAtEB`

`scrapeParticlesAtEB` was interpolating the surface normal at the particle's position and passing it to the boundary functor, but **no functor used it**. This was originally done in preparation for the reflective boundary functor (i.e. what #6588). But when implementing #6588, we realized that this computation of `normal` cannot be actually used because:
- We first need to find the position of the intersection point (i.e. the intersection between the particle trajectory and the EB)
- Only then can we compute the accurate normal vector **at the intersection point**

Thus, the normal computation is removed here, and the `normal` argument is dropped from the scraper functor interface (`NoOp`, `Absorb`). In #6588, the normal is computed again, but in a different place of the code (i.e. only after finding the position of the intersection point).