### PR TITLE
[WIP] Add Thermal option for boundary.particle_eb

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1013,7 +1013,14 @@ additionally define the electric potential at the embedded boundary with an anal
 
     * ``Absorbing``: Particles that reach the embedded boundary are deleted. This is the default behavior.
 
-    * ``Reflecting``: Particles that reach the embedded boundary are specularly reflected back into the simulation domain
+    * ``Reflecting``: Particles that reach the embedded boundary are specularly reflected back into the simulation domain.
+
+    * ``Thermal``: Particles that reach the embedded boundary are re-emitted back into the simulation domain
+      with a thermalized velocity, as from a fully accommodating diffuse wall. The two velocity components
+      tangential to the local surface are sampled from a ``gaussian`` distribution, and the component along
+      the (inward) surface normal is sampled from a ``gaussian flux`` distribution.
+      The standard deviation for these distributions should be provided for each species using
+      ``boundary.<species_name>.u_th``. The same standard deviation is used to sample all components.
 
 .. _param-particle-thermalizer:
 

--- a/Examples/Tests/particle_boundary_interaction/CMakeLists.txt
+++ b/Examples/Tests/particle_boundary_interaction/CMakeLists.txt
@@ -20,4 +20,13 @@ if(WarpX_EB)
         "analysis_default_regression.py --path diags/diag1/"  # checksum
         OFF  # dependency
     )
+    add_warpx_test(
+        test_3d_particle_boundary_interaction_thermal_eb  # name
+        3  # dims
+        1  # nprocs
+        inputs_test_3d_particle_boundary_interaction_thermal_eb  # inputs
+        "analysis_thermal.py diags/diag1/"  # analysis
+        OFF  # checksum (statistical test; validated by analysis_thermal.py)
+        OFF  # dependency
+    )
 endif()

--- a/Examples/Tests/particle_boundary_interaction/analysis_thermal.py
+++ b/Examples/Tests/particle_boundary_interaction/analysis_thermal.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+"""
+This script tests the ``Thermal`` value of ``boundary.particle_eb``.
+
+A cold, low-density beam of electrons is launched at a planar embedded boundary
+(a wall at x = x_wall, with the physics region at x < x_wall). Each electron
+that reaches the wall is re-emitted with a thermalized velocity, as from a fully
+accommodating diffuse wall: the two components tangential to the wall (y, z) are
+sampled from a Gaussian of standard deviation u_th, and the component along the
+inward normal (-x) from a Gaussian-flux (Rayleigh-like) distribution with the
+same standard deviation.
+
+By the end of the simulation all electrons have re-emitted (and none has had time
+to reach the far x boundary), so the recorded velocity distribution is entirely
+set by the thermal boundary. This script checks that:
+  - all electrons move away from the wall (ux < 0),
+  - the tangential components uy, uz are zero-mean Gaussians of std u_th,
+  - the normal component |ux| follows a Gaussian-flux distribution, whose mean is
+    u_th * sqrt(pi/2).
+Here (ux, uy, uz) are the proper velocities gamma*v normalized by c, which is the
+convention in which u_th is expressed.
+"""
+
+import sys
+
+sys.path.append("../../../Tools/Parser/")
+
+import numpy as np
+from input_file_parser import parse_input_file
+from openpmd_viewer import OpenPMDTimeSeries
+
+# Open plotfile specified in command line
+filename = sys.argv[1]
+ts = OpenPMDTimeSeries(filename)
+
+# Read the thermal velocity used by the boundary from the input file, so that the
+# reference values below automatically follow any change of the input parameter.
+input_dict = parse_input_file("./warpx_used_inputs")
+uth = float(input_dict["my_constants.uth_e"][0])
+
+# Velocities of the re-emitted electrons at the final iteration. openPMD-viewer
+# returns ux, uy, uz as the proper velocity gamma*v normalized by c.
+it = ts.iterations
+ux, uy, uz = ts.get_particle(["ux", "uy", "uz"], species="electrons", iteration=it[-1])
+
+n = ux.size
+print(f"Number of re-emitted electrons: {n}")
+assert n > 1000, "Not enough particles for a meaningful statistical test"
+
+# All electrons must move away from the wall, i.e. along the inward normal (-x).
+frac_into_domain = np.mean(ux < 0.0)
+print(f"Fraction of electrons moving into the domain (ux < 0): {frac_into_domain:.4f}")
+assert frac_into_domain > 0.999
+
+# Statistical moments of the re-emitted velocity distribution.
+mean_abs_ux = np.mean(np.abs(ux))
+expected_mean_abs_ux = uth * np.sqrt(np.pi / 2.0)  # mean of a Gaussian-flux dist.
+std_uy = np.std(uy)
+std_uz = np.std(uz)
+mean_uy = np.mean(uy)
+mean_uz = np.mean(uz)
+
+print(f"mean(|ux|) = {mean_abs_ux:.6e} (expected {expected_mean_abs_ux:.6e})")
+print(f"std(uy)    = {std_uy:.6e} (expected {uth:.6e})")
+print(f"std(uz)    = {std_uz:.6e} (expected {uth:.6e})")
+print(f"mean(uy)   = {mean_uy:.6e} (expected 0)")
+print(f"mean(uz)   = {mean_uz:.6e} (expected 0)")
+
+# Generous tolerances: the statistical error on these moments is well below 2% for
+# the ~1e4 particles used here, so a 15% tolerance leaves a large safety margin.
+tol = 0.15
+assert abs(mean_abs_ux - expected_mean_abs_ux) / expected_mean_abs_ux < tol
+assert abs(std_uy - uth) / uth < tol
+assert abs(std_uz - uth) / uth < tol
+assert abs(mean_uy) < 0.1 * uth
+assert abs(mean_uz) < 0.1 * uth
+
+print("\nTest particle_boundary_interaction_thermal_eb passed")

