### PR TITLE
[WIP] Clean up duplicated code, using `set_particle_position`

### DIFF
--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.H
@@ -130,15 +130,21 @@ struct LorentzTransformParticles
         // weighted sum of old and new values
 #if !defined(WARPX_DIM_1D_Z)
         const amrex::ParticleReal xp = m_xpold[i_src] * weight_old + xpnew * weight_new;
+#else
+        amrex::ParticleReal constexpr xp = 0._rt;
 #endif
 #if defined(WARPX_DIM_3D) || defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
         const amrex::ParticleReal yp = m_ypold[i_src] * weight_old + ypnew * weight_new;
+#else
+        amrex::ParticleReal constexpr yp = 0._rt;
 #endif
 #if !defined(WARPX_DIM_RCYLINDER)
         const amrex::Real z_new_p = m_gammaboost* ( zpnew + m_betaboost * m_Phys_c * m_t_boost);
         const amrex::Real z_old_p = m_gammaboost * ( m_zpold[i_src] + m_betaboost
                                                      * m_Phys_c * (m_t_boost - m_dt ) );
         const amrex::ParticleReal zp = z_old_p * weight_old + z_new_p * weight_new;
+#else
+        amrex::ParticleReal constexpr zp = 0._rt;
 #endif
         const amrex::ParticleReal uxp = m_uxpold[i_src] * weight_old
                                       + m_uxpnew[i_src] * weight_new;
@@ -146,28 +152,7 @@ struct LorentzTransformParticles
                                       + m_uypnew[i_src] * weight_new;
         const amrex::ParticleReal uzp = uz_old_p * weight_old
                                       + uz_new_p * weight_new;
