### PR TITLE
Fix RZ/RCYLINDER DSMC ionization double velocity rotation and guard against negative energy

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -432,15 +432,16 @@ public:
                 // calculate kinetic energy of the collision
                 const amrex::ParticleReal p_non_target_in = m0 * std::sqrt(ux0*ux0 + uy0*uy0 + uz0*uz0);
                 const amrex::ParticleReal E_coll = 0.5_prt * p_non_target_in * p_non_target_in * (1.0_prt/m0 + 1.0_prt/m1);
+
                 // subtract the energy cost for ionization (converted from eV to J)
-                // Clamped to a tiny positive floor: CollisionFilterFunc.H selects this pair for
+                amrex::ParticleReal E_out = E_coll - scattering_process.m_energy_penalty * PhysConst::q_e;
+
+                // clamp E_out to a tiny positive floor: CollisionFilterFunc.H selects this pair for
                 // ionization using a differently-computed (relativistic, whole-pair) collision
                 // energy, so E_out can come out (slightly) negative here even though the pair
                 // cleared the ionization threshold there; without the floor, the sqrt() calls
                 // below would produce a NaN velocity.
-                const amrex::ParticleReal E_out = amrex::max(
-                    E_coll - scattering_process.m_energy_penalty * PhysConst::q_e,
-                    std::numeric_limits<amrex::ParticleReal>::min());
+                E_out = amrex::max(E_out, std::numeric_limits<amrex::ParticleReal>::min());
 
                 // The kinematics of the ionization event (i.e. how the energy and momentum are
                 // distributed among the products) depend on the nature of the incident particle

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -18,6 +18,7 @@
 #include "Utils/WarpXAlgorithmSelection.H"
 
 #include <array>
+#include <limits>
 
 /**
  * \brief This class defines an operator to create product particles from DSMC
@@ -401,24 +402,14 @@ public:
                 auto& uy3 = soa_products_data[3].m_rdata[PIdx::uy][slot3_idx];
                 auto& uz3 = soa_products_data[3].m_rdata[PIdx::uz][slot3_idx];
 
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-                /* In RZ and RCYLINDER geometry, macroparticles can collide with other macroparticles
-                * in the same *cylindrical* cell. For this reason, collisions between macroparticles
-                * are actually not local in space. In this case, the underlying assumption is that
-                * particles within the same cylindrical cell represent a cylindrically-symmetry
-                * momentum distribution function. Therefore, here, we temporarily rotate the
-                * momentum of one of the macroparticles in agreement with this cylindrical symmetry.
-                * (This is technically only valid if we use only the m=0 azimuthal mode in the simulation;
-                * there is a corresponding assert statement at initialization.)
-                */
-                amrex::ParticleReal const theta = (
-                    soa_products_data[2].m_rdata[PIdx::theta][slot2_idx]
-                    - soa_products_data[0].m_rdata[PIdx::theta][slot0_idx]
-                );
-                amrex::ParticleReal const ux0buf = ux0;
-                ux0 = ux0buf*std::cos(theta) - uy0*std::sin(theta);
-                uy0 = ux0buf*std::sin(theta) + uy0*std::cos(theta);
-#endif
+                // Note: in RZ/RCYLINDER geometry, ux0/uy0 and ux2,3/uy2,3 have already been
+                // rotated into each particle's own local curvilinear frame (theta = 0) by
+                // WarpXParticleContainer::TransformMomentumToCurvilinear(), called once for the
+                // whole particle container in CollisionHandler::doCollisions() before any collision
+                // routine runs. They are combined directly below, with no further per-pair rotation,
+                // for consistency with CollisionFilterFunc.H (which selects this pair for ionization
+                // using that same convention) and with TwoProductComputeProductMomenta (used by every
+                // other DSMC scattering process).
 
                 // for simplicity (for now) we assume non-relativistic particles
                 // and simply calculate the center-of-momentum velocity from the
@@ -442,8 +433,14 @@ public:
                 const amrex::ParticleReal p_non_target_in = m0 * std::sqrt(ux0*ux0 + uy0*uy0 + uz0*uz0);
                 const amrex::ParticleReal E_coll = 0.5_prt * p_non_target_in * p_non_target_in * (1.0_prt/m0 + 1.0_prt/m1);
                 // subtract the energy cost for ionization (converted from eV to J)
-                const amrex::ParticleReal E_out =
-                    E_coll - scattering_process.m_energy_penalty * PhysConst::q_e;
+                // Clamped to a tiny positive floor: CollisionFilterFunc.H selects this pair for
+                // ionization using a differently-computed (relativistic, whole-pair) collision
+                // energy, so E_out can come out (slightly) negative here even though the pair
+                // cleared the ionization threshold there; without the floor, the sqrt() calls
+                // below would produce a NaN velocity.
+                const amrex::ParticleReal E_out = amrex::max(
+                    E_coll - scattering_process.m_energy_penalty * PhysConst::q_e,
+                    std::numeric_limits<amrex::ParticleReal>::min());
 
                 // The kinematics of the ionization event (i.e. how the energy and momentum are
                 // distributed among the products) depend on the nature of the incident particle
@@ -555,13 +552,6 @@ public:
                 ux3 += uCOM_x;
                 uy3 += uCOM_y;
                 uz3 += uCOM_z;
-
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-                /* Undo the earlier velocity rotation. */
-                amrex::ParticleReal const ux0buf_new = ux0;
-                ux0 = ux0buf_new*std::cos(-theta) - uy0*std::sin(-theta);
-                uy0 = ux0buf_new*std::sin(-theta) + uy0*std::cos(-theta);
-#endif
             }
         });
 

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -18,7 +18,6 @@
 #include "Utils/WarpXAlgorithmSelection.H"
 
 #include <array>
-#include <limits>
 
 /**
  * \brief This class defines an operator to create product particles from DSMC
@@ -436,12 +435,12 @@ public:
                 // subtract the energy cost for ionization (converted from eV to J)
                 amrex::ParticleReal E_out = E_coll - scattering_process.m_energy_penalty * PhysConst::q_e;
 
-                // clamp E_out to a tiny positive floor: CollisionFilterFunc.H selects this pair for
-                // ionization using a differently-computed (relativistic, whole-pair) collision
-                // energy, so E_out can come out (slightly) negative here even though the pair
-                // cleared the ionization threshold there; without the floor, the sqrt() calls
-                // below would produce a NaN velocity.
-                E_out = amrex::max(E_out, std::numeric_limits<amrex::ParticleReal>::min());
+                // clamp E_out to 0: CollisionFilterFunc.H selects this pair for ionization
+                // using  a differently-computed (relativistic, whole-pair) collision energy,
+                // so E_out can come out (slightly) negative here even though the pair cleared
+                // the ionization threshold there; without the floor, the sqrt() calls below
+                // would produce a NaN velocity in such cases.
+                E_out = amrex::max(E_out, 0.0);
 
                 // The kinematics of the ionization event (i.e. how the energy and momentum are
                 // distributed among the products) depend on the nature of the incident particle

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -440,7 +440,7 @@ public:
                 // so E_out can come out (slightly) negative here even though the pair cleared
                 // the ionization threshold there; without the floor, the sqrt() calls below
                 // would produce a NaN velocity in such cases.
-                E_out = amrex::max(E_out, 0.0);
+                E_out = amrex::max(E_out, 0.0_prt);
 
                 // The kinematics of the ionization event (i.e. how the energy and momentum are
                 // distributed among the products) depend on the nature of the incident particle

--- a/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
+++ b/Source/Particles/Collision/BinaryCollision/DSMC/SplitAndScatterFunc.H
@@ -440,6 +440,8 @@ public:
                 // so E_out can come out (slightly) negative here even though the pair cleared
                 // the ionization threshold there; without the floor, the sqrt() calls below
                 // would produce a NaN velocity in such cases.
+                // TODO: update the E_coll calculation above to match the calculation in
+                // CollisionFilterFunc.H
                 E_out = amrex::max(E_out, 0.0_prt);
 
                 // The kinematics of the ionization event (i.e. how the energy and momentum are


### PR DESCRIPTION
In RZ/RCYLINDER geometry, CollisionHandler::doCollisions rotates every particle's momentum into its own local curvilinear frame (theta=0) before any collision type runs, and CollisionFilterFunc.H / get_collision_parameters combine colliding pairs directly in that frame, as does every other DSMC scattering process's kinematics (TwoProductComputeProductMomenta).

The ionization branch in SplitAndScatterFunc.H instead applied a second, pair-relative rotation (by the real theta difference between the two macroparticles) before computing its own collision energy, using a different, unreconciled convention. Since CollisionFilterFunc.H selects a pair for ionization using the first convention while the ionization kinematics computed available energy using the second, the two could disagree near the ionization threshold, letting E_out go negative and std::sqrt(E_out / ...) return NaN.

Remove the extra rotation so ionization matches the rest of the collision pipeline's convention, and add a defensive floor on E_out as a safety net against the residual (much smaller) relativistic vs. non-relativistic E_coll discrepancy between the two paths.