--- a/Examples/Tests/particle_boundary_interaction/inputs_test_3d_particle_boundary_interaction_thermal_eb
+++ b/Examples/Tests/particle_boundary_interaction/inputs_test_3d_particle_boundary_interaction_thermal_eb
@@ -1,0 +1,81 @@
+#################################
+####### GENERAL PARAMETERS ######
+#################################
+max_step = 30
+
+amr.n_cell = 48 8 8
+amr.max_level = 0
+amr.max_grid_size = 48
+
+geometry.dims = 3
+# Cubic cells of size 2.5e-4. The lower x boundary (far from the wall) is placed
+# far enough that no re-emitted particle can reach it during the simulation.
+geometry.prob_lo = -1.0e-2 -1.0e-3 -1.0e-3
+geometry.prob_hi =  2.0e-3  1.0e-3  1.0e-3
+
+#################################
+###### BOUNDARY CONDITIONS ######
+#################################
+boundary.field_lo = pec periodic periodic
+boundary.field_hi = pec periodic periodic
+boundary.particle_lo = absorbing periodic periodic
+boundary.particle_hi = absorbing periodic periodic
+
+# Embedded boundary: a planar wall at x = x_wall. The physics region is x < x_wall
+# (where the implicit function is negative) and the solid is x > x_wall. x_wall is
+# deliberately placed off-node to avoid a degenerate level-set at grid nodes.
+my_constants.x_wall = 1.0e-4
+warpx.eb_implicit_function = "x - x_wall"
+
+# Re-emit particles from the embedded boundary with a thermalized velocity
+# (fully accommodating diffuse wall), instead of absorbing them (the default).
+boundary.particle_eb = thermal
+# Thermal velocity (u_th = sqrt(k*T/m)/c) used to sample the re-emission
+# distribution for this species. The tangential components are sampled from a
+# Gaussian of standard deviation u_th, and the (inward) normal component from a
+# Gaussian-flux distribution with the same standard deviation.
+my_constants.uth_e = 0.01
+boundary.electrons.u_th = uth_e
+
+#################################
+############ NUMERICS ###########
+#################################
+warpx.const_dt = 1e-11
+warpx.do_electrostatic = labframe
+warpx.poisson_solver = Multigrid
+warpx.self_fields_absolute_tolerance = 1e-7
+algo.particle_shape = 1
+
+#################################
+########### PARTICLES ###########
+#################################
+particles.species_names = electrons
+
+# A cold, low-density beam of electrons is launched towards the wall at
+# ux = 0.1 (proper velocity gamma*v normalized by c). The density is kept low so
+# that self-fields are negligible and the re-emitted velocity distribution is
+# controlled purely by the thermal embedded-boundary condition. The beam is
+# injected in a thin slab close to the wall so that all particles reach it and
+# re-emit well before the end of the simulation.
+electrons.species_type = electron
+electrons.injection_style = NUniformPerCell
+electrons.num_particles_per_cell_each_dim = 4 4 4
+electrons.profile = constant
+electrons.density = 1.0e6
+electrons.xmin = -1.0e-3
+electrons.xmax = -1.0e-4
+electrons.momentum_distribution_type = constant
+electrons.ux = 0.1
+electrons.uy = 0.0
+electrons.uz = 0.0
+electrons.initialize_self_fields = 0
+
+#################################
+########## DIAGNOSTICS ##########
+#################################
+diagnostics.diags_names = diag1
+diag1.intervals = 30
+diag1.diag_type = Full
+diag1.fields_to_plot = rho
+diag1.format = openpmd
+diag1.species = electrons