-#if defined (WARPX_DIM_3D)
-        dst.m_rdata[PIdx::x][i_dst] = xp;
-        dst.m_rdata[PIdx::y][i_dst] = yp;
-        dst.m_rdata[PIdx::z][i_dst] = zp;
-#elif defined (WARPX_DIM_RZ)
-        dst.m_rdata[PIdx::r][i_dst] = std::sqrt(xp*xp + yp*yp);
-        dst.m_rdata[PIdx::z][i_dst] = zp;
-        dst.m_rdata[PIdx::theta][i_dst] = std::atan2(yp, xp);
-#elif defined(WARPX_DIM_RCYLINDER)
-        dst.m_rdata[PIdx::r][i_dst] = std::sqrt(xp*xp + yp*yp);
-        dst.m_rdata[PIdx::theta][i_dst] = std::atan2(yp, xp);
-#elif defined(WARPX_DIM_RSPHERE)
-        amrex::ParticleReal const rpxy = std::sqrt(xp*xp + yp*yp);
-        dst.m_rdata[PIdx::r][i_dst] = std::sqrt(xp*xp + yp*yp + zp*zp);
-        dst.m_rdata[PIdx::theta][i_dst] = std::atan2(yp, xp);
-        dst.m_rdata[PIdx::phi][i_dst] = std::atan2(rpxy, zp);
-#elif defined (WARPX_DIM_XZ)
-        dst.m_rdata[PIdx::x][i_dst] = xp;
-        dst.m_rdata[PIdx::z][i_dst] = zp;
-#elif defined (WARPX_DIM_1D_Z)
-        dst.m_rdata[PIdx::z][i_dst] = zp;
-#endif
+        set_particle_position( dst, i_dst, xp, yp, zp );
         dst.m_rdata[PIdx::w][i_dst] = m_wpnew[i_src];
         dst.m_rdata[PIdx::ux][i_dst] = uxp;
         dst.m_rdata[PIdx::uy][i_dst] = uyp;

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -82,7 +82,7 @@ struct FindEmbeddedBoundaryIntersection {
         // Move it to the point of intersection with the embedded boundary
         // (which is found by using a bisection algorithm)
 
-        const auto& p = dst.getSuperParticle(dst_i);
+        auto p = dst.getSuperParticle(dst_i);
         amrex::ParticleReal xp, yp, zp;
         get_particle_position( p, xp, yp, zp );
         amrex::ParticleReal const ux = dst.m_rdata[PIdx::ux][dst_i];
@@ -123,24 +123,8 @@ struct FindEmbeddedBoundaryIntersection {
         auto const n3d = DistanceToEB::interp_normal(x_temp, y_temp, z_temp, plo, dxi, phiarr);
 
         // record the position of the intersection point on the destination
-#if (defined WARPX_DIM_3D)
-        dst.m_rdata[PIdx::x][dst_i] = x_temp;
-        dst.m_rdata[PIdx::y][dst_i] = y_temp;
-        dst.m_rdata[PIdx::z][dst_i] = z_temp;
-#elif (defined WARPX_DIM_XZ)
-        dst.m_rdata[PIdx::x][dst_i] = x_temp;
-        dst.m_rdata[PIdx::z][dst_i] = z_temp;
-#elif (defined WARPX_DIM_RZ)
-        dst.m_rdata[PIdx::r][dst_i] = std::sqrt(x_temp*x_temp + y_temp*y_temp);
-        dst.m_rdata[PIdx::z][dst_i] = z_temp;
-        dst.m_rdata[PIdx::theta][dst_i] = std::atan2(y_temp, x_temp);
-#elif (defined WARPX_DIM_1D_Z)
-        dst.m_rdata[PIdx::z][dst_i] = z_temp;
-#elif (defined WARPX_DIM_RCYLINDER)
-        dst.m_rdata[PIdx::r][dst_i] = std::sqrt(x_temp*x_temp + y_temp*y_temp);
-#elif (defined WARPX_DIM_RSPHERE)
-        dst.m_rdata[PIdx::r][dst_i] = std::sqrt(x_temp*x_temp + y_temp*y_temp + z_temp*z_temp);
-#endif
+        set_particle_position( p, x_temp, y_temp, z_temp );
+        dst.setSuperParticle( p, dst_i );
 
         // record the surface normal (in 3D Cartesian coordinates) on the destination
         dst.m_runtime_rdata[m_normal_index][dst_i]   = n3d[0];

--- a/Source/Particles/Pusher/GetAndSetPosition.H
+++ b/Source/Particles/Pusher/GetAndSetPosition.H
@@ -103,6 +103,44 @@ void set_particle_position (WarpXParticleContainer::SuperParticleType& p,
 #endif
 }
 
+/** \brief Set the cartesian position coordinates `x`, `y`, `z` on the
+ *         particle at index `i` of the particle tile data `ptd`
+ *
+ * \tparam T_PIdx particle index enumerator
+ */
+template<typename T_PIdx = PIdx, typename PTD>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void set_particle_position (const PTD& ptd, int i,
+                            amrex::ParticleReal x,
+                            amrex::ParticleReal y,
+                            amrex::ParticleReal z) noexcept
+{
+    amrex::ignore_unused(x, y, z);
+
+#if defined(WARPX_DIM_RZ)
+    ptd.m_rdata[T_PIdx::theta][i] = std::atan2(y, x);
+    ptd.m_rdata[T_PIdx::r][i] = std::sqrt(x*x + y*y);
+    ptd.m_rdata[PIdx::z][i] = z;
+#elif defined(WARPX_DIM_RCYLINDER)
+    ptd.m_rdata[T_PIdx::theta][i] = std::atan2(y, x);
+    ptd.m_rdata[T_PIdx::r][i] = std::sqrt(x*x + y*y);
+#elif defined(WARPX_DIM_RSPHERE)
+    amrex::ParticleReal const rxy = std::sqrt(x*x + y*y);
+    ptd.m_rdata[T_PIdx::r][i] = std::sqrt(x*x + y*y + z*z);
+    ptd.m_rdata[T_PIdx::theta][i] = std::atan2(y, x);
+    ptd.m_rdata[T_PIdx::phi][i] = std::atan2(z, rxy);
+#elif defined(WARPX_DIM_3D)
+    ptd.m_rdata[PIdx::x][i] = x;
+    ptd.m_rdata[PIdx::y][i] = y;
+    ptd.m_rdata[PIdx::z][i] = z;
+#elif defined(WARPX_DIM_XZ)
+    ptd.m_rdata[PIdx::x][i] = x;
+    ptd.m_rdata[PIdx::z][i] = z;
+#else
+    ptd.m_rdata[PIdx::z][i] = z;
+#endif
+}
+
 /** \brief Functor that can be used to extract the positions of the macroparticles
  *         inside a ParallelFor kernel
  *

--- a/Source/Particles/Pusher/GetAndSetPosition.H
+++ b/Source/Particles/Pusher/GetAndSetPosition.H
@@ -65,6 +65,44 @@ void get_particle_position (const WarpXParticleContainer::SuperParticleType& p,
 #endif
 }
 
+/** \brief Set the cartesian position coordinates `x`, `y`, `z` on the
+ *         particle p. This version operates on a SuperParticle
+ *
+ * \tparam T_PIdx particle index enumerator
+ */
+template<typename T_PIdx = PIdx>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void set_particle_position (WarpXParticleContainer::SuperParticleType& p,
+                            amrex::ParticleReal x,
+                            amrex::ParticleReal y,
+                            amrex::ParticleReal z) noexcept
+{
+    amrex::ignore_unused(x, y, z);
+
+#if defined(WARPX_DIM_RZ)
+    p.rdata(T_PIdx::theta) = std::atan2(y, x);
+    p.rdata(T_PIdx::r) = std::sqrt(x*x + y*y);
+    p.rdata(PIdx::z) = z;
+#elif defined(WARPX_DIM_RCYLINDER)
+    p.rdata(T_PIdx::theta) = std::atan2(y, x);
+    p.rdata(T_PIdx::r) = std::sqrt(x*x + y*y);
+#elif defined(WARPX_DIM_RSPHERE)
+    amrex::ParticleReal const rxy = std::sqrt(x*x + y*y);
+    p.rdata(T_PIdx::r) = std::sqrt(x*x + y*y + z*z);
+    p.rdata(T_PIdx::theta) = std::atan2(y, x);
+    p.rdata(T_PIdx::phi) = std::atan2(z, rxy);
+#elif defined(WARPX_DIM_3D)
+    p.rdata(PIdx::x) = x;
+    p.rdata(PIdx::y) = y;
+    p.rdata(PIdx::z) = z;
+#elif defined(WARPX_DIM_XZ)
+    p.rdata(PIdx::x) = x;
+    p.rdata(PIdx::z) = z;
+#else
+    p.rdata(PIdx::z) = z;
+#endif
+}
+
 /** \brief Functor that can be used to extract the positions of the macroparticles
  *         inside a ParallelFor kernel
  *


### PR DESCRIPTION
- Create a new `set_particle_position` free function, mirroring the existing `get_particle_position helper`.
- Use it to cleanup geometry-dependent code