### PR TITLE
Allow non-uniform cross-section energy grids

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3073,9 +3073,10 @@ Details about the collision models can be found in the :ref:`theory section <mul
 
     Only for ``dsmc`` and ``background_mcc``. Path to the file containing cross-section data
     for the given scattering processes. The cross-section file must have exactly
-    2 columns of data, the first containing equally spaced energies in eV and the
-    second the corresponding cross-section in :math:`m^2`. The energy column should
-    represent the kinetic energy of the colliding particles in the center-of-mass frame.
+    2 columns of data, the first containing energies in eV and the
+    second the corresponding cross-section in :math:`m^2`. The energies must be sorted in
+    strictly increasing order, but they do not need to be evenly spaced. The energy column
+    should represent the kinetic energy of the colliding particles in the center-of-mass frame.
 
 .. pp:param:: <collision_name>.<scattering_process>_energy
     :type: ``float``

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3074,8 +3074,9 @@ Details about the collision models can be found in the :ref:`theory section <mul
     Only for ``dsmc`` and ``background_mcc``. Path to the file containing cross-section data
     for the given scattering processes. The cross-section file must have exactly
     2 columns of data, the first containing energies in eV and the
-    second the corresponding cross-section in :math:`m^2`. The energies must be sorted in
-    strictly increasing order. The energy column should represent the kinetic energy of the
+    second the corresponding cross-section in :math:`m^2`. The energy column should 
+    represent the kinetic energy of the center-of-mass frame. The energy values in this column
+    must be in strictly increasing order.
     colliding particles in the center-of-mass frame.
 
 .. pp:param:: <collision_name>.<scattering_process>_energy

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3075,8 +3075,8 @@ Details about the collision models can be found in the :ref:`theory section <mul
     for the given scattering processes. The cross-section file must have exactly
     2 columns of data, the first containing energies in eV and the
     second the corresponding cross-section in :math:`m^2`. The energies must be sorted in
-    strictly increasing order, but they do not need to be evenly spaced. The energy column
-    should represent the kinetic energy of the colliding particles in the center-of-mass frame.
+    strictly increasing order. The energy column should represent the kinetic energy of the 
+    colliding particles in the center-of-mass frame.
 
 .. pp:param:: <collision_name>.<scattering_process>_energy
     :type: ``float``

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3074,7 +3074,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
     Only for ``dsmc`` and ``background_mcc``. Path to the file containing cross-section data
     for the given scattering processes. The cross-section file must have exactly
     2 columns of data, the first containing energies in eV and the
-    second the corresponding cross-section in :math:`m^2`. The energy column should 
+    second the corresponding cross-section in :math:`m^2`. The energy column should
     represent the kinetic energy of the center-of-mass frame. The energy values in this column
     must be in strictly increasing order.
     colliding particles in the center-of-mass frame.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3075,7 +3075,7 @@ Details about the collision models can be found in the :ref:`theory section <mul
     for the given scattering processes. The cross-section file must have exactly
     2 columns of data, the first containing energies in eV and the
     second the corresponding cross-section in :math:`m^2`. The energies must be sorted in
