### PR TITLE
Fix inconsistent indentation in `WarpXAlgorithmSelection.H`

### DIFF
--- a/Source/Utils/WarpXAlgorithmSelection.H
+++ b/Source/Utils/WarpXAlgorithmSelection.H
@@ -171,30 +171,25 @@ AMREX_ENUM(PushType,
            Default = Explicit);
 
 /** \brief For advanced collision algorithms that split the particle push in substeps */
-AMREX_ENUM(
-    PositionPushType,
-    None,
-    Full,
-    Default = Full
-);
+AMREX_ENUM(PositionPushType,
+           None,
+           Full,
+           Default = Full);
 
 /** \brief For advanced collision algorithms that split the particle push in substeps */
-AMREX_ENUM(
-    MomentumPushType,
-    Full,
-    FirstHalf,
-    SecondHalf,
-    Default = Full
-);
+AMREX_ENUM(MomentumPushType,
+           Full,
+           FirstHalf,
+           SecondHalf,
+           Default = Full);
 
 /** \brief For binary collision algorithms, the strategy to determine
  *  the scattering angle in the center of mass frame */
-AMREX_ENUM(
-    ScatteringAngleModel,
-    Forward,    /**< Scattering angle is zero, i.e., products have the same direction as the incident particle in the center of mass frame */
-    Backward,   /**< Scattering angle is pi, i.e., products have the opposite direction of the incident particle in the center of mass frame */
-    Isotropic,  /**< Scattering angle is random, i.e., products are scattered isotropically in the center of mass frame */
-    Default = Isotropic  /**< Isotropic */
+AMREX_ENUM(ScatteringAngleModel,
+           Forward,    /**< Scattering angle is zero, i.e., products have the same direction as the incident particle in the center of mass frame */
+           Backward,   /**< Scattering angle is pi, i.e., products have the opposite direction of the incident particle in the center of mass frame */
+           Isotropic,  /**< Scattering angle is random, i.e., products are scattered isotropically in the center of mass frame */
+           Default = Isotropic  /**< Isotropic */
 );
 
 #endif // WARPX_UTILS_WARPXALGORITHMSELECTION_H_


### PR DESCRIPTION
As pointed out by @roelof-groenewald, the indentation was inconsistent with the rest of the file.