### PR TITLE
Re-enable test_3d_eb_picmi_restart

### DIFF
--- a/Examples/Tests/restart_eb/CMakeLists.txt
+++ b/Examples/Tests/restart_eb/CMakeLists.txt
@@ -13,15 +13,14 @@ if(WarpX_EB)
     )
 endif()
 
-# FIXME
-#if(WarpX_EB)
-#    add_warpx_test(
-#        test_3d_eb_picmi_restart  # name
-#        3  # dims
-#        1  # nprocs
-#        "inputs_test_3d_eb_picmi.py amr.restart='../test_3d_eb_picmi/diags/chk000030'"  # inputs
-#        "analysis_default_restart.py diags/diag1000060"  # analysis
-#        "analysis_default_regression.py --path diags/diag1000060"  # checksum
-#        test_3d_eb_picmi  # dependency
-#    )
-#endif()
+if(WarpX_EB)
+    add_warpx_test(
+        test_3d_eb_picmi_restart  # name
+        3  # dims
+        1  # nprocs
+        "inputs_test_3d_eb_picmi.py amr.restart='../test_3d_eb_picmi/diags/chk000030'"  # inputs
+        "analysis_default_restart.py diags/diag1000060"  # analysis
+        "analysis_default_regression.py --path diags/diag1000060"  # checksum
+        test_3d_eb_picmi  # dependency
+    )
+endif()


### PR DESCRIPTION
Re-enable `test_3d_eb_picmi_restart`, which seems to pass without having to fix anything.

Close the first sub-issue in #5221. In fact, since #7067 has been merged, this PR closes #5221 entirely.