### PR TITLE
Docs: cite 2004 ECT paper for the ect solver

### DIFF
--- a/Docs/source/refs.bib
+++ b/Docs/source/refs.bib
@@ -454,15 +454,15 @@ volume = {12},
 year = {2004}
 }
 
-@inproceedings{XiaoIEEE2005,
+@article{XiaoIEEE2004,
 author = {Tian Xiao and Qing Huo Liu},
-booktitle = {2005 IEEE Antennas and Propagation Society International Symposium},
-doi = {10.1109/APS.2005.1551259},
-number = {},
-pages = {122-125 Vol. 1A},
-title = {{An enlarged cell technique for the conformal FDTD method to model perfectly conducting objects}},
-volume = {1A},
-year = {2005}
+journal = {IEEE Microwave and Wireless Components Letters},
+doi = {10.1109/LMWC.2004.837384},
+number = {12},
+pages = {551-553},
+title = {{Enlarged cells for the conformal FDTD method to avoid the time step reduction}},
+volume = {14},
+year = {2004}
 }
 
 @article{GrismayerNJP2021,

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3435,7 +3435,7 @@ Two families of Maxwell solvers are implemented in WarpX, based on the Finite-Di
      - ``ckc``: (not available in ``RZ``, ``RCYLINDER``, and ``RSPHERE`` geometries) Cole-Karkkainen solver with Cowan
        coefficients (see :cite:t:`param-CowanPRSTAB13`).
      - ``psatd``: Pseudo-spectral solver (see :ref:`theory <theory-mwsolve-psatd>`).
-     - ``ect``: Enlarged cell technique (conformal finite difference solver. See :cite:t:`param-XiaoIEEE2005`).
+     - ``ect``: Enlarged cell technique (conformal finite difference solver. See :cite:t:`param-XiaoIEEE2004`).
      - ``hybrid``: The E-field will be solved using Ohm's law and a kinetic-fluid hybrid model (see :ref:`theory <theory-kinetic-fluid-hybrid-model>`).
      - ``none``: No field solve will be performed.
 


### PR DESCRIPTION
Replace the 2005 conference paper with the journal article 'Enlarged cells for the conformal FDTD method to avoid the time step reduction' (Xiao & Liu, IEEE MWCL, 2004) for the ECT solver.