### PR TITLE
use max directional value of |vp|/dx when limiting time step by particle cfl

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3266,10 +3266,10 @@ Time step
     The ratio between the actual timestep that is used in the simulation
     and the Courant-Friedrichs-Lewy (CFL) limit. (e.g. for ``warpx.cfl=1``,
     the timestep will be exactly equal to the CFL limit.)
-    For some speed v and grid spacing dx, this limits the timestep to ``warpx.cfl * dx / v``.
+    For some speed ``v`` and grid spacing ``dx``, this limits the timestep to ``warpx.cfl * dx / v``.
     When used with electromagnetic solvers that treat light waves explicitly, ``v`` is the speed of light.
     For the electrostatic solver and electromagnetic solvers that treat light waves implicitly, ``dx / v``
-    is the maximum direction value ``dx_i/v_i`` among all particles in the domain, where ``v_i`` is the
+    is the minimum direction-dependent value ``dx_i / v_i`` among all particles in the domain, where ``v_i`` is the
     maximum speed in grid direction ``i`` and ``dx_i`` is the associated grid spacing.
 
 .. pp:param:: warpx.const_dt

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3267,8 +3267,10 @@ Time step
     and the Courant-Friedrichs-Lewy (CFL) limit. (e.g. for ``warpx.cfl=1``,
     the timestep will be exactly equal to the CFL limit.)
     For some speed v and grid spacing dx, this limits the timestep to ``warpx.cfl * dx / v``.
-    When used with the electromagnetic solver, ``v`` is the speed of light.
-    For the electrostatic solver, ``v`` is the maximum speed among all particles in the domain.
+    When used with electromagnetic solvers that treat light waves explicitly, ``v`` is the speed of light.
+    For the electrostatic solver and electromagnetic solvers that treat light waves implicitly, ``dx / v``
+    is the maximum direction value ``dx_i/v_i`` among all particles in the domain, where ``v_i`` is the
+    maximum speed in grid direction ``i`` and ``dx_i`` is the associated grid spacing.
 
 .. pp:param:: warpx.const_dt
     :type: ``float``

--- a/Examples/Tests/electrostatic_sphere/CMakeLists.txt
+++ b/Examples/Tests/electrostatic_sphere/CMakeLists.txt
@@ -46,8 +46,8 @@ add_warpx_test(
     3  # dims
     2  # nprocs
     inputs_test_3d_electrostatic_sphere_adaptive  # inputs
-    "analysis_electrostatic_sphere.py diags/diag1000054"  # analysis
-    "analysis_default_regression.py --path diags/diag1000054"  # checksum
+    "analysis_electrostatic_sphere.py diags/diag1000040"  # analysis
+    "analysis_default_regression.py --path diags/diag1000040"  # checksum
     OFF  # dependency
 )
 

--- a/Examples/Tests/electrostatic_sphere/analysis_electrostatic_sphere.py
+++ b/Examples/Tests/electrostatic_sphere/analysis_electrostatic_sphere.py
@@ -43,7 +43,7 @@ if emass_10:
     l2_tolerance = 0.096
     e_mass = 10
 else:
-    l2_tolerance = 0.05
+    l2_tolerance = 0.06
     e_mass = m_e  # Electron mass in kg
 ndims = np.count_nonzero(ds.domain_dimensions > 1)
 

--- a/Examples/Tests/electrostatic_sphere/inputs_test_3d_electrostatic_sphere_adaptive
+++ b/Examples/Tests/electrostatic_sphere/inputs_test_3d_electrostatic_sphere_adaptive
@@ -1,4 +1,4 @@
-stop_time = 60e-6
+max_step = 40
 warpx.cfl = 0.2
 warpx.dt_update_interval = 10
 warpx.dt_update_diagnostic_file = diags/reducedfiles/dt_updates.txt

--- a/Regression/Checksum/benchmarks_json/test_3d_electrostatic_sphere_adaptive.json
+++ b/Regression/Checksum/benchmarks_json/test_3d_electrostatic_sphere_adaptive.json
@@ -1,17 +1,17 @@
 {
   "lev=0": {
-    "Ex": 5.177444764601125,
-    "Ey": 5.177444764601124,
-    "Ez": 5.177444764601125,
+    "Ex": 5.698234120574831,
+    "Ey": 5.698234120574831,
+    "Ez": 5.698234120574831,
     "rho": 2.6092568008333797e-10
   },
   "electron": {
-    "particle_momentum_x": 1.3214029529275882e-23,
-    "particle_momentum_y": 1.3214029529275882e-23,
-    "particle_momentum_z": 1.3214029529275882e-23,
-    "particle_position_x": 912.2310001092305,
-    "particle_position_y": 912.2310001092305,
-    "particle_position_z": 912.2310001092305,
+    "particle_momentum_x": 1.2407652256511285e-23,
+    "particle_momentum_y": 1.2407652256511285e-23,
+    "particle_momentum_z": 1.2407652256511285e-23,
+    "particle_position_x": 755.9274620910003,
+    "particle_position_y": 755.9274620910003,
+    "particle_position_z": 755.9274620910003,
     "particle_weight": 6212.501525878906
   }
 }

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -113,18 +113,6 @@ WarpX::ComputeDt ()
     }
 }
 
