### PR TITLE
Fix and re-enable test_2d_runtime_components_picmi_restart

### DIFF
--- a/Examples/Tests/restart/CMakeLists.txt
+++ b/Examples/Tests/restart/CMakeLists.txt
@@ -21,14 +21,13 @@ add_warpx_test(
     OFF  # dependency
 )
 
-# FIXME
 add_warpx_test(
     test_2d_runtime_components_picmi_restart  # name
     2  # dims
     1  # nprocs
     "inputs_test_2d_runtime_components_picmi.py amr.restart='../test_2d_runtime_components_picmi/diags/chk000005'"  # inputs
-    OFF  #"analysis_default_restart.py diags/diag1000010"  # analysis
-    OFF  #"analysis_default_regression.py --path diags/diag1000010"  # checksum
+    "analysis_default_restart.py diags/diag1000010"  # analysis
+    "analysis_default_regression.py --path diags/diag1000010"  # checksum
     test_2d_runtime_components_picmi  # dependency
 )
 

--- a/Examples/Tests/restart/inputs_test_2d_runtime_components_picmi.py
+++ b/Examples/Tests/restart/inputs_test_2d_runtime_components_picmi.py
@@ -108,6 +108,11 @@ sim.initialize_warpx()
 # below will be reproducible from run to run
 xp, _ = load_cupy()
 xp.random.seed(30025025)
+np.random.seed(30025025)
+
+step_number = sim.extension.warpx.getistep(lev=0)
+# Restore the random state because Python RNGs are not checkpointed.
+np.random.normal(loc=0, scale=1e3, size=30 * step_number)
 
 electrons = sim.particles.get("electrons")
 if not sim.amr_restart:
@@ -152,7 +157,6 @@ callbacks.installbeforestep(add_particles)
 # simulation run
 ##########################
 
-step_number = sim.extension.warpx.getistep(lev=0)
 sim.step(max_steps - 1 - step_number)
 
 #######################################

--- a/Examples/Tests/restart/inputs_test_2d_runtime_components_picmi.py
+++ b/Examples/Tests/restart/inputs_test_2d_runtime_components_picmi.py
@@ -51,7 +51,7 @@ grid = picmi.Cartesian2DGrid(
 solver = picmi.ElectrostaticSolver(
     grid=grid,
     method="Multigrid",
-    required_precision=1e-6,
+    required_precision=1e-8,
     warpx_self_fields_verbosity=0,
 )
 

--- a/Regression/Checksum/benchmarks_json/test_2d_runtime_components_picmi.json
+++ b/Regression/Checksum/benchmarks_json/test_2d_runtime_components_picmi.json
@@ -1,9 +1,9 @@
 {
   "lev=0": {
-    "phi": 0.0015162616250098885
+    "phi": 0.001516277832366790
   },
   "electrons": {
-    "particle_momentum_x": 7.751654401854974e-26,
+    "particle_momentum_x": 7.751654401825959e-26,
     "particle_momentum_y": 6.938526607259151e-26,
     "particle_momentum_z": 6.572519453006187e-26,
     "particle_newPid": 500.0,


### PR DESCRIPTION
Fix and re-enable `test_2d_runtime_components_picmi_restart` as follows:
- Restore NumPy’s random state after restart so callback-injected particles remain reproducible.
- Tighten the electrostatic solver precision for restart comparisons.
- Re-enable restart analysis and checksum validation.
- Update the checksum benchmarks accordingly.

Close the second sub-issue in #5221.