### PR TITLE
Add missing `WarnManager.H` includes for nonlinear solvers

### DIFF
--- a/Source/NonlinearSolvers/CurlCurlMLMGPC.H
+++ b/Source/NonlinearSolvers/CurlCurlMLMGPC.H
@@ -13,6 +13,7 @@
 #include "Preconditioner.H"
 
 #include <ablastr/fields/MultiFabRegister.H>
+#include <ablastr/warn_manager/WarnManager.H>
 
 #include <AMReX.H>
 #include <AMReX_ParmParse.H>

--- a/Source/NonlinearSolvers/MatrixPC.H
+++ b/Source/NonlinearSolvers/MatrixPC.H
@@ -13,6 +13,7 @@
 #include "Preconditioner.H"
 
 #include <ablastr/fields/MultiFabRegister.H>
+#include <ablastr/warn_manager/WarnManager.H>
 
 #include <AMReX.H>
 #include <AMReX_ParmParse.H>

--- a/Source/NonlinearSolvers/NewtonSolver.H
+++ b/Source/NonlinearSolvers/NewtonSolver.H
@@ -13,6 +13,8 @@
 #include "Preconditioner.H"
 #include "Utils/TextMsg.H"
 
+#include <ablastr/warn_manager/WarnManager.H>
+
 #include <AMReX_ParmParse.H>
 #include <AMReX_Config.H>
 


### PR DESCRIPTION
The warning manager is currently included due to the order of `includes` from files that use the non-linear solvers (by first having `#include "WarpXSolverVec.H"`. 
The Darwin implicit solver work (#6293) adds a new solver path/translation unit that instantiates the same MatrixPC/JacobianFunctionMF templates without that same WarpXSolverVec.H first include order propping things up, so the missing include finally surfaces as a real build failure.