--- a/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
+++ b/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
@@ -127,6 +127,7 @@ struct ParticleBoundaryInteraction {
         amrex::ParticleReal const n3d_y = n3d[1];
         amrex::ParticleReal const n3d_z = n3d[2];
 
+        amrex::ParticleReal ux_new = 0._prt, uy_new = 0._prt, uz_new = 0._prt;
         if (m_boundary_type == ParticleBoundaryType::Thermal) {
 
             // Re-emit the particle in the (half-Maxwellian normal, full
@@ -146,40 +147,29 @@ struct ParticleBoundaryInteraction {
             amrex::ParticleReal const u_flux =
                 cc * static_cast<amrex::ParticleReal>(generateGaussianFluxDist(0._rt, m_uth, engine));
             amrex::ParticleReal const u_iso_dot_n = ux_iso*n3d_x + uy_iso*n3d_y + uz_iso*n3d_z;
-            amrex::ParticleReal const ux_new = ux_iso + (u_flux - u_iso_dot_n)*n3d_x;
-            amrex::ParticleReal const uy_new = uy_iso + (u_flux - u_iso_dot_n)*n3d_y;
-            amrex::ParticleReal const uz_new = uz_iso + (u_flux - u_iso_dot_n)*n3d_z;
-            ptd.m_rdata[PIdx::ux][i] = ux_new;
-            ptd.m_rdata[PIdx::uy][i] = uy_new;
-            ptd.m_rdata[PIdx::uz][i] = uz_new;
-
-            // Advance from the contact point, with the new velocity,
-            // for the remaining fraction of the timestep
-            amrex::ParticleReal x_new = x_c, y_new = y_c, z_new = z_c;
-            UpdatePosition(x_new, y_new, z_new, ux_new, uy_new, uz_new,
-                           dt_fraction * dt, mass);
-
-            setPosition(i, x_new, y_new, z_new);
+            ux_new = ux_iso + (u_flux - u_iso_dot_n)*n3d_x;
+            uy_new = uy_iso + (u_flux - u_iso_dot_n)*n3d_y;
+            uz_new = uz_iso + (u_flux - u_iso_dot_n)*n3d_z;
         } else {
             // Specular reflection: u_refl = u - 2 (u.n) n
             amrex::ParticleReal const u_dot_n = ux*n3d_x + uy*n3d_y + uz*n3d_z;
-            amrex::ParticleReal const ux_refl = ux - 2.0_prt * u_dot_n * n3d_x;
-            amrex::ParticleReal const uy_refl = uy - 2.0_prt * u_dot_n * n3d_y;
-            amrex::ParticleReal const uz_refl = uz - 2.0_prt * u_dot_n * n3d_z;
-            // Store reflected velocity
-            ptd.m_rdata[PIdx::ux][i] = ux_refl;
-            ptd.m_rdata[PIdx::uy][i] = uy_refl;
-            ptd.m_rdata[PIdx::uz][i] = uz_refl;
-
-            // Advance from the contact point, with the reflected velocity,
-            // for the remaining fraction of the timestep
-            amrex::ParticleReal x_new = x_c, y_new = y_c, z_new = z_c;
-            UpdatePosition(x_new, y_new, z_new, ux_refl, uy_refl, uz_refl,
-                           dt_fraction * dt, mass);
-            // SetParticlePosition handles the conversion to the stored
-            // (reduced-dimension) coordinates.
-            setPosition(i, x_new, y_new, z_new);
+            ux_new = ux - 2.0_prt * u_dot_n * n3d_x;
+            uy_new = uy - 2.0_prt * u_dot_n * n3d_y;
+            uz_new = uz - 2.0_prt * u_dot_n * n3d_z;
         }
+
+        // Store the new velocity
+        ptd.m_rdata[PIdx::ux][i] = ux_new;
+        ptd.m_rdata[PIdx::uy][i] = uy_new;
+        ptd.m_rdata[PIdx::uz][i] = uz_new;
+
+        // Advance from the contact point, with the new velocity, for the
+        // remaining fraction of the timestep. SetParticlePosition handles the
+        // conversion to the stored (reduced-dimension) coordinates.
+        amrex::ParticleReal x_new = x_c, y_new = y_c, z_new = z_c;
+        UpdatePosition(x_new, y_new, z_new, ux_new, uy_new, uz_new,
+                       dt_fraction * dt, mass);
+        setPosition(i, x_new, y_new, z_new);
     }
 };
 

--- a/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
+++ b/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
@@ -129,37 +129,26 @@ struct ParticleBoundaryInteraction {
 
         if (m_boundary_type == ParticleBoundaryType::Thermal) {
 
-            // Build an orthonormal frame (n, t1, t2) out of the surface normal,
-            // to re-emit the particle in the (half-Maxwellian normal, full
-            // Maxwellian tangential) wall distribution.
-            amrex::ParticleReal e0 = 0._prt, e1 = 0._prt, e2 = 0._prt;
-            if (std::abs(n3d_x) <= std::abs(n3d_y) && std::abs(n3d_x) <= std::abs(n3d_z)) {
-                e0 = 1._prt;
-            } else if (std::abs(n3d_y) <= std::abs(n3d_z)) {
-                e1 = 1._prt;
-            } else {
-                e2 = 1._prt;
-            }
-            amrex::ParticleReal const edn = e0*n3d_x + e1*n3d_y + e2*n3d_z;
-            amrex::ParticleReal t10 = e0 - edn*n3d_x;
-            amrex::ParticleReal t11 = e1 - edn*n3d_y;
-            amrex::ParticleReal t12 = e2 - edn*n3d_z;
-            amrex::ParticleReal const t1n = 1._prt/std::sqrt(t10*t10 + t11*t11 + t12*t12);
-            t10 *= t1n; t11 *= t1n; t12 *= t1n;
-            amrex::ParticleReal const t20 = n3d_y*t12 - n3d_z*t11;
-            amrex::ParticleReal const t21 = n3d_z*t10 - n3d_x*t12;
-            amrex::ParticleReal const t22 = n3d_x*t11 - n3d_y*t10;
-
+            // Re-emit the particle in the (half-Maxwellian normal, full
+            // Maxwellian tangential) wall distribution. First draw an
+            // isotropic Maxwellian velocity in 3D, then replace the component
+            // along the normal by a (positive) half-Maxwellian flux velocity,
+            // directed into the domain along n3d. Since n3d is a unit vector,
+            // subtracting the current normal projection (u_iso . n3d) and
+            // adding u_flux leaves the tangential components untouched.
             auto const cc = static_cast<amrex::ParticleReal>(PhysConst::c);
-            amrex::ParticleReal const u_norm =
+            amrex::ParticleReal const ux_iso =
+                cc * static_cast<amrex::ParticleReal>(amrex::RandomNormal(0._rt, m_uth, engine));
+            amrex::ParticleReal const uy_iso =
+                cc * static_cast<amrex::ParticleReal>(amrex::RandomNormal(0._rt, m_uth, engine));
+            amrex::ParticleReal const uz_iso =
+                cc * static_cast<amrex::ParticleReal>(amrex::RandomNormal(0._rt, m_uth, engine));
+            amrex::ParticleReal const u_flux =
                 cc * static_cast<amrex::ParticleReal>(generateGaussianFluxDist(0._rt, m_uth, engine));
-            amrex::ParticleReal const u_tang1 =
-                cc * static_cast<amrex::ParticleReal>(amrex::RandomNormal(0._rt, m_uth, engine));
-            amrex::ParticleReal const u_tang2 =
-                cc * static_cast<amrex::ParticleReal>(amrex::RandomNormal(0._rt, m_uth, engine));
-            amrex::ParticleReal const ux_new = u_norm*n3d_x + u_tang1*t10 + u_tang2*t20;
-            amrex::ParticleReal const uy_new = u_norm*n3d_y + u_tang1*t11 + u_tang2*t21;
-            amrex::ParticleReal const uz_new = u_norm*n3d_z + u_tang1*t12 + u_tang2*t22;
+            amrex::ParticleReal const u_iso_dot_n = ux_iso*n3d_x + uy_iso*n3d_y + uz_iso*n3d_z;
+            amrex::ParticleReal const ux_new = ux_iso + (u_flux - u_iso_dot_n)*n3d_x;
+            amrex::ParticleReal const uy_new = uy_iso + (u_flux - u_iso_dot_n)*n3d_y;
+            amrex::ParticleReal const uz_new = uz_iso + (u_flux - u_iso_dot_n)*n3d_z;
             ptd.m_rdata[PIdx::ux][i] = ux_new;
             ptd.m_rdata[PIdx::uy][i] = uy_new;
             ptd.m_rdata[PIdx::uz][i] = uz_new;

--- a/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
+++ b/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
@@ -8,9 +8,12 @@
 #define WARPX_PARTICLEBOUNDARYPROCESS_H_
 
 #include "EmbeddedBoundary/DistanceToEB.H"
+#include "Initialization/SampleGaussianFluxDistribution.H"
 #include "Particles/Pusher/GetAndSetPosition.H"
 #include "Particles/Pusher/UpdatePosition.H"
 #include "Particles/WarpXParticleContainer.H"
+#include "Utils/WarpXAlgorithmSelection.H"
+#include "Utils/WarpXConst.H"
 
 #include <ablastr/particles/NodalFieldGather.H>
 
@@ -21,6 +24,8 @@
 #include <AMReX_REAL.H>
 #include <AMReX_RealVect.H>
 #include <AMReX_Random.H>
+
+#include <cmath>
 
 
 namespace ParticleBoundaryProcess {
@@ -53,19 +58,29 @@ struct Absorb {
     }
 };
 
-/** \brief Specular reflection off the embedded boundary.
+/** \brief Particle interaction with the embedded boundary, for the
+ *         ``Reflecting`` and ``Thermal`` values of ``boundary.particle_eb``.
  *
  *  For each particle that has crossed into the EB (distance_to_eb < 0), this functor:
  *   - Bisects along the particle trajectory to find the contact point on
  *     the EB surface (where distance_to_eb = 0).
  *   - Computes the surface normal at the exact contact point.
- *   - Performs specular reflection on the momentum: u_new = u - 2*(u . n)*n.
- *   - Advances the particle from the contact point with the reflected
+ *   - Sets the new velocity of the particle, depending on m_boundary_type:
+ *     - Reflecting: specular reflection, u_new = u - 2*(u . n)*n.
+ *     - Thermal: re-emission from a wall Maxwellian (fully accommodating
+ *       diffuse wall): a half-Maxwellian flux distribution along the
+ *       (outward, into the domain) normal, and a full Maxwellian in the
+ *       tangential plane, with thermal speed m_uth (same convention as the
+ *       domain thermal particle boundary, see
+ *       ApplyParticleBoundaries::thermalize_boundary_particle).
+ *   - Advances the particle from the contact point with the new
  *     velocity for the remaining fraction of the timestep.
  */
-struct Reflect {
+struct ParticleBoundaryInteraction {
     amrex::Real m_dt;
     amrex::ParticleReal m_mass;
+    ParticleBoundaryType m_boundary_type;
+    amrex::ParticleReal m_uth = 0._prt;
 
     template <typename PData>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -75,7 +90,7 @@ struct Reflect {
                      amrex::Array4<const amrex::Real> const& distance_to_eb,
                      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const& plo,
                      amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const& dxi,
-                     amrex::RandomEngine const& /*engine*/) const noexcept
+                     amrex::RandomEngine const& engine) const noexcept
     {
         using namespace amrex::literals;
 
@@ -105,30 +120,95 @@ struct Reflect {
         UpdatePosition(x_c, y_c, z_c, ux, uy, uz, -dt_fraction * dt, mass);
 
         // Compute the surface normal vector at the contact point, in 3D
-        // Cartesian coordinates (as is the velocity below).
+        // Cartesian coordinates (as is the velocity below). The normal
+        // points away from the EB solid, into the domain (gas region).
         auto const n3d = DistanceToEB::interp_normal(x_c, y_c, z_c, plo, dxi, distance_to_eb);
         amrex::ParticleReal const n3d_x = n3d[0];
         amrex::ParticleReal const n3d_y = n3d[1];
         amrex::ParticleReal const n3d_z = n3d[2];
 
-        // Specular reflection: u_refl = u - 2 (u.n) n
-        amrex::ParticleReal const u_dot_n = ux*n3d_x + uy*n3d_y + uz*n3d_z;
-        amrex::ParticleReal const ux_refl = ux - 2.0_prt * u_dot_n * n3d_x;
-        amrex::ParticleReal const uy_refl = uy - 2.0_prt * u_dot_n * n3d_y;
-        amrex::ParticleReal const uz_refl = uz - 2.0_prt * u_dot_n * n3d_z;
-        // Store reflected velocity
-        ptd.m_rdata[PIdx::ux][i] = ux_refl;
-        ptd.m_rdata[PIdx::uy][i] = uy_refl;
-        ptd.m_rdata[PIdx::uz][i] = uz_refl;
+        if (m_boundary_type == ParticleBoundaryType::Thermal) {
+            // Degenerate level-set gradient at a sharp corner makes the
+            // (internally normalized) normal non-finite: absorb the particle
+            // rather than re-emit it in an ill-defined direction.
+            if (!(std::isfinite(n3d_x) && std::isfinite(n3d_y) && std::isfinite(n3d_z))) {
+                amrex::ParticleIDWrapper{ptd.m_idcpu[i]}.make_invalid();
+                return;
+            }
 
-        // Advance from the contact point, with the reflected velocity,
-        // for the remaining fraction of the timestep
-        amrex::ParticleReal x_new = x_c, y_new = y_c, z_new = z_c;
-        UpdatePosition(x_new, y_new, z_new, ux_refl, uy_refl, uz_refl,
-                       dt_fraction * dt, mass);
-        // SetParticlePosition handles the conversion to the stored
-        // (reduced-dimension) coordinates.
-        setPosition(i, x_new, y_new, z_new);
+            // Build an orthonormal frame (n, t1, t2) out of the surface normal,
+            // to re-emit the particle in the (half-Maxwellian normal, full
+            // Maxwellian tangential) wall distribution.
+            amrex::ParticleReal e0 = 0._prt, e1 = 0._prt, e2 = 0._prt;
+            if (std::abs(n3d_x) <= std::abs(n3d_y) && std::abs(n3d_x) <= std::abs(n3d_z)) {
+                e0 = 1._prt;
+            } else if (std::abs(n3d_y) <= std::abs(n3d_z)) {
+                e1 = 1._prt;
+            } else {
+                e2 = 1._prt;
+            }
+            amrex::ParticleReal const edn = e0*n3d_x + e1*n3d_y + e2*n3d_z;
+            amrex::ParticleReal t10 = e0 - edn*n3d_x;
+            amrex::ParticleReal t11 = e1 - edn*n3d_y;
+            amrex::ParticleReal t12 = e2 - edn*n3d_z;
+            amrex::ParticleReal const t1n = 1._prt/std::sqrt(t10*t10 + t11*t11 + t12*t12);
+            t10 *= t1n; t11 *= t1n; t12 *= t1n;
+            amrex::ParticleReal const t20 = n3d_y*t12 - n3d_z*t11;
+            amrex::ParticleReal const t21 = n3d_z*t10 - n3d_x*t12;
+            amrex::ParticleReal const t22 = n3d_x*t11 - n3d_y*t10;
+
+            auto const cc = static_cast<amrex::ParticleReal>(PhysConst::c);
+            amrex::ParticleReal const u_norm =
+                cc * static_cast<amrex::ParticleReal>(generateGaussianFluxDist(0._rt, m_uth, engine));
+            amrex::ParticleReal const u_tang1 =
+                cc * static_cast<amrex::ParticleReal>(amrex::RandomNormal(0._rt, m_uth, engine));
+            amrex::ParticleReal const u_tang2 =
+                cc * static_cast<amrex::ParticleReal>(amrex::RandomNormal(0._rt, m_uth, engine));
+            amrex::ParticleReal const ux_new = u_norm*n3d_x + u_tang1*t10 + u_tang2*t20;
+            amrex::ParticleReal const uy_new = u_norm*n3d_y + u_tang1*t11 + u_tang2*t21;
+            amrex::ParticleReal const uz_new = u_norm*n3d_z + u_tang1*t12 + u_tang2*t22;
+            ptd.m_rdata[PIdx::ux][i] = ux_new;
+            ptd.m_rdata[PIdx::uy][i] = uy_new;
+            ptd.m_rdata[PIdx::uz][i] = uz_new;
+
+            // Advance from the contact point, with the new velocity,
+            // for the remaining fraction of the timestep
+            amrex::ParticleReal x_new = x_c, y_new = y_c, z_new = z_c;
+            UpdatePosition(x_new, y_new, z_new, ux_new, uy_new, uz_new,
+                           dt_fraction * dt, mass);
+
+            // If re-emission still lands inside the solid (sharp concave
+            // corner), absorb the particle rather than let it accumulate
+            // inside the EB.
+            int ri, rj, rk;
+            amrex::Real rW[AMREX_SPACEDIM][2];
+            ablastr::particles::compute_weights<amrex::IndexType::NODE>(
+                x_new, y_new, z_new, plo, dxi, ri, rj, rk, rW);
+            if (ablastr::particles::interp_field_nodal(ri, rj, rk, rW, distance_to_eb) < 0.0) {
+                amrex::ParticleIDWrapper{ptd.m_idcpu[i]}.make_invalid();
+                return;
+            }
+            setPosition(i, x_new, y_new, z_new);
+        } else {
+            // Specular reflection: u_refl = u - 2 (u.n) n
+            amrex::ParticleReal const u_dot_n = ux*n3d_x + uy*n3d_y + uz*n3d_z;
+            amrex::ParticleReal const ux_refl = ux - 2.0_prt * u_dot_n * n3d_x;
+            amrex::ParticleReal const uy_refl = uy - 2.0_prt * u_dot_n * n3d_y;
+            amrex::ParticleReal const uz_refl = uz - 2.0_prt * u_dot_n * n3d_z;
+            // Store reflected velocity
+            ptd.m_rdata[PIdx::ux][i] = ux_refl;
+            ptd.m_rdata[PIdx::uy][i] = uy_refl;
+            ptd.m_rdata[PIdx::uz][i] = uz_refl;
+
+            // Advance from the contact point, with the reflected velocity,
+            // for the remaining fraction of the timestep
+            amrex::ParticleReal x_new = x_c, y_new = y_c, z_new = z_c;
+            UpdatePosition(x_new, y_new, z_new, ux_refl, uy_refl, uz_refl,
+                           dt_fraction * dt, mass);
+            // SetParticlePosition handles the conversion to the stored
+            // (reduced-dimension) coordinates.
+            setPosition(i, x_new, y_new, z_new);
+        }
     }
 };
 

--- a/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
+++ b/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
@@ -170,17 +170,6 @@ struct ParticleBoundaryInteraction {
             UpdatePosition(x_new, y_new, z_new, ux_new, uy_new, uz_new,
                            dt_fraction * dt, mass);
 
-            // If re-emission still lands inside the solid (sharp concave
-            // corner), absorb the particle rather than let it accumulate
-            // inside the EB.
-            int ri, rj, rk;
-            amrex::Real rW[AMREX_SPACEDIM][2];
-            ablastr::particles::compute_weights<amrex::IndexType::NODE>(
-                x_new, y_new, z_new, plo, dxi, ri, rj, rk, rW);
-            if (ablastr::particles::interp_field_nodal(ri, rj, rk, rW, distance_to_eb) < 0.0) {
-                amrex::ParticleIDWrapper{ptd.m_idcpu[i]}.make_invalid();
-                return;
-            }
             setPosition(i, x_new, y_new, z_new);
         } else {
             // Specular reflection: u_refl = u - 2 (u.n) n

--- a/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
+++ b/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
@@ -80,7 +80,7 @@ struct ParticleBoundaryInteraction {
     amrex::Real m_dt;
     amrex::ParticleReal m_mass;
     ParticleBoundaryType m_boundary_type;
-    amrex::ParticleReal m_uth = 0._prt;
+    amrex::ParticleReal m_uth = amrex::ParticleReal(0);
 
     template <typename PData>
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
+++ b/Source/EmbeddedBoundary/ParticleBoundaryProcess.H
@@ -128,13 +128,6 @@ struct ParticleBoundaryInteraction {
         amrex::ParticleReal const n3d_z = n3d[2];
 
         if (m_boundary_type == ParticleBoundaryType::Thermal) {
-            // Degenerate level-set gradient at a sharp corner makes the
-            // (internally normalized) normal non-finite: absorb the particle
-            // rather than re-emit it in an ill-defined direction.
-            if (!(std::isfinite(n3d_x) && std::isfinite(n3d_y) && std::isfinite(n3d_z))) {
-                amrex::ParticleIDWrapper{ptd.m_idcpu[i]}.make_invalid();
-                return;
-            }
 
             // Build an orthonormal frame (n, t1, t2) out of the surface normal,
             // to re-emit the particle in the (half-Maxwellian normal, full

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -1246,14 +1246,17 @@ void MultiParticleContainer::CheckIonizationProductSpecies()
 void MultiParticleContainer::ScrapeParticlesAtEB (
     ablastr::fields::MultiLevelScalarField const& distance_to_eb)
 {
-    if (WarpX::eb_particle_boundary == ParticleBoundaryType::Reflecting) {
+    if (WarpX::eb_particle_boundary == ParticleBoundaryType::Reflecting ||
+        WarpX::eb_particle_boundary == ParticleBoundaryType::Thermal) {
         auto& warpx = WarpX::GetInstance();
         for (auto& pc : allcontainers) {
             amrex::ParticleReal const mass = pc->getMass();
+            amrex::ParticleReal const uth = pc->getBoundaryThermalVelocity();
             for (int lev = 0; lev <= pc->finestLevel(); ++lev) {
                 amrex::Real const dt_lev = warpx.getdt(lev);
                 scrapeParticlesAtEB(*pc, distance_to_eb, lev,
-                    ParticleBoundaryProcess::Reflect{dt_lev, mass});
+                    ParticleBoundaryProcess::ParticleBoundaryInteraction{
+                        dt_lev, mass, WarpX::eb_particle_boundary, uth});
             }
         }
     } else {

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -582,6 +582,14 @@ public:
 
     amrex::ParticleReal getMass () const {return m_mass;}
 
+    /** Thermal velocity (normalized by c) used by thermal particle boundaries
+     *  for this species, parsed from ``boundary.<species_name>.u_th``.
+     */
+    amrex::ParticleReal getBoundaryThermalVelocity () const
+    {
+        return static_cast<amrex::ParticleReal>(m_boundary_conditions.data.m_uth);
+    }
+
     int DoFieldIonization() const { return do_field_ionization; }
 
 #ifdef WARPX_QED

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -297,8 +297,9 @@ void WarpX::MakeWarpX ()
         pp_boundary.query_enum_case_insensitive("particle_eb", eb_particle_boundary);
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             eb_particle_boundary == ParticleBoundaryType::Absorbing ||
-            eb_particle_boundary == ParticleBoundaryType::Reflecting,
-            "boundary.particle_eb must be Absorbing or Reflecting");
+            eb_particle_boundary == ParticleBoundaryType::Reflecting ||
+            eb_particle_boundary == ParticleBoundaryType::Thermal,
+            "boundary.particle_eb must be Absorbing, Reflecting, or Thermal");
     }
 
     CheckGriddingForRZSpectral();
@@ -3564,6 +3565,7 @@ WarpX::isAnyParticleBoundaryThermal ()
         if (WarpX::particle_boundary_lo[idim] == ParticleBoundaryType::Thermal) {return true;}
         if (WarpX::particle_boundary_hi[idim] == ParticleBoundaryType::Thermal) {return true;}
     }
+    if (WarpX::eb_particle_boundary == ParticleBoundaryType::Thermal) {return true;}
     return false;
 }
 

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -3565,8 +3565,7 @@ WarpX::isAnyParticleBoundaryThermal ()
         if (WarpX::particle_boundary_lo[idim] == ParticleBoundaryType::Thermal) {return true;}
         if (WarpX::particle_boundary_hi[idim] == ParticleBoundaryType::Thermal) {return true;}
     }
-    if (WarpX::eb_particle_boundary == ParticleBoundaryType::Thermal) {return true;}
-    return false;
+    return WarpX::eb_particle_boundary == ParticleBoundaryType::Thermal;
 }
 
 void


### PR DESCRIPTION
Particles that reach the embedded boundary can now be re-emitted from a fully accommodating diffuse wall (half-Maxwellian flux along the outward normal, full Maxwellian in the tangential plane), reusing the same per-species thermal velocity as the domain thermal particle boundary. Particles are absorbed instead if the surface normal is ill-defined (degenerate level-set gradient at a sharp corner) or if re-emission still lands inside the solid (sharp concave corner).