### PR TITLE
[DO NOT MERGE] Demonstrate ParallelFor issues with GCC 15

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -41,7 +41,17 @@ jobs:
     matrix:
       # 1D Cartesian, Cylindrical, Spherical
       1d:
-        WARPX_CMAKE_FLAGS: -DWarpX_DIMS='1;RCYLINDER;RSPHERE' -DWarpX_FFT=ON -DWarpX_PYTHON=ON -DWarpX_PETSC=ON
+        # DEMONSTRATION ONLY - DO NOT MERGE.
+        # Build this job with GCC 15 instead of the image default (GCC 13). With
+        # cubic shape factors, GCC 15 vectorizes the particle loop in
+        # doChargeDepositionShapeN (licensed by the "GCC ivdep" that
+        # AMREX_PRAGMA_SIMD puts on amrex::ParallelFor) even though consecutive
+        # particles accumulate into the same rho nodes and CPU
+        # Gpu::Atomic::AddNoRet is a plain "+=". 3 of every 4 updates are
+        # dropped, rho comes out 4x too small, and the energy-conservation
+        # analysis fails. GCC 13 does not vectorize that loop, which is why this
+        # bug is invisible on the current CI image.
+        WARPX_CMAKE_FLAGS: -DWarpX_DIMS='1;RCYLINDER;RSPHERE' -DWarpX_FFT=ON -DWarpX_PYTHON=ON -DWarpX_PETSC=ON -DCMAKE_C_COMPILER=gcc-15 -DCMAKE_CXX_COMPILER=g++-15
       # Cartesian 2D
       cartesian_2d:
         WARPX_CMAKE_FLAGS: -DWarpX_DIMS=2 -DWarpX_FFT=ON -DWarpX_PYTHON=ON -DWarpX_PETSC=ON
@@ -90,6 +100,14 @@ jobs:
       df -h
       echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
       sudo apt update
+      # DEMONSTRATION ONLY - DO NOT MERGE.
+      # ubuntu-24.04 ships GCC 13, which does not vectorize the affected
+      # deposition loop. Pull in GCC 15 so the 1d job can expose the bug.
+      sudo apt install -y software-properties-common
+      sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+      sudo apt update
+      sudo apt install -y gcc-15 g++-15
+      g++-15 --version
       sudo apt install -y ccache curl gcc gfortran git g++ ninja-build \
         openmpi-bin libopenmpi-dev \
         libfftw3-dev libfftw3-mpi-dev libhdf5-openmpi-dev pkg-config make \

--- a/Examples/Tests/energy_conserving_thermal_plasma/inputs_test_1d_energy_conserving_thermal_plasma
+++ b/Examples/Tests/energy_conserving_thermal_plasma/inputs_test_1d_energy_conserving_thermal_plasma
@@ -8,7 +8,7 @@ geometry.dims = 1
 
 warpx.do_electrostatic = labframe
 algo.field_gathering = energy-conserving
-algo.particle_shape = 2
+algo.particle_shape = 3
 warpx.use_filter = 0
 
 #################################

--- a/Source/Particles/Deposition/ChargeDeposition.H
+++ b/Source/Particles/Deposition/ChargeDeposition.H
@@ -60,7 +60,7 @@ void doChargeDepositionShapeN (const GetParticlePosition<PIdx>& GetPosition,
     constexpr int CELL = amrex::IndexType::CELL;
 
     // Loop over particles and deposit into rho_fab
-    amrex::ParallelFor(
+    amrex::For(
             np_to_deposit,
             [=] AMREX_GPU_DEVICE (long ip) {
             // --- Get particle quantities
@@ -265,7 +265,7 @@ void doChargeDepositionSharedShapeN (const GetParticlePosition<PIdx>& GetPositio
                   nblocks, threads_per_block, shared_mem_bytes, amrex::Gpu::gpuStream(),
                   [=] AMREX_GPU_DEVICE () noexcept
 #else // defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
-    amrex::ParallelFor(np_to_deposit, [=] AMREX_GPU_DEVICE (long ip_orig) noexcept
+    amrex::For(np_to_deposit, [=] AMREX_GPU_DEVICE (long ip_orig) noexcept
 #endif
       {
 #if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -331,7 +331,7 @@ void doDepositionShapeN (const GetParticlePosition<PIdx>& GetPosition,
     amrex::IntVect const jz_type = jz_fab.box().type();
 
     // Loop over particles and deposit into jx_fab, jy_fab and jz_fab
-    amrex::ParallelFor(
+    amrex::For(
         np_to_deposit,
         [=] AMREX_GPU_DEVICE (long ip) {
             amrex::ParticleReal xp, yp, zp;
@@ -416,7 +416,7 @@ void doDepositionShapeNImplicit(const GetParticlePosition<PIdx>& GetPosition,
     amrex::IntVect const jz_type = jz_fab.box().type();
 
     // Loop over particles and deposit into jx_fab, jy_fab and jz_fab
-    amrex::ParallelFor(
+    amrex::For(
             np_to_deposit,
             [=] AMREX_GPU_DEVICE (long ip) {
             amrex::ParticleReal xp, yp, zp;
@@ -1159,7 +1159,7 @@ void doChargeConservingDepositionShapeNImplicit ([[maybe_unused]]const amrex::Pa
 #endif
 
     // Loop over particles and deposit into Jx_arr, Jy_arr and Jz_arr
-    amrex::ParallelFor(
+    amrex::For(
         np_to_deposit,
         [=] AMREX_GPU_DEVICE (long const ip) {
 
@@ -2215,7 +2215,7 @@ void doVillasenorDepositionShapeNExplicit (const GetParticlePosition<PIdx>& GetP
     const amrex::Real invvol = dinv.x*dinv.y*dinv.z;
 
     // Loop over particles and deposit into Jx_arr, Jy_arr and Jz_arr
-    amrex::ParallelFor(
+    amrex::For(
         np_to_deposit,
         [=] AMREX_GPU_DEVICE (long const ip) {
 
@@ -2312,7 +2312,7 @@ void doVillasenorDepositionShapeNImplicit ([[maybe_unused]]const amrex::Particle
     const amrex::Real invvol = dinv.x*dinv.y*dinv.z;
 
     // Loop over particles and deposit into Jx_arr, Jy_arr and Jz_arr
-    amrex::ParallelFor(
+    amrex::For(
         np_to_deposit,
         [=] AMREX_GPU_DEVICE (long const ip) {
 
@@ -2444,7 +2444,7 @@ void doVayDepositionShapeN (const GetParticlePosition<PIdx>& GetPosition,
     amrex::Array4<amrex::Real> const& Dz_arr = Dz_fab.array();
 
     // Loop over particles and deposit (Dx,Dy,Dz) into Dx_fab, Dy_fab and Dz_fab
-    amrex::ParallelFor(np_to_deposit, [=] AMREX_GPU_DEVICE (long ip)
+    amrex::For(np_to_deposit, [=] AMREX_GPU_DEVICE (long ip)
     {
         // Inverse of Lorentz factor gamma
         const amrex::Real invgam = 1._rt / std::sqrt(1._rt + uxp[ip] * uxp[ip] * PhysConst::inv_c2


### PR DESCRIPTION
This PR is not meant to be merged, but instead is here to demonstrate some CI failures due to what I believe is **invalid usage of `ParallelFor` in WarpX**, through a series of short commits and looking at which commits pass or fail certain CI tests.

When looking at the CI failures, PLEASE FOCUS ONLY ON `test_1d_energy_conserving_thermal_plasma.analysis`. Other CI tests are also failing but are less convincing and some of them are expected (e.g. brittle checksum values) ; on the other hand `test_1d_energy_conserving_thermal_plasma.analysis` is not brittle and clearly fails for some commits.

Here is the list of commits:
- [eeae7f8](https://github.com/BLAST-WarpX/warpx/pull/7095/commits/eeae7f8f0347b6c76fbc192c6158f24c18f30f31): switches the `test_1d_energy_conserving_thermal_plasma` to cubic shape factor (this is the condition under which I first observed the bug, but I believe it is more general). `test_1d_energy_conserving_thermal_plasma.analysis` **passes**.
- [eee2d9f](https://github.com/BLAST-WarpX/warpx/pull/7095/commits/eee2d9fbabd5374e0ead60654e75756981f3f395): switches the compiler from gcc 13 to gcc 15. `test_1d_energy_conserving_thermal_plasma.analysis` **fails**.
- [f8bf60b](https://github.com/BLAST-WarpX/warpx/pull/7095/commits/f8bf60b04a53fd3f7f30b95bf6a44f8a7d08dbb8): switches from `amrex::ParallelFor` to `amrex::For` for some of the charge/current deposition kernels. `test_1d_energy_conserving_thermal_plasma.analysis` **passes again**.