-    strictly increasing order. The energy column should represent the kinetic energy of the 
+    strictly increasing order. The energy column should represent the kinetic energy of the
     colliding particles in the center-of-mass frame.
 
 .. pp:param:: <collision_name>.<scattering_process>_energy

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3077,7 +3077,6 @@ Details about the collision models can be found in the :ref:`theory section <mul
     second the corresponding cross-section in :math:`m^2`. The energy column should
     represent the kinetic energy of the center-of-mass frame. The energy values in this column
     must be in strictly increasing order.
-    colliding particles in the center-of-mass frame.
 
 .. pp:param:: <collision_name>.<scattering_process>_energy
     :type: ``float``

--- a/Regression/Checksum/benchmarks_json/test_1d_background_mcc_picmi.json
+++ b/Regression/Checksum/benchmarks_json/test_1d_background_mcc_picmi.json
@@ -1,20 +1,20 @@
 {
   "electrons": {
-    "particle_momentum_x": 1.4658501087810079e-21,
-    "particle_momentum_y": 1.3947582721049346e-21,
-    "particle_momentum_z": 1.5801892488204323e-21,
-    "particle_position_x": 52.133310411162746,
-    "particle_weight": 3264156250000.0005
+    "particle_momentum_x": 1.5369628100277018e-21,
+    "particle_momentum_y": 1.5441563949506739e-21,
+    "particle_momentum_z": 1.7205044798560895e-21,
+    "particle_position_x": 54.695699646541115,
+    "particle_weight": 3419093750000.0005
   },
   "he_ions": {
-    "particle_momentum_x": 1.4852643320168478e-20,
-    "particle_momentum_y": 1.4466644837605498e-20,
-    "particle_momentum_z": 2.0942543064387905e-19,
-    "particle_position_x": 82.08281665560685,
-    "particle_weight": 5098281250000.001
+    "particle_momentum_x": 1.4810957242996578e-20,
+    "particle_momentum_y": 1.543623193759017e-20,
+    "particle_momentum_z": 2.2195171019756154e-19,
+    "particle_position_x": 84.9427496280595,
+    "particle_weight": 5261593750000.001
   },
   "lev=0": {
-    "rho_electrons": 0.00024977933724059997,
-    "rho_he_ions": 0.0003811208081333327
+    "rho_electrons": 0.00026163544433219997,
+    "rho_he_ions": 0.00039352295081760595
   }
 }

--- a/Source/Particles/Collision/ScatteringProcess.H
+++ b/Source/Particles/Collision/ScatteringProcess.H
@@ -11,6 +11,7 @@
 
 #include "Utils/WarpXAlgorithmSelection.H"
 
+#include <AMReX_Algorithm.H>
 #include <AMReX_GpuContainers.H>
 #include <AMReX_Math.H>
 #include <AMReX_REAL.H>
@@ -71,8 +72,7 @@ public:
 
     static
     void sanityCheckEnergyGrid (
-                                const amrex::Vector<amrex::ParticleReal>& energies,
-                                amrex::ParticleReal dE
+                                const amrex::Vector<amrex::ParticleReal>& energies
                                 );
 
     struct Executor {
@@ -92,20 +92,24 @@ public:
             } else if (E_coll > m_energy_hi) {
                 return m_sigma_hi;
             } else {
-                using amrex::Math::floor;
-                using amrex::Math::ceil;
-                // calculate index of bounding energy pairs
-                amrex::ParticleReal temp = (E_coll - m_energy_lo) / m_dE;
-                const int idx_1 = static_cast<int>(floor(temp));
-                const int idx_2 = static_cast<int>(ceil(temp));
+                // Locate the pair of energy grid points bracketing E_coll using a
+                // bisection search. This does not assume an evenly spaced energy grid.
+                // `amrex::bisect` returns idx_1 such that
+                // m_energies_data[idx_1] <= E_coll < m_energies_data[idx_1 + 1].
+                const int idx_1 = amrex::bisect(m_energies_data, 0, m_grid_size - 1, E_coll);
+                const int idx_2 = idx_1 + 1;
 
                 // linearly interpolate to the given energy value
-                temp -= idx_1;
+                const amrex::ParticleReal temp =
+                    (E_coll - m_energies_data[idx_1])
+                    / (m_energies_data[idx_2] - m_energies_data[idx_1]);
                 return m_sigmas_data[idx_1] + (m_sigmas_data[idx_2] - m_sigmas_data[idx_1]) * temp;
             }
         }
 
+        amrex::ParticleReal* m_energies_data = nullptr;
         amrex::ParticleReal* m_sigmas_data = nullptr;
+        int m_grid_size = 0;
         amrex::ParticleReal m_energy_lo, m_energy_hi, m_sigma_lo, m_sigma_hi, m_dE;
         amrex::ParticleReal m_energy_penalty;
         ScatteringProcessType m_type;
@@ -147,6 +151,7 @@ private:
     amrex::Vector<amrex::ParticleReal> m_energies;
 
 #ifdef AMREX_USE_GPU
+    amrex::Gpu::DeviceVector<amrex::ParticleReal> m_energies_d;
     amrex::Gpu::DeviceVector<amrex::ParticleReal> m_sigmas_d;
     Executor m_exe_d;
 #endif

--- a/Source/Particles/Collision/ScatteringProcess.H
+++ b/Source/Particles/Collision/ScatteringProcess.H
@@ -157,8 +157,6 @@ private:
 #endif
     amrex::Gpu::HostVector<amrex::ParticleReal> m_sigmas_h;
     Executor m_exe_h;
-
-    int m_grid_size;
 };
 
 #endif // WARPX_PARTICLES_COLLISION_SCATTERING_PROCESS_H_

--- a/Source/Particles/Collision/ScatteringProcess.cpp
+++ b/Source/Particles/Collision/ScatteringProcess.cpp
@@ -10,6 +10,8 @@
 
 #include "Utils/TextMsg.H"
 
+#include <algorithm>
+
 ScatteringProcess::ScatteringProcess (
                         const std::string& scattering_process,
                         const std::string& cross_section_file,
@@ -41,15 +43,24 @@ ScatteringProcess::init (const std::string& scattering_process, const amrex::Par
                          const ScatteringAngleModel scattering_angle_model)
 {
     using namespace amrex::literals;
+    m_exe_h.m_energies_data = m_energies.data();
     m_exe_h.m_sigmas_data = m_sigmas_h.data();
 
     // save energy grid parameters for easy use
     m_grid_size = static_cast<int>(m_energies.size());
+    m_exe_h.m_grid_size = m_grid_size;
     m_exe_h.m_energy_lo = m_energies[0];
     m_exe_h.m_energy_hi = m_energies[m_grid_size-1];
     m_exe_h.m_sigma_lo = m_sigmas_h[0];
     m_exe_h.m_sigma_hi = m_sigmas_h[m_grid_size-1];
-    m_exe_h.m_dE = (m_exe_h.m_energy_hi - m_exe_h.m_energy_lo)/(m_grid_size - 1._prt);
+    // The energy grid does not need to be evenly spaced; `m_dE` is only used as a
+    // representative energy step (e.g. to set the scan resolution when computing the
+    // maximum collision frequency). Use the smallest spacing so that finely resolved
+    // regions of a non-uniform grid are not skipped over.
+    m_exe_h.m_dE = m_energies[m_grid_size-1] - m_energies[0];
+    for (int i = 1; i < m_grid_size; i++) {
+        m_exe_h.m_dE = std::min(m_exe_h.m_dE, m_energies[i] - m_energies[i-1]);
+    }
     m_exe_h.m_energy_penalty = energy;
     m_exe_h.m_type = parseProcessType(scattering_process);
     m_exe_h.m_scattering_angle_model = scattering_angle_model;
@@ -59,7 +70,7 @@ ScatteringProcess::init (const std::string& scattering_process, const amrex::Par
         m_exe_h.m_type == ScatteringProcessType::CHARGE_EXCHANGE);
 
     // sanity check cross-section energy grid
-    sanityCheckEnergyGrid(m_energies, m_exe_h.m_dE);
+    sanityCheckEnergyGrid(m_energies);
 
     // check that the cross-section is 0 at the energy cost if the energy
     // cost is > 0 - this is to prevent the possibility of negative left
@@ -73,8 +84,12 @@ ScatteringProcess::init (const std::string& scattering_process, const amrex::Par
 
 #ifdef AMREX_USE_GPU
     m_exe_d = m_exe_h;
+    m_energies_d.resize(m_energies.size());
     m_sigmas_d.resize(m_sigmas_h.size());
+    m_exe_d.m_energies_data = m_energies_d.data();
     m_exe_d.m_sigmas_data = m_sigmas_d.data();
+    amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, m_energies.begin(), m_energies.end(),
+                          m_energies_d.begin());
     amrex::Gpu::copyAsync(amrex::Gpu::hostToDevice, m_sigmas_h.begin(), m_sigmas_h.end(),
                           m_sigmas_d.begin());
     amrex::Gpu::streamSynchronize();
@@ -122,16 +137,17 @@ ScatteringProcess::readCrossSectionFile (
 
 void
 ScatteringProcess::sanityCheckEnergyGrid (
-                                   const amrex::Vector<amrex::ParticleReal>& energies,
-                                   amrex::ParticleReal dE
+                                   const amrex::Vector<amrex::ParticleReal>& energies
                                    )
 {
-    // confirm that the input data for the cross-section was provided with
-    // equal energy steps, otherwise the linear interpolation will fail
+    // The energy grid does not need to be evenly spaced, but it must be sorted in
+    // strictly increasing order for the bisection search and linear interpolation
+    // used in `Executor::getCrossSection` to work correctly.
     for (unsigned i = 1; i < energies.size(); i++) {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-                                         (std::abs(energies[i] - energies[i-1] - dE) < dE / 100.0),
-                                         "Energy grid not evenly spaced."
+                                         (energies[i] > energies[i-1]),
+                                         "Cross-section energy grid must be sorted in "
+                                         "strictly increasing order."
                                          );
     }
 }

--- a/Source/Particles/Collision/ScatteringProcess.cpp
+++ b/Source/Particles/Collision/ScatteringProcess.cpp
@@ -47,18 +47,18 @@ ScatteringProcess::init (const std::string& scattering_process, const amrex::Par
     m_exe_h.m_sigmas_data = m_sigmas_h.data();
 
     // save energy grid parameters for easy use
-    m_grid_size = static_cast<int>(m_energies.size());
-    m_exe_h.m_grid_size = m_grid_size;
+    const int grid_size = static_cast<int>(m_energies.size());
+    m_exe_h.m_grid_size = grid_size;
     m_exe_h.m_energy_lo = m_energies[0];
-    m_exe_h.m_energy_hi = m_energies[m_grid_size-1];
+    m_exe_h.m_energy_hi = m_energies[grid_size-1];
     m_exe_h.m_sigma_lo = m_sigmas_h[0];
-    m_exe_h.m_sigma_hi = m_sigmas_h[m_grid_size-1];
+    m_exe_h.m_sigma_hi = m_sigmas_h[grid_size-1];
     // The energy grid does not need to be evenly spaced; `m_dE` is only used as a
     // representative energy step (e.g. to set the scan resolution when computing the
     // maximum collision frequency). Use the smallest spacing so that finely resolved
     // regions of a non-uniform grid are not skipped over.
-    m_exe_h.m_dE = m_energies[m_grid_size-1] - m_energies[0];
-    for (int i = 1; i < m_grid_size; i++) {
+    m_exe_h.m_dE = m_energies[grid_size-1] - m_energies[0];
+    for (int i = 1; i < grid_size; i++) {
         m_exe_h.m_dE = std::min(m_exe_h.m_dE, m_energies[i] - m_energies[i-1]);
     }
     m_exe_h.m_energy_penalty = energy;


### PR DESCRIPTION
Previously, cross-section data files for DSMC and background MCC collisions were required to have equally spaced energy values, since the linear interpolator located the bracketing grid points from the (constant) energy step. This drops that requirement: the bracketing grid points are now found with amrex::bisect, so the energy grid only needs to be sorted in strictly increasing order.

- `ScatteringProcess::Executor::getCrossSection` now bisects the energy grid instead of assuming a constant step, and stores the energy grid (on device as well, for GPU builds).
- `sanityCheckEnergyGrid` now checks that the grid is strictly increasing rather than evenly spaced.
- `m_dE` (still used to set the nu_max scan resolution) is now the smallest grid spacing; for uniform grids this is unchanged.
- Update the parameters documentation accordingly.