-/**
- * Used to determine the simulation timestep from the maximum speed of all particles
- * Timestep will be set so that a particle can cross at most cfl*dx cells per timestep.
- */
-amrex::Real
-WarpX::ParticleGridSpeedMax ()
-{
-    const amrex::ParticleReal max_dt_inv = mypc->maxParticleDtInv();
-
-    return max_dt_inv;
-}
-
 amrex::Real
 WarpX::GlobalPlasmaFrequencyMax ()
 {
@@ -236,12 +224,12 @@ WarpX::ApplyDtLimiters ()
     using namespace amrex::literals;
 
     // Calculate limiting values from the simulation conditions
-    const amrex::Real vmax_o_dx = ParticleGridSpeedMax();
+    const amrex::Real max_dt_inv = mypc->maxParticleDtInv();  // max value of abs(vp_i/dx[i])
     const amrex::Real omegap_max = m_max_omegap_dt.has_value() ? GlobalPlasmaFrequencyMax() : 0._rt;
     const amrex::Real omegac_max = m_max_omegac_dt.has_value() ? GlobalCyclotronFrequencyMax() : 0._rt;
 
     // Ensure that a valid time step value exists, either from the simulation conditions or from max_dt
-    if (vmax_o_dx == 0._rt &&
+    if (max_dt_inv == 0._rt &&
         (!m_max_omegap_dt.has_value() || omegap_max == 0._rt) &&
         (!m_max_omegac_dt.has_value() || omegac_max == 0._rt)) {
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(m_max_dt.has_value(),
@@ -250,8 +238,8 @@ WarpX::ApplyDtLimiters ()
 
     amrex::Real dt_new = std::numeric_limits<amrex::Real>::max();
 
-    if (vmax_o_dx > 0._rt) {
-        dt_new = std::min(dt_new, cfl/vmax_o_dx);
+    if (max_dt_inv > 0._rt) {
+        dt_new = std::min(dt_new, cfl/max_dt_inv);
     }
     if (m_max_omegap_dt.has_value() && omegap_max > 0._rt) {
         dt_new = std::min(dt_new, m_max_omegap_dt.value()/omegap_max);
@@ -323,7 +311,7 @@ WarpX::ApplyDtLimiters ()
         diagnostic_file << " ";
         diagnostic_file << dt_new;
         diagnostic_file << " ";
-        diagnostic_file << vmax_o_dx*dt_new;
+        diagnostic_file << max_dt_inv*dt_new;
 
         if (m_max_omegap_dt.has_value()) {
             diagnostic_file << " ";

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -120,7 +120,12 @@ WarpX::ComputeDt ()
 amrex::Real
 WarpX::ParticleGridSpeedMax ()
 {
-    const amrex::Real* dx = geom[max_level].CellSize();
+    const auto dx_array = WarpX::CellSize(max_level);
+    amrex::XDim3 const dx{
+        dx_array[0],
+        dx_array[1],
+        dx_array[2]
+    };
     const amrex::ParticleReal max_dt_inv = mypc->maxParticleDtInv(dx);
 
     return max_dt_inv;

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -120,13 +120,7 @@ WarpX::ComputeDt ()
 amrex::Real
 WarpX::ParticleGridSpeedMax ()
 {
-    const auto dx_array = WarpX::CellSize(max_level);
-    amrex::XDim3 const dx{
-        dx_array[0],
-        dx_array[1],
-        dx_array[2]
-    };
-    const amrex::ParticleReal max_dt_inv = mypc->maxParticleDtInv(dx);
+    const amrex::ParticleReal max_dt_inv = mypc->maxParticleDtInv();
 
     return max_dt_inv;
 }

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -121,11 +121,9 @@ amrex::Real
 WarpX::ParticleGridSpeedMax ()
 {
     const amrex::Real* dx = geom[max_level].CellSize();
-    const amrex::Real dx_min = minDim(dx);
+    const amrex::ParticleReal max_dt_inv = mypc->maxParticleDtInv(dx);
 
-    const amrex::ParticleReal max_v = mypc->maxParticleVelocity();
-
-    return max_v/dx_min;
+    return max_dt_inv;
 }
 
 amrex::Real

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -38,6 +38,7 @@
 #include <AMReX_REAL.H>
 #include <AMReX_RealBox.H>
 #include <AMReX_Vector.H>
+#include <AMReX_Dim3.H>
 
 #include <AMReX_BaseFwd.H>
 #include <AMReX_AmrCoreFwd.H>

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -38,7 +38,6 @@
 #include <AMReX_REAL.H>
 #include <AMReX_RealBox.H>
 #include <AMReX_Vector.H>
-#include <AMReX_Dim3.H>
 
 #include <AMReX_BaseFwd.H>
 #include <AMReX_AmrCoreFwd.H>
@@ -93,7 +92,7 @@ public:
         return allcontainers[index]->meanParticleVelocity();
     }
 
-    amrex::ParticleReal maxParticleDtInv(amrex::XDim3 dx);
+    amrex::ParticleReal maxParticleDtInv();
 
     void TransformMomentumToCurvilinear (bool forward);
 

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -92,7 +92,7 @@ public:
         return allcontainers[index]->meanParticleVelocity();
     }
 
-    amrex::ParticleReal maxParticleVelocity();
+    amrex::ParticleReal maxParticleDtInv(amrex::Real const * const dx);
 
     void TransformMomentumToCurvilinear (bool forward);
 

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -92,7 +92,7 @@ public:
         return allcontainers[index]->meanParticleVelocity();
     }
 
-    amrex::ParticleReal maxParticleDtInv(amrex::Real const * const dx);
+    amrex::ParticleReal maxParticleDtInv(amrex::Real const * dx);
 
     void TransformMomentumToCurvilinear (bool forward);
 

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -92,7 +92,7 @@ public:
         return allcontainers[index]->meanParticleVelocity();
     }
 
-    amrex::ParticleReal maxParticleDtInv(amrex::Real const * dx);
+    amrex::ParticleReal maxParticleDtInv(amrex::XDim3 dx);
 
     void TransformMomentumToCurvilinear (bool forward);
 

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -415,12 +415,12 @@ MultiParticleContainer::GetParticleContainerFromName (const std::string& name) c
 }
 
 amrex::ParticleReal
-MultiParticleContainer::maxParticleVelocity() {
-    amrex::ParticleReal max_v = 0.0_prt;
+MultiParticleContainer::maxParticleDtInv(amrex::Real const * const dx) {
+    amrex::ParticleReal max_dt_inv = 0.0_prt;
     for (const auto &pc : allcontainers) {
-        max_v = std::max(max_v, pc->maxParticleVelocity());
+        max_dt_inv = std::max(max_dt_inv, pc->maxParticleDtInv(dx));
     }
-    return max_v;
+    return max_dt_inv;
 }
 
 void

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -71,6 +71,7 @@
 #include <AMReX_StructOfArrays.H>
 #include <AMReX_Utility.H>
 #include <AMReX_Vector.H>
+#include <AMReX_XDim3.H>
 
 #include <algorithm>
 #include <cmath>
@@ -415,7 +416,7 @@ MultiParticleContainer::GetParticleContainerFromName (const std::string& name) c
 }
 
 amrex::ParticleReal
-MultiParticleContainer::maxParticleDtInv(amrex::Real const * const dx) {
+MultiParticleContainer::maxParticleDtInv(amrex::XDim3 dx) {
     amrex::ParticleReal max_dt_inv = 0.0_prt;
     for (const auto &pc : allcontainers) {
         max_dt_inv = std::max(max_dt_inv, pc->maxParticleDtInv(dx));

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -71,7 +71,6 @@
 #include <AMReX_StructOfArrays.H>
 #include <AMReX_Utility.H>
 #include <AMReX_Vector.H>
-#include <AMReX_XDim3.H>
 
 #include <algorithm>
 #include <cmath>

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -418,7 +418,7 @@ amrex::ParticleReal
 MultiParticleContainer::maxParticleDtInv() {
     amrex::ParticleReal max_dt_inv = 0.0_prt;
     for (const auto &pc : allcontainers) {
-        max_dt_inv = std::max(max_dt_inv, pc->maxParticleDtInv());
+        max_dt_inv = amrex::max(max_dt_inv, pc->maxParticleDtInv());
     }
     return max_dt_inv;
 }

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -415,10 +415,10 @@ MultiParticleContainer::GetParticleContainerFromName (const std::string& name) c
 }
 
 amrex::ParticleReal
-MultiParticleContainer::maxParticleDtInv(amrex::XDim3 dx) {
+MultiParticleContainer::maxParticleDtInv() {
     amrex::ParticleReal max_dt_inv = 0.0_prt;
     for (const auto &pc : allcontainers) {
-        max_dt_inv = std::max(max_dt_inv, pc->maxParticleDtInv(dx));
+        max_dt_inv = std::max(max_dt_inv, pc->maxParticleDtInv());
     }
     return max_dt_inv;
 }

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -41,7 +41,6 @@
 #include <AMReX_REAL.H>
 #include <AMReX_StructOfArrays.H>
 #include <AMReX_Vector.H>
-#include <AMReX_Dim3.H>
 
 #include <AMReX_BaseFwd.H>
 #include <AMReX_AmrCoreFwd.H>
@@ -480,8 +479,7 @@ public:
 
     std::array<amrex::ParticleReal, 3> meanParticleVelocity(bool local = false);
 
-    amrex::ParticleReal maxParticleDtInv(amrex::XDim3 dx,
-                                         bool local = false);
+    amrex::ParticleReal maxParticleDtInv(bool local = false);
 
     /**
      * \brief Map the momentum of the particles to and from the curvilinear frame.

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -41,6 +41,7 @@
 #include <AMReX_REAL.H>
 #include <AMReX_StructOfArrays.H>
 #include <AMReX_Vector.H>
+#include <AMReX_XDim3.H>
 
 #include <AMReX_BaseFwd.H>
 #include <AMReX_AmrCoreFwd.H>
@@ -479,7 +480,7 @@ public:
 
     std::array<amrex::ParticleReal, 3> meanParticleVelocity(bool local = false);
 
-    amrex::ParticleReal maxParticleDtInv(amrex::Real const * dx,
+    amrex::ParticleReal maxParticleDtInv(amrex::XDim3 dx,
                                          bool local = false);
 
     /**

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -479,7 +479,7 @@ public:
 
     std::array<amrex::ParticleReal, 3> meanParticleVelocity(bool local = false);
 
-    amrex::ParticleReal maxParticleDtInv(amrex::Real const * const dx,
+    amrex::ParticleReal maxParticleDtInv(amrex::Real const * dx,
                                          bool local = false);
 
     /**

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -41,7 +41,7 @@
 #include <AMReX_REAL.H>
 #include <AMReX_StructOfArrays.H>
 #include <AMReX_Vector.H>
-#include <AMReX_XDim3.H>
+#include <AMReX_Dim3.H>
 
 #include <AMReX_BaseFwd.H>
 #include <AMReX_AmrCoreFwd.H>

--- a/Source/Particles/WarpXParticleContainer.H
+++ b/Source/Particles/WarpXParticleContainer.H
@@ -479,7 +479,8 @@ public:
 
     std::array<amrex::ParticleReal, 3> meanParticleVelocity(bool local = false);
 
-    amrex::ParticleReal maxParticleVelocity(bool local = false);
+    amrex::ParticleReal maxParticleDtInv(amrex::Real const * const dx,
+                                         bool local = false);
 
     /**
      * \brief Map the momentum of the particles to and from the curvilinear frame.

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2646,14 +2646,14 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(amrex::Real const *
                 const amrex::ParticleReal gaminv = 1.0_prt/std::sqrt(1.0_prt + betasq);
 
 #if defined(WARPX_DIM_3D)
-                const amrex::ParticleReal dir0_dt_inv = gaminv * std::abs(ux[ip]) / dx[0];
-                const amrex::ParticleReal dir1_dt_inv = gaminv * std::abs(uy[ip]) / dx[1];
-                const amrex::ParticleReal dir2_dt_inv = gaminv * std::abs(uz[ip]) / dx[2];
-                const amrex::ParticleReal dt_inv = std::max({dir0_dt_inv, dir1_dt_inv, dir2_dt_inv});
+                const amrex::ParticleReal dt_inv = gamminv *
+                                                   std::max({std::abs(ux[ip]) / dx[0],
+                                                             std::abs(uy[ip]) / dx[1],
+                                                             std::abs(uz[ip]) / dx[2]});
 #elif defined(WARPX_DIM_XZ)
-                const amrex::ParticleReal dir0_dt_inv = gaminv * std::abs(ux[ip]) / dx[0];
-                const amrex::ParticleReal dir2_dt_inv = gaminv * std::abs(uz[ip]) / dx[2];
-                const amrex::ParticleReal dt_inv = std::max(dir0_dt_inv, dir2_dt_inv);
+                const amrex::ParticleReal dt_inv = gamminv *
+                                                   std::max(std::abs(ux[ip]) / dx[0],
+                                                            std::abs(uz[ip]) / dx[2]);
 #elif defined(WARPX_DIM_1D_Z)
                 const amrex::ParticleReal dt_inv = gaminv * std::abs(uz[ip]) / dx[2];
 #elif defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
@@ -2663,12 +2663,12 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(amrex::Real const *
                 const amrex::ParticleReal costh = (rp > 0._rt ? xp/rp : 1._rt);
                 const amrex::ParticleReal sinth = (rp > 0._rt ? yp/rp : 0._rt);
                 const amrex::ParticleReal ur = ux[ip]*costh + uy[ip]*sinth;
-                const amrex::ParticleReal dir0_dt_inv = gaminv * std::abs(ur) / dx[0];
 #if defined(WARPX_DIM_RCYLINDER)
-                const amrex::ParticleReal dt_inv = dir0_dt_inv;
+                const amrex::ParticleReal dt_inv = gaminv * std::abs(ur) / dx[0];
 #else
-                const amrex::ParticleReal dir2_dt_inv = gaminv * std::abs(uz[ip]) / dx[2];
-                const amrex::ParticleReal dt_inv = std::max(dir0_dt_inv, dir2_dt_inv);
+                const amrex::ParticleReal dt_inv = gamminv *
+                                                   std::max(std::abs(ur) / dx[0],
+                                                            std::abs(uz[ip]) / dx[2]);
 #endif
 #elif defined(WARPX_DIM_RSPHERE)
                 amrex::ParticleReal xp, yp, zp;

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2609,7 +2609,7 @@ std::array<ParticleReal, 3> WarpXParticleContainer::meanParticleVelocity(bool lo
     return mean_v;
 }
 
-amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(amrex::Real const * const dx,
+amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(amrex::XDim3 dx,
                                                              bool local) {
 
     constexpr auto inv_c2 = PhysConst::inv_c2_v<amrex::ParticleReal>;
@@ -2648,15 +2648,15 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(amrex::Real const *
 
 #if defined(WARPX_DIM_3D)
                 const amrex::ParticleReal dt_inv = gaminv *
-                                                   std::max({std::abs(ux[ip]) / dx[0],
-                                                             std::abs(uy[ip]) / dx[1],
-                                                             std::abs(uz[ip]) / dx[2]});
+                                                   std::max({std::abs(ux[ip]) / dx.x,
+                                                             std::abs(uy[ip]) / dx.y,
+                                                             std::abs(uz[ip]) / dx.z});
 #elif defined(WARPX_DIM_XZ)
                 const amrex::ParticleReal dt_inv = gaminv *
-                                                   std::max(std::abs(ux[ip]) / dx[0],
-                                                            std::abs(uz[ip]) / dx[2]);
+                                                   std::max(std::abs(ux[ip]) / dx.x,
+                                                            std::abs(uz[ip]) / dx.z);
 #elif defined(WARPX_DIM_1D_Z)
-                const amrex::ParticleReal dt_inv = gaminv * std::abs(uz[ip]) / dx[2];
+                const amrex::ParticleReal dt_inv = gaminv * std::abs(uz[ip]) / dx.z;
 #elif defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
                 amrex::ParticleReal xp, yp, zp;
                 GetPosition(ip, xp, yp, zp);
@@ -2665,11 +2665,11 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(amrex::Real const *
                 const amrex::ParticleReal sinth = (rp > 0._rt ? yp/rp : 0._rt);
                 const amrex::ParticleReal ur = ux[ip]*costh + uy[ip]*sinth;
 #if defined(WARPX_DIM_RCYLINDER)
-                const amrex::ParticleReal dt_inv = gaminv * std::abs(ur) / dx[0];
+                const amrex::ParticleReal dt_inv = gaminv * std::abs(ur) / dx.x;
 #else
                 const amrex::ParticleReal dt_inv = gaminv *
-                                                   std::max(std::abs(ur) / dx[0],
-                                                            std::abs(uz[ip]) / dx[2]);
+                                                   std::max(std::abs(ur) / dx.x,
+                                                            std::abs(uz[ip]) / dx.z);
 #endif
 #elif defined(WARPX_DIM_RSPHERE)
                 amrex::ParticleReal xp, yp, zp;
@@ -2681,7 +2681,7 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(amrex::Real const *
                 const amrex::ParticleReal cosph = (rp > 0._rt ? rpxy/rp : 1._rt);
                 const amrex::ParticleReal sinph = (rp > 0._rt ? zp/rp : 0._rt);
                 const amrex::ParticleReal ur = ux[ip]*costh*cosph + uy[ip]*sinth*cosph + uz[ip]*sinph;
-                const amrex::ParticleReal dt_inv = gaminv * std::abs(ur) / dx[0];
+                const amrex::ParticleReal dt_inv = gaminv * std::abs(ur) / dx.x;
 #endif
                 return dt_inv;
                 });

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2690,7 +2690,10 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(amrex::Real const *
     amrex::ParticleReal max_dt_inv = (np_total > 0 ? amrex::get<0>(reduce_data.value()) : 0._prt);
     if (!local) { ParallelAllReduce::Max(max_dt_inv, ParallelDescriptor::Communicator()); }
 
-    return max_dt_inv * PhysConst::c;
+    // Need to scale the result by c since u in reduction above is actually beta
+    max_dt_inv *= PhysConst::c;
+
+    return max_dt_inv;
 }
 
 void

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2662,8 +2662,8 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(bool local) {
                 amrex::ParticleReal xp, yp, zp;
                 GetPosition(ip, xp, yp, zp);
                 const amrex::ParticleReal rp = std::sqrt(xp*xp + yp*yp);
-                const amrex::ParticleReal costh = (rp > 0._rt ? xp/rp : 1._rt);
-                const amrex::ParticleReal sinth = (rp > 0._rt ? yp/rp : 0._rt);
+                const amrex::ParticleReal costh = (rp > 0._prt ? xp/rp : 1._prt);
+                const amrex::ParticleReal sinth = (rp > 0._prt ? yp/rp : 0._prt);
                 const amrex::ParticleReal ur = ux[ip]*costh + uy[ip]*sinth;
 #if defined(WARPX_DIM_RCYLINDER)
                 const amrex::ParticleReal dt_inv = gaminv * std::abs(ur) * dxi.x;

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2647,12 +2647,12 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(amrex::Real const *
                 const amrex::ParticleReal gaminv = 1.0_prt/std::sqrt(1.0_prt + betasq);
 
 #if defined(WARPX_DIM_3D)
-                const amrex::ParticleReal dt_inv = gamminv *
+                const amrex::ParticleReal dt_inv = gaminv *
                                                    std::max({std::abs(ux[ip]) / dx[0],
                                                              std::abs(uy[ip]) / dx[1],
                                                              std::abs(uz[ip]) / dx[2]});
 #elif defined(WARPX_DIM_XZ)
-                const amrex::ParticleReal dt_inv = gamminv *
+                const amrex::ParticleReal dt_inv = gaminv *
                                                    std::max(std::abs(ux[ip]) / dx[0],
                                                             std::abs(uz[ip]) / dx[2]);
 #elif defined(WARPX_DIM_1D_Z)
@@ -2667,7 +2667,7 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(amrex::Real const *
 #if defined(WARPX_DIM_RCYLINDER)
                 const amrex::ParticleReal dt_inv = gaminv * std::abs(ur) / dx[0];
 #else
-                const amrex::ParticleReal dt_inv = gamminv *
+                const amrex::ParticleReal dt_inv = gaminv *
                                                    std::max(std::abs(ur) / dx[0],
                                                             std::abs(uz[ip]) / dx[2]);
 #endif

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2677,10 +2677,10 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(bool local) {
                 GetPosition(ip, xp, yp, zp);
                 const amrex::ParticleReal rpxy = std::sqrt(xp*xp + yp*yp);
                 const amrex::ParticleReal rp = std::sqrt(xp*xp + yp*yp + zp*zp);
-                const amrex::ParticleReal costh = (rpxy > 0._rt ? xp/rpxy : 1._rt);
-                const amrex::ParticleReal sinth = (rpxy > 0._rt ? yp/rpxy : 0._rt);
-                const amrex::ParticleReal cosph = (rp > 0._rt ? rpxy/rp : 1._rt);
-                const amrex::ParticleReal sinph = (rp > 0._rt ? zp/rp : 0._rt);
+                const amrex::ParticleReal costh = (rpxy > 0._prt ? xp/rpxy : 1._prt);
+                const amrex::ParticleReal sinth = (rpxy > 0._prt ? yp/rpxy : 0._prt);
+                const amrex::ParticleReal cosph = (rp > 0._prt ? rpxy/rp : 1._prt);
+                const amrex::ParticleReal sinph = (rp > 0._prt ? zp/rp : 0._prt);
                 const amrex::ParticleReal ur = ux[ip]*costh*cosph + uy[ip]*sinth*cosph + uz[ip]*sinph;
                 const amrex::ParticleReal dt_inv = gaminv * std::abs(ur) * dxi.x;
 #endif

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2643,8 +2643,8 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(amrex::Real const *
                 [=] AMREX_GPU_DEVICE (int ip)
                 {
 
-                const amrex::ParticleReal betasq = ux[ip]*ux[ip] + uy[ip]*uy[ip] + uz[ip]*uz[ip] * inv_c2;
-                const amrex::ParticleReal gaminv = 1.0_prt/std::sqrt(1.0_prt + betasq);
+                const amrex::ParticleReal usq = ux[ip]*ux[ip] + uy[ip]*uy[ip] + uz[ip]*uz[ip];
+                const amrex::ParticleReal gaminv = 1.0_prt/std::sqrt(1.0_prt + usq * inv_c2);
 
 #if defined(WARPX_DIM_3D)
                 const amrex::ParticleReal dt_inv = gaminv *

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2659,12 +2659,9 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(bool local) {
 #elif defined(WARPX_DIM_1D_Z)
                 const amrex::ParticleReal dt_inv = gaminv * std::abs(uz[ip]) * dxi.z;
 #elif defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-                amrex::ParticleReal xp, yp, zp;
-                GetPosition(ip, xp, yp, zp);
-                const amrex::ParticleReal rp = std::sqrt(xp*xp + yp*yp);
-                const amrex::ParticleReal costh = (rp > 0._prt ? xp/rp : 1._prt);
-                const amrex::ParticleReal sinth = (rp > 0._prt ? yp/rp : 0._prt);
-                const amrex::ParticleReal ur = ux[ip]*costh + uy[ip]*sinth;
+                amrex::ParticleReal rp, tp, zp;
+                GetPosition.AsStored(ip, rp, tp, zp);
+                const amrex::ParticleReal ur = ux[ip]*std::cos(tp) + uy[ip]*std::sin(tp);
 #if defined(WARPX_DIM_RCYLINDER)
                 const amrex::ParticleReal dt_inv = gaminv * std::abs(ur) * dxi.x;
 #else
@@ -2673,14 +2670,12 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(bool local) {
                                                               std::abs(uz[ip]) * dxi.z);
 #endif
 #elif defined(WARPX_DIM_RSPHERE)
-                amrex::ParticleReal xp, yp, zp;
-                GetPosition(ip, xp, yp, zp);
-                const amrex::ParticleReal rpxy = std::sqrt(xp*xp + yp*yp);
-                const amrex::ParticleReal rp = std::sqrt(xp*xp + yp*yp + zp*zp);
-                const amrex::ParticleReal costh = (rpxy > 0._prt ? xp/rpxy : 1._prt);
-                const amrex::ParticleReal sinth = (rpxy > 0._prt ? yp/rpxy : 0._prt);
-                const amrex::ParticleReal cosph = (rp > 0._prt ? rpxy/rp : 1._prt);
-                const amrex::ParticleReal sinph = (rp > 0._prt ? zp/rp : 0._prt);
+                amrex::ParticleReal rp, tp, pp;
+                GetPosition.AsStored(ip, rp, tp, pp);
+                const amrex::ParticleReal costh = std::cos(tp);
+                const amrex::ParticleReal sinth = std::sin(tp);
+                const amrex::ParticleReal cosph = std::cos(pp);
+                const amrex::ParticleReal sinph = std::sin(pp);
                 const amrex::ParticleReal ur = ux[ip]*costh*cosph + uy[ip]*sinth*cosph + uz[ip]*sinph;
                 const amrex::ParticleReal dt_inv = gaminv * std::abs(ur) * dxi.x;
 #endif

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2612,6 +2612,7 @@ std::array<ParticleReal, 3> WarpXParticleContainer::meanParticleVelocity(bool lo
 amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(amrex::Real const * const dx,
                                                              bool local) {
 
+    constexpr auto inv_c2 = PhysConst::inv_c2_v<amrex::ParticleReal>;
     ReduceOps<ReduceOpMax> reduce_op;
     ReduceData<ParticleReal> reduce_data(reduce_op);
 
@@ -2642,7 +2643,7 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(amrex::Real const *
                 [=] AMREX_GPU_DEVICE (int ip)
                 {
 
-                const amrex::ParticleReal betasq = ux[ip]*ux[ip] + uy[ip]*uy[ip] + uz[ip]*uz[ip];
+                const amrex::ParticleReal betasq = ux[ip]*ux[ip] + uy[ip]*uy[ip] + uz[ip]*uz[ip] * inv_c2;
                 const amrex::ParticleReal gaminv = 1.0_prt/std::sqrt(1.0_prt + betasq);
 
 #if defined(WARPX_DIM_3D)
@@ -2689,9 +2690,6 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(amrex::Real const *
 
     amrex::ParticleReal max_dt_inv = (np_total > 0 ? amrex::get<0>(reduce_data.value()) : 0._prt);
     if (!local) { ParallelAllReduce::Max(max_dt_inv, ParallelDescriptor::Communicator()); }
-
-    // Need to scale the result by c since u in reduction above is actually beta
-    max_dt_inv *= PhysConst::c;
 
     return max_dt_inv;
 }

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2658,7 +2658,7 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(amrex::Real const *
                 const amrex::ParticleReal dt_inv = gaminv * std::abs(uz[ip]) / dx[2];
 #elif defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
                 amrex::ParticleReal xp, yp, zp;
-                GetPosition(xp, yp, zp)
+                GetPosition(ip, xp, yp, zp);
                 const amrex::ParticleReal rp = std::sqrt(xp*xp + yp*yp);
                 const amrex::ParticleReal costh = (rp > 0._rt ? xp/rp : 1._rt);
                 const amrex::ParticleReal sinth = (rp > 0._rt ? yp/rp : 0._rt);
@@ -2672,7 +2672,7 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(amrex::Real const *
 #endif
 #elif defined(WARPX_DIM_RSPHERE)
                 amrex::ParticleReal xp, yp, zp;
-                GetPosition(xp, yp, zp)
+                GetPosition(ip, xp, yp, zp);
                 const amrex::ParticleReal rpxy = std::sqrt(xp*xp + yp*yp);
                 const amrex::ParticleReal rp = std::sqrt(xp*xp + yp*yp + zp*zp);
                 const amrex::ParticleReal costh = (rpxy > 0._rt ? xp/rpxy : 1._rt);

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2649,9 +2649,9 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(bool local) {
 
 #if defined(WARPX_DIM_3D)
                 const amrex::ParticleReal dt_inv = gaminv *
-                                                   amrex::max({std::abs(ux[ip]) * dxi.x,
-                                                               std::abs(uy[ip]) * dxi.y,
-                                                               std::abs(uz[ip]) * dxi.z});
+                                                   amrex::max(std::abs(ux[ip]) * dxi.x,
+                                                              std::abs(uy[ip]) * dxi.y,
+                                                              std::abs(uz[ip]) * dxi.z);
 #elif defined(WARPX_DIM_XZ)
                 const amrex::ParticleReal dt_inv = gaminv *
                                                    amrex::max(std::abs(ux[ip]) * dxi.x,

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2669,8 +2669,8 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(bool local) {
                 const amrex::ParticleReal dt_inv = gaminv * std::abs(ur) * dxi.x;
 #else
                 const amrex::ParticleReal dt_inv = gaminv *
-                                                   std::max(std::abs(ur) * dxi.x,
-                                                            std::abs(uz[ip]) * dxi.z);
+                                                   amrex::max(std::abs(ur) * dxi.x,
+                                                              std::abs(uz[ip]) * dxi.z);
 #endif
 #elif defined(WARPX_DIM_RSPHERE)
                 amrex::ParticleReal xp, yp, zp;

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2609,9 +2609,9 @@ std::array<ParticleReal, 3> WarpXParticleContainer::meanParticleVelocity(bool lo
     return mean_v;
 }
 
-amrex::ParticleReal WarpXParticleContainer::maxParticleVelocity(bool local) {
+amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(amrex::Real const * const dx,
+                                                             bool local) {
 
-    constexpr auto inv_c2 = PhysConst::inv_c2_v<amrex::ParticleReal>;
     ReduceOps<ReduceOpMax> reduce_op;
     ReduceData<ParticleReal> reduce_data(reduce_op);
 
@@ -2634,19 +2634,63 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleVelocity(bool local) {
             auto *const uy = pti.GetAttribs(PIdx::uy).data();
             auto *const uz = pti.GetAttribs(PIdx::uz).data();
 
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+            const auto GetPosition = GetParticlePosition<PIdx>(pti);
+#endif
+
             reduce_op.eval(np, reduce_data,
                 [=] AMREX_GPU_DEVICE (int ip)
-                { return (ux[ip]*ux[ip] + uy[ip]*uy[ip] + uz[ip]*uz[ip]) * inv_c2; });
+                {
+
+                const amrex::ParticleReal betasq = ux[ip]*ux[ip] + uy[ip]*uy[ip] + uz[ip]*uz[ip];
+                const amrex::ParticleReal gaminv = 1.0_prt/std::sqrt(1.0_prt + betasq);
+
+#if defined(WARPX_DIM_3D)
+                const amrex::ParticleReal dir0_dt_inv = gaminv * std::abs(ux[ip]) / dx[0];
+                const amrex::ParticleReal dir1_dt_inv = gaminv * std::abs(uy[ip]) / dx[1];
+                const amrex::ParticleReal dir2_dt_inv = gaminv * std::abs(uz[ip]) / dx[2];
+                const amrex::ParticleReal dt_inv = std::max(dir0_dt_inv, std::max(dir1_dt_inv, dir2_dt_inv));
+#elif defined(WARPX_DIM_XZ)
+                const amrex::ParticleReal dir0_dt_inv = gaminv * std::abs(ux[ip]) / dx[0];
+                const amrex::ParticleReal dir2_dt_inv = gaminv * std::abs(uz[ip]) / dx[2];
+                const amrex::ParticleReal dt_inv = std::max(dir0_dt_inv, dir2_dt_inv);
+#elif defined(WARPX_DIM_1D_Z)
+                const amrex::ParticleReal dt_inv = gaminv * std::abs(uz[ip]) / dx[2];
+#elif defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
+                amrex::ParticleReal xp, yp, zp;
+                GetPosition(xp, yp, zp)
+                const amrex::ParticleReal rp = std::sqrt(xp*xp + yp*yp);
+                const amrex::ParticleReal costh = (rp > 0._rt ? xp/rp : 1._rt);
+                const amrex::ParticleReal sinth = (rp > 0._rt ? yp/rp : 0._rt);
+                const amrex::ParticleReal ur = ux[ip]*costh + uy[ip]*sinth;
+                const amrex::ParticleReal dir0_dt_inv = gaminv * std::abs(ur) / dx[0];
+#if defined(WARPX_DIM_RCYLINDER)
+                const amrex::ParticleReal dt_inv = dir0_dt_inv;
+#else
+                const amrex::ParticleReal dir2_dt_inv = gaminv * std::abs(uz[ip]) / dx[2];
+                const amrex::ParticleReal dt_inv = std::max(dir0_dt_inv, dir2_dt_inv);
+#endif
+#elif defined(WARPX_DIM_RSPHERE)
+                amrex::ParticleReal xp, yp, zp;
+                GetPosition(xp, yp, zp)
+                const amrex::ParticleReal rpxy = std::sqrt(xp*xp + yp*yp);
+                const amrex::ParticleReal rp = std::sqrt(xp*xp + yp*yp + zp*zp);
+                const amrex::ParticleReal costh = (rpxy > 0._rt ? xp/rpxy : 1._rt);
+                const amrex::ParticleReal sinth = (rpxy > 0._rt ? yp/rpxy : 0._rt);
+                const amrex::ParticleReal cosph = (rp > 0._rt ? rpxy/rp : 1._rt);
+                const amrex::ParticleReal sinph = (rp > 0._rt ? zp/rp : 0._rt);
+                const amrex::ParticleReal ur = ux[ip]*costh*cosph + uy[ip]*sinth*cosph + uz[ip]*sinph;
+                const amrex::ParticleReal dt_inv = gaminv * std::abs(ur) / dx[0];
+#endif
+                return dt_inv;
+                });
         }
     }
 
-    const amrex::ParticleReal max_usq = (np_total > 0 ? amrex::get<0>(reduce_data.value()) : 0._prt);
+    amrex::ParticleReal max_dt_inv = (np_total > 0 ? amrex::get<0>(reduce_data.value()) : 0._prt);
+    if (!local) { ParallelAllReduce::Max(max_dt_inv, ParallelDescriptor::Communicator()); }
 
-    const amrex::ParticleReal gaminv = 1.0_prt/std::sqrt(1.0_prt + max_usq);
-    amrex::ParticleReal max_v = gaminv * std::sqrt(max_usq) * PhysConst::c;
-
-    if (!local) { ParallelAllReduce::Max(max_v, ParallelDescriptor::Communicator()); }
-    return max_v;
+    return max_dt_inv * PhysConst::c;
 }
 
 void

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2649,9 +2649,9 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(bool local) {
 
 #if defined(WARPX_DIM_3D)
                 const amrex::ParticleReal dt_inv = gaminv *
-                                                   std::max({std::abs(ux[ip]) * dxi.x,
-                                                             std::abs(uy[ip]) * dxi.y,
-                                                             std::abs(uz[ip]) * dxi.z});
+                                                   amrex::max({std::abs(ux[ip]) * dxi.x,
+                                                               std::abs(uy[ip]) * dxi.y,
+                                                               std::abs(uz[ip]) * dxi.z});
 #elif defined(WARPX_DIM_XZ)
                 const amrex::ParticleReal dt_inv = gaminv *
                                                    amrex::max(std::abs(ux[ip]) * dxi.x,

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2609,8 +2609,7 @@ std::array<ParticleReal, 3> WarpXParticleContainer::meanParticleVelocity(bool lo
     return mean_v;
 }
 
-amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(amrex::XDim3 dx,
-                                                             bool local) {
+amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(bool local) {
 
     constexpr auto inv_c2 = PhysConst::inv_c2_v<amrex::ParticleReal>;
     ReduceOps<ReduceOpMax> reduce_op;
@@ -2639,6 +2638,8 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(amrex::XDim3 dx,
             const auto GetPosition = GetParticlePosition<PIdx>(pti);
 #endif
 
+            const XDim3 dxi = WarpX::InvCellSize(lev);
+
             reduce_op.eval(np, reduce_data,
                 [=] AMREX_GPU_DEVICE (int ip)
                 {
@@ -2648,15 +2649,15 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(amrex::XDim3 dx,
 
 #if defined(WARPX_DIM_3D)
                 const amrex::ParticleReal dt_inv = gaminv *
-                                                   std::max({std::abs(ux[ip]) / dx.x,
-                                                             std::abs(uy[ip]) / dx.y,
-                                                             std::abs(uz[ip]) / dx.z});
+                                                   std::max({std::abs(ux[ip]) * dxi.x,
+                                                             std::abs(uy[ip]) * dxi.y,
+                                                             std::abs(uz[ip]) * dxi.z});
 #elif defined(WARPX_DIM_XZ)
                 const amrex::ParticleReal dt_inv = gaminv *
-                                                   std::max(std::abs(ux[ip]) / dx.x,
-                                                            std::abs(uz[ip]) / dx.z);
+                                                   std::max(std::abs(ux[ip]) * dxi.x,
+                                                            std::abs(uz[ip]) * dxi.z);
 #elif defined(WARPX_DIM_1D_Z)
-                const amrex::ParticleReal dt_inv = gaminv * std::abs(uz[ip]) / dx.z;
+                const amrex::ParticleReal dt_inv = gaminv * std::abs(uz[ip]) * dxi.z;
 #elif defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
                 amrex::ParticleReal xp, yp, zp;
                 GetPosition(ip, xp, yp, zp);
@@ -2665,11 +2666,11 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(amrex::XDim3 dx,
                 const amrex::ParticleReal sinth = (rp > 0._rt ? yp/rp : 0._rt);
                 const amrex::ParticleReal ur = ux[ip]*costh + uy[ip]*sinth;
 #if defined(WARPX_DIM_RCYLINDER)
-                const amrex::ParticleReal dt_inv = gaminv * std::abs(ur) / dx.x;
+                const amrex::ParticleReal dt_inv = gaminv * std::abs(ur) * dxi.x;
 #else
                 const amrex::ParticleReal dt_inv = gaminv *
-                                                   std::max(std::abs(ur) / dx.x,
-                                                            std::abs(uz[ip]) / dx.z);
+                                                   std::max(std::abs(ur) * dxi.x,
+                                                            std::abs(uz[ip]) * dxi.z);
 #endif
 #elif defined(WARPX_DIM_RSPHERE)
                 amrex::ParticleReal xp, yp, zp;
@@ -2681,7 +2682,7 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(amrex::XDim3 dx,
                 const amrex::ParticleReal cosph = (rp > 0._rt ? rpxy/rp : 1._rt);
                 const amrex::ParticleReal sinph = (rp > 0._rt ? zp/rp : 0._rt);
                 const amrex::ParticleReal ur = ux[ip]*costh*cosph + uy[ip]*sinth*cosph + uz[ip]*sinph;
-                const amrex::ParticleReal dt_inv = gaminv * std::abs(ur) / dx.x;
+                const amrex::ParticleReal dt_inv = gaminv * std::abs(ur) * dxi.x;
 #endif
                 return dt_inv;
                 });

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2654,8 +2654,8 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(bool local) {
                                                              std::abs(uz[ip]) * dxi.z});
 #elif defined(WARPX_DIM_XZ)
                 const amrex::ParticleReal dt_inv = gaminv *
-                                                   std::max(std::abs(ux[ip]) * dxi.x,
-                                                            std::abs(uz[ip]) * dxi.z);
+                                                   amrex::max(std::abs(ux[ip]) * dxi.x,
+                                                              std::abs(uz[ip]) * dxi.z);
 #elif defined(WARPX_DIM_1D_Z)
                 const amrex::ParticleReal dt_inv = gaminv * std::abs(uz[ip]) * dxi.z;
 #elif defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2649,7 +2649,7 @@ amrex::ParticleReal WarpXParticleContainer::maxParticleDtInv(amrex::Real const *
                 const amrex::ParticleReal dir0_dt_inv = gaminv * std::abs(ux[ip]) / dx[0];
                 const amrex::ParticleReal dir1_dt_inv = gaminv * std::abs(uy[ip]) / dx[1];
                 const amrex::ParticleReal dir2_dt_inv = gaminv * std::abs(uz[ip]) / dx[2];
-                const amrex::ParticleReal dt_inv = std::max(dir0_dt_inv, std::max(dir1_dt_inv, dir2_dt_inv));
+                const amrex::ParticleReal dt_inv = std::max({dir0_dt_inv, dir1_dt_inv, dir2_dt_inv});
 #elif defined(WARPX_DIM_XZ)
                 const amrex::ParticleReal dir0_dt_inv = gaminv * std::abs(ux[ip]) / dx[0];
                 const amrex::ParticleReal dir2_dt_inv = gaminv * std::abs(uz[ip]) / dx[2];

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -429,7 +429,6 @@ public:
     /**
      * Determine the simulation timestep from the time step limiters
      */
-    amrex::Real ParticleGridSpeedMax ();
     amrex::Real GlobalPlasmaFrequencyMax ();
     amrex::Real GlobalCyclotronFrequencyMax ();
     void ApplyDtLimiters ();


### PR DESCRIPTION
For time solvers that permit dynamic time steps, WarpX currently computes the particle time step using the maximum particle speed divided by the minimum cell size. This can be overly restrictive for systems with anisotropic particle velocity distributions and/or anisotropic grid cell sizes.

This PR instead computes the particle time step from the maximum directional value of $|v_i|/\Delta x_i$. For 2D simulations, only the in-plane directions are considered; likewise, only the single spatial direction is considered in 1D simulations.