### PR TITLE
Replace removed scipy interp2d with RegularGridInterpolator

### DIFF
--- a/Examples/Tests/ohm_solver_magnetic_reconnection/analysis.py
+++ b/Examples/Tests/ohm_solver_magnetic_reconnection/analysis.py
@@ -107,8 +107,12 @@ if not sim.test:
     def get_field_lines(Bx, Bz):
         field_line_coords = []
 
-        Bx_interp = interpolate.interp2d(x_grid, z_grid, Bx[:-1].T)
-        Bz_interp = interpolate.interp2d(x_grid, z_grid, Bz[:, :-1].T)
+        Bx_interp = interpolate.RegularGridInterpolator(
+            (x_grid, z_grid), Bx[:-1], bounds_error=False, fill_value=None
+        )
+        Bz_interp = interpolate.RegularGridInterpolator(
+            (x_grid, z_grid), Bz[:, :-1], bounds_error=False, fill_value=None
+        )
 
         for kk, z in enumerate(start_z):
             path_x = [start_x[kk]]
@@ -117,8 +121,8 @@ if not sim.test:
             ii = 0
             while ii < 10000:
                 ii += 1
-                Bx = Bx_interp(path_x[-1], path_z[-1])[0]
-                Bz = Bz_interp(path_x[-1], path_z[-1])[0]
+                Bx = Bx_interp((path_x[-1], path_z[-1])).item()
+                Bz = Bz_interp((path_x[-1], path_z[-1])).item()
 
                 # print(path_x[-1], path_z[-1], Bx, Bz)
 


### PR DESCRIPTION
scipy.interpolate.interp2d was deprecated in SciPy 1.10 and removed in 1.14, so the field-line tracer in the reconnection analysis hard-fails on current SciPy. RegularGridInterpolator takes the value array in natural (x, z) order, so the transpose is dropped rather than moved, and single-point queries return a 0-d array, hence .item() at the call sites. bounds_error=False with fill_value=None (linear extrapolation) guards against float-rounding queries a hair outside the grid; the tracer's own bounds checks still terminate field lines at the domain edge.

Note that this part of the analysis script is not ran during the CI test.