### PR TITLE
Fix stale ../../../../warpx/ paths in test analysis scripts

### DIFF
--- a/Examples/Tests/collider_relevant_diags/analysis.py
+++ b/Examples/Tests/collider_relevant_diags/analysis.py
@@ -7,7 +7,7 @@ import openpmd_api as io
 import pandas as pd
 from scipy.constants import c, e, hbar, m_e
 
-sys.path.append("../../../../warpx/Tools/Parser/")
+sys.path.append("../../../Tools/Parser/")
 from input_file_parser import parse_input_file
 
 E_crit = m_e**2 * c**3 / (e * hbar)

--- a/Examples/Tests/collision/analysis_test_2d_collisions_split_momentum_push.py
+++ b/Examples/Tests/collision/analysis_test_2d_collisions_split_momentum_push.py
@@ -17,7 +17,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from scipy import constants
 
-sys.path.append("../../../../warpx/Tools/Parser/")
+sys.path.append("../../../Tools/Parser/")
 from input_file_parser import parse_input_file
 
 

--- a/Examples/Tests/pass_mpi_communicator/analysis.py
+++ b/Examples/Tests/pass_mpi_communicator/analysis.py
@@ -13,7 +13,7 @@ import yt
 yt.funcs.mylog.setLevel(50)
 import numpy as np
 
-sys.path.insert(1, "../../../../warpx/Regression/Checksum/")
+sys.path.insert(1, "../../../Regression/Checksum/")
 import checksum
 
 # this will be the name of the first plot file


### PR DESCRIPTION
I think this fixes the issue that was raised in https://github.com/BLAST-WarpX/warpx/pull/6638#issuecomment-4009086891 and https://github.com/BLAST-WarpX/warpx/pull/6638#issuecomment-4056541007 some time ago, by at least removing the literal directory name `warpx`, which would break local CTest runs for those who have named the root directory differently.