### PR TITLE
Fix RSPHERE phi computation in LorentzTransformParticles

### DIFF
--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.H
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformParticleFunctor.H
@@ -161,7 +161,7 @@ struct LorentzTransformParticles
         amrex::ParticleReal const rpxy = std::sqrt(xp*xp + yp*yp);
         dst.m_rdata[PIdx::r][i_dst] = std::sqrt(xp*xp + yp*yp + zp*zp);
         dst.m_rdata[PIdx::theta][i_dst] = std::atan2(yp, xp);
-        dst.m_rdata[PIdx::phi][i_dst] = std::atan2(rpxy, zp);
+        dst.m_rdata[PIdx::phi][i_dst] = std::atan2(zp, rpxy);
 #elif defined (WARPX_DIM_XZ)
         dst.m_rdata[PIdx::x][i_dst] = xp;
         dst.m_rdata[PIdx::z][i_dst] = zp;


### PR DESCRIPTION
`atan2` arguments were reversed, giving the wrong polar angle convention compared to [`SetParticlePosition`](https://github.com/BLAST-WarpX/warpx/blob/6c04a74dc578ab43a908fd0e859cd6c47c44d610/Source/Particles/Pusher/GetAndSetPosition.H#L285) (`phi = atan2(z, rxy)`, not `atan2(rxy, z)`).