### PR TITLE
Bug: `amrex::For` if indices are not independent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,6 +122,7 @@ Commits should limit any formatting changes of unchanged code.
 - Fields are stored as AMReX `MultiFab` objects, managed via `ablastr::fields::MultiFabRegister`
 - Particle species managed by `MultiParticleContainer` → `WarpXParticleContainer`
 - Compile-time macros: `WARPX_DIM_3D`, `WARPX_DIM_XZ`, `WARPX_DIM_1D_Z`, `WARPX_DIM_RZ`
+- `amrex::ParallelFor` promises the compiler that loop iterations are independent (it applies a CPU SIMD pragma). Kernels where different iterations can write the same memory location — particle-to-grid deposition, scatter-add, histogram binning, shared counters — must use `amrex::For` instead, and whole-loop sums/maxima the `amrex::Reduce` framework. `amrex::Gpu::Atomic` operations are plain non-atomic updates on CPU and do not make a `ParallelFor` safe. See `Docs/source/developers/portability.rst`.
 
 ## C++ Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ Commits should limit any formatting changes of unchanged code.
 - Fields are stored as AMReX `MultiFab` objects, managed via `ablastr::fields::MultiFabRegister`
 - Particle species managed by `MultiParticleContainer` → `WarpXParticleContainer`
 - Compile-time macros: `WARPX_DIM_3D`, `WARPX_DIM_XZ`, `WARPX_DIM_1D_Z`, `WARPX_DIM_RZ`
-- `amrex::ParallelFor` promises the compiler that loop iterations are independent (it applies a CPU SIMD pragma). Kernels where different iterations can write the same memory location — particle-to-grid deposition, scatter-add, histogram binning, shared counters — must use `amrex::For` instead, and whole-loop sums/maxima the `amrex::Reduce` framework. `amrex::Gpu::Atomic` operations are plain non-atomic updates on CPU and do not make a `ParallelFor` safe. See `Docs/source/developers/portability.rst`.
+- `amrex::ParallelFor` promises the compiler that loop iterations are independent (it applies a CPU SIMD pragma). Kernels where different iterations can write the same memory location — particle-to-grid deposition, scatter-add, histogram binning, shared counters — must use `amrex::For` instead, and whole-loop sums/maxima the `amrex::Reduce` function. `amrex::Gpu::Atomic` operations are plain non-atomic updates on CPU and do not make a `ParallelFor` safe. See `Docs/source/developers/portability.rst`.
 
 ## C++ Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ Commits should limit any formatting changes of unchanged code.
 - Fields are stored as AMReX `MultiFab` objects, managed via `ablastr::fields::MultiFabRegister`
 - Particle species managed by `MultiParticleContainer` → `WarpXParticleContainer`
 - Compile-time macros: `WARPX_DIM_3D`, `WARPX_DIM_XZ`, `WARPX_DIM_1D_Z`, `WARPX_DIM_RZ`
-- `amrex::ParallelFor` promises the compiler that loop iterations are independent (it applies a CPU SIMD pragma). Kernels where different iterations can write the same memory location — particle-to-grid deposition, scatter-add, histogram binning, shared counters — must use `amrex::For` instead, and whole-loop sums/maxima the `amrex::Reduce` function. `amrex::Gpu::Atomic` operations are plain non-atomic updates on CPU and do not make a `ParallelFor` safe. See `Docs/source/developers/portability.rst`.
+- `amrex::ParallelFor` promises the compiler that loop iterations are independent (it applies a CPU SIMD pragma). Kernels where different iterations can write the same memory location — particle-to-grid deposition, scatter-add, histogram binning, shared counters — must use `amrex::For` instead, and whole-loop sums/maxima the `amrex::Reduce` function. `amrex::Gpu::Atomic` operations are plain non-atomic updates on CPU and do not make a `ParallelFor` safe; `amrex::HostDevice::Atomic` is atomic across OpenMP threads on CPU but does not make a `ParallelFor` safe either. See `Docs/source/developers/portability.rst`.
 
 ## C++ Style
 

--- a/Docs/source/developers/particles.rst
+++ b/Docs/source/developers/particles.rst
@@ -37,7 +37,7 @@ A typical loop over particles reads:
   }
 
 The innermost step ``[MY INNER LOOP]`` typically calls ``amrex::ParallelFor`` or ``amrex::For`` to perform operations on all particles in a portable way.
-``amrex::ParallelFor`` may only be used when the loop iterations are independent of each other; kernels in which particles scatter-add into shared grid cells — most notably charge and current deposition — must use ``amrex::For`` instead (see :ref:`Developers: Portability <developers-portability>`).
+``amrex::ParallelFor`` may only be used when the loop iterations are independent of each other. Kernels in which particles scatter-add into shared grid cells (e.g. deposition, histogram bins, etc.) must use ``amrex::For`` instead (see :ref:`Developers: Portability <developers-portability>`).
 The innermost loop in the code snippet above could look like:
 
 .. code-block:: cpp

--- a/Docs/source/developers/particles.rst
+++ b/Docs/source/developers/particles.rst
@@ -36,7 +36,9 @@ A typical loop over particles reads:
       }
   }
 
-The innermost step ``[MY INNER LOOP]`` typically calls ``amrex::ParallelFor`` to perform operations on all particles in a portable way. The innermost loop in the code snippet above could look like:
+The innermost step ``[MY INNER LOOP]`` typically calls ``amrex::ParallelFor`` or ``amrex::For`` to perform operations on all particles in a portable way.
+``amrex::ParallelFor`` may only be used when the loop iterations are independent of each other; kernels in which particles scatter-add into shared grid cells — most notably charge and current deposition — must use ``amrex::For`` instead (see :ref:`Developers: Portability <developers-portability>`).
+The innermost loop in the code snippet above could look like:
 
 .. code-block:: cpp
 

--- a/Docs/source/developers/particles.rst
+++ b/Docs/source/developers/particles.rst
@@ -37,7 +37,7 @@ A typical loop over particles reads:
   }
 
 The innermost step ``[MY INNER LOOP]`` typically calls ``amrex::ParallelFor`` or ``amrex::For`` to perform operations on all particles in a portable way.
-``amrex::ParallelFor`` may only be used when the loop iterations are independent of each other. Kernels in which particles scatter-add into shared grid cells (e.g. deposition, histogram bins, etc.) must use ``amrex::For`` instead (see :ref:`Developers: Portability <developers-portability>`).
+``amrex::ParallelFor`` may only be used when the loop iterations are independent of each other. Kernels in which particles scatter-add into shared grid cells (e.g., deposition, histogram bins, etc.) must use ``amrex::For`` instead (see :ref:`Developers: Portability <developers-portability>`).
 The innermost loop in the code snippet above could look like:
 
 .. code-block:: cpp

--- a/Docs/source/developers/portability.rst
+++ b/Docs/source/developers/portability.rst
@@ -22,7 +22,8 @@ Picking the wrong one compiles and runs, but can produce silently wrong results,
 
 * ``amrex::ParallelForRNG``: carries no SIMD pragma on CPU; used when random numbers are needed and also safe for non-independent iterations.
 
-* Reductions (sums, maxima over all iterations): use the ``amrex::Reduce`` functions (``amrex::Reduce::Sum``, ``ReduceOps``, ...) instead of accumulating into a shared scalar from a kernel.
+* Whole-loop reductions (sums, maxima) should use the ``amrex::ReduceSIMD`` (or ``amrex::Reduce``) functions instead of accumulating into a shared scalar from a kernel.
+  When compiled for GPU, the ``ReduceSIMD`` code path is inactive and the standard ``amrex::Reduce`` device reduction is used.
 
 .. warning::
 
@@ -30,6 +31,6 @@ Picking the wrong one compiles and runs, but can produce silently wrong results,
    They make scatter kernels safe between GPU threads, but they do *not* make a ``ParallelFor`` loop safe on CPU: under the SIMD pragma the compiler may still vectorize the loop, and vector lanes that hit the same address lose all but one update.
    A kernel that needs ``Gpu::Atomic`` because iterations collide almost always needs ``amrex::For`` (or ``ParallelForRNG``) rather than ``ParallelFor``.
 
-Getting this wrong is silent and compiler-dependent: the miscompilation only appears when a vectorizer decides to act on the pragma.
+Getting ``amrex::ParallelFor`` and atomics wrong is silent and compiler-dependent: the miscompilation only appears when a vectorizer decides to act on the pragma.
 For example, GCC 15 vectorized the charge deposition loop for cubic shape factors in 1D, which dropped three of every four contributions and produced a charge density four times too small, while GCC 13 left the same invalid code intact.
 See `issue #7097 <https://github.com/BLAST-WarpX/warpx/issues/7097>`__ for the full analysis.

--- a/Docs/source/developers/portability.rst
+++ b/Docs/source/developers/portability.rst
@@ -22,7 +22,7 @@ Picking the wrong one compiles and runs, but can produce silently wrong results,
 
 * ``amrex::ParallelForRNG``: carries no SIMD pragma on CPU; used when random numbers are needed and also safe for non-independent iterations.
 
-* Reductions (sums, maxima over all iterations): use the ``amrex::Reduce`` framework (``amrex::Reduce::Sum``, ``ReduceOps``, ...) instead of accumulating into a shared scalar from a kernel.
+* Reductions (sums, maxima over all iterations): use the ``amrex::Reduce`` functions (``amrex::Reduce::Sum``, ``ReduceOps``, ...) instead of accumulating into a shared scalar from a kernel.
 
 .. warning::
 

--- a/Docs/source/developers/portability.rst
+++ b/Docs/source/developers/portability.rst
@@ -3,5 +3,33 @@
 Portability
 ===========
 
-.. note::
-   Section empty!
+WarpX runs on CPUs (serial or OpenMP) and GPUs (CUDA, HIP, SYCL) from a single source.
+Compute kernels are written as C++ lambdas and launched through AMReX's portable constructs, which compile to loops on CPU and kernel launches on GPU (see the `AMReX GPU documentation <https://amrex-codes.github.io/amrex/docs_html/GPU.html>`__).
+
+Choosing a kernel launch construct
+----------------------------------
+
+The launch constructs differ in the promises they make to the compiler.
+Picking the wrong one compiles and runs, but can produce silently wrong results, so review this choice carefully in every new kernel:
+
+* ``amrex::ParallelFor``: on CPU, the innermost loop is marked with ``AMREX_PRAGMA_SIMD`` (e.g., ``#pragma GCC ivdep``), which **promises the compiler that loop iterations are independent** and safe to vectorize.
+  Use it only when no two iterations can touch the same memory location.
+  Standard field stencils (each iteration writes only its own ``(i,j,k)`` and reads separate input arrays) and per-particle updates (each iteration writes only element ``ip``) qualify.
+
+* ``amrex::For``: identical to ``ParallelFor`` on GPU, but omits the SIMD pragma on CPU.
+  Use it whenever different iterations may access the same memory location with at least one write.
+  Typical cases in WarpX: **charge/current deposition** and any other particle-to-grid scatter, histogram binning, and updates of shared counters.
+
+* ``amrex::ParallelForRNG``: carries no SIMD pragma on CPU; used when random numbers are needed and also safe for non-independent iterations.
+
+* Reductions (sums, maxima over all iterations): use the ``amrex::Reduce`` framework (``amrex::Reduce::Sum``, ``ReduceOps``, ...) instead of accumulating into a shared scalar from a kernel.
+
+.. warning::
+
+   ``amrex::Gpu::Atomic`` operations (``AddNoRet``, ``Add``, ``Max``, ...) are **plain, non-atomic updates on CPU**.
+   They make scatter kernels safe between GPU threads, but they do *not* make a ``ParallelFor`` loop safe on CPU: under the SIMD pragma the compiler may still vectorize the loop, and vector lanes that hit the same address lose all but one update.
+   A kernel that needs ``Gpu::Atomic`` because iterations collide almost always needs ``amrex::For`` (or ``ParallelForRNG``) rather than ``ParallelFor``.
+
+Getting this wrong is silent and compiler-dependent: the miscompilation only appears when a vectorizer decides to act on the pragma.
+For example, GCC 15 vectorized the charge deposition loop for cubic shape factors in 1D, which dropped three of every four contributions and produced a charge density four times too small, while GCC 13 left the same invalid code intact.
+See `issue #7097 <https://github.com/BLAST-WarpX/warpx/issues/7097>`__ for the full analysis.

--- a/Docs/source/developers/portability.rst
+++ b/Docs/source/developers/portability.rst
@@ -31,6 +31,9 @@ Picking the wrong one compiles and runs, but can produce silently wrong results,
    They make scatter kernels safe between GPU threads, but they do *not* make a ``ParallelFor`` loop safe on CPU: under the SIMD pragma the compiler may still vectorize the loop, and vector lanes that hit the same address lose all but one update.
    A kernel that needs ``Gpu::Atomic`` because iterations collide almost always needs ``amrex::For`` (or ``ParallelForRNG``) rather than ``ParallelFor``.
 
+   ``amrex::HostDevice::Atomic`` (``Add``, ``FetchAdd``) is atomic on GPU *and* across OpenMP threads on CPU, so prefer it over ``Gpu::Atomic`` in host-device code.
+   It still does not make a ``ParallelFor`` safe: the SIMD pragma's independence promise remains violated, and in non-OpenMP builds the update is a plain ``+=``.
+
 Getting ``amrex::ParallelFor`` and atomics wrong is silent and compiler-dependent: the miscompilation only appears when a vectorizer decides to act on the pragma.
 For example, GCC 15 vectorized the charge deposition loop for cubic shape factors in 1D, which dropped three of every four contributions and produced a charge density four times too small, while GCC 13 left the same invalid code intact.
 See `issue #7097 <https://github.com/BLAST-WarpX/warpx/issues/7097>`__ for the full analysis.

--- a/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
+++ b/Source/Diagnostics/ComputeDiagFunctors/BackTransformFunctor.cpp
@@ -148,6 +148,10 @@ BackTransformFunctor::operator ()(amrex::MultiFab& mf_dst, int /*dcomp*/, const 
                     // real part of mode 1 for Et (1*3+1) = 4
                     dst_arr(i, k_lab, k, n) = src_arr(i, j, k, icomp*n_rz_comp+rzcomp);
 #else
+                    // The destination index does not depend on i: this is only
+                    // compatible with the iteration-independence requirement of
+                    // ParallelFor because in 1D the z-slice box tbx contains a
+                    // single cell in i (see issue #7097)
                     dst_arr(k_lab, j, k, n) = src_arr(i, j, k, icomp);
 #endif
                 } );

--- a/Source/Diagnostics/ReducedDiags/ChargeOnEB.cpp
+++ b/Source/Diagnostics/ReducedDiags/ChargeOnEB.cpp
@@ -160,7 +160,10 @@ void ChargeOnEB::ComputeDiags (const int step)
         const amrex::Array4<const amrex::Real> & dSy_fraction_arr = eb_area_fraction[1]->array(mfi);
         const amrex::Array4<const amrex::Real> & dSz_fraction_arr = eb_area_fraction[2]->array(mfi);
 
-        amrex::ParallelFor( box,
+        // amrex::For: iterations accumulate into the shared surface integral;
+        // in serial (non-OpenMP) builds HostDevice::Atomic::Add is a plain +=,
+        // which is unsafe under the SIMD pragma of ParallelFor (see issue #7097)
+        amrex::For( box,
             [=] AMREX_GPU_DEVICE (int i, int j, int k) {
 
                 // Only cells that are partially covered do contribute to the integral

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity.cpp
@@ -214,7 +214,11 @@ void DifferentialLuminosity::ComputeDiags (int step)
             // pair of macroparticles, it samples max(NI1,NI2) pairs
             // and scales the resulting number by multiplying by min(NI1,NI2).
             // The parallelization strategy follows: https://dl.acm.org/doi/10.1145/3732775.3733578
-            amrex::ParallelFor( n_independent_pairs, [=] AMREX_GPU_DEVICE (int i_coll) noexcept
+            // amrex::For: iterations accumulate into shared luminosity bins;
+            // in serial (non-OpenMP) builds HostDevice::Atomic::Add is a plain
+            // +=, which is unsafe under the SIMD pragma of ParallelFor
+            // (see issue #7097)
+            amrex::For( n_independent_pairs, [=] AMREX_GPU_DEVICE (int i_coll) noexcept
             {
                 // to avoid type mismatch errors
                 auto ui_coll = (index_type)i_coll;

--- a/Source/Diagnostics/ReducedDiags/DifferentialLuminosity2D.cpp
+++ b/Source/Diagnostics/ReducedDiags/DifferentialLuminosity2D.cpp
@@ -234,7 +234,11 @@ void DifferentialLuminosity2D::ComputeDiags (int step)
             // pair of macroparticles, it samples max(NI1,NI2) pairs
             // and scales the resulting number by multiplying by min(NI1,NI2).
             // The parallelization strategy follows: https://dl.acm.org/doi/10.1145/3732775.3733578
-            amrex::ParallelFor( n_independent_pairs, [=] AMREX_GPU_DEVICE (int i_coll) noexcept
+            // amrex::For: iterations accumulate into shared luminosity bins;
+            // in serial (non-OpenMP) builds HostDevice::Atomic::Add is a plain
+            // +=, which is unsafe under the SIMD pragma of ParallelFor
+            // (see issue #7097)
+            amrex::For( n_independent_pairs, [=] AMREX_GPU_DEVICE (int i_coll) noexcept
             {
                 // to avoid type mismatch errors
                 auto ui_coll = (index_type)i_coll;

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram.cpp
@@ -211,8 +211,12 @@ void ParticleHistogram::ComputeDiags (int step)
 
                 long const np = pti.numParticles();
 
-                //Flag particles that need to be copied if they cross the z_slice
-                amrex::ParallelFor(np,
+                //Flag particles that need to be copied if they cross the z_slice.
+                // amrex::For: iterations accumulate into shared histogram bins;
+                // in serial (non-OpenMP) builds HostDevice::Atomic::Add is a plain
+                // +=, which is unsafe under the SIMD pragma of ParallelFor
+                // (see issue #7097)
+                amrex::For(np,
                    [=] AMREX_GPU_DEVICE(int i)
                 {
                     amrex::ParticleReal x, y, z;

--- a/Source/Diagnostics/ReducedDiags/ParticleHistogram2D.cpp
+++ b/Source/Diagnostics/ReducedDiags/ParticleHistogram2D.cpp
@@ -207,8 +207,12 @@ void ParticleHistogram2D::ComputeDiags (int step)
 
                 long const np = pti.numParticles();
 
-                //Flag particles that need to be copied if they cross the z_slice
-                amrex::ParallelFor(np,
+                //Flag particles that need to be copied if they cross the z_slice.
+                // amrex::For: iterations accumulate into shared histogram bins;
+                // in serial (non-OpenMP) builds HostDevice::Atomic::Add is a plain
+                // +=, which is unsafe under the SIMD pragma of ParallelFor
+                // (see issue #7097)
+                amrex::For(np,
                                    [=] AMREX_GPU_DEVICE(int i)
                                    {
                                        amrex::ParticleReal x, y, z;

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
@@ -279,8 +279,10 @@ void FiniteDifferenceSolver::EvolveBCartesianECT (
             // Extract tileboxes for which to loop
             Box const &tb = mfi.tilebox(Bfield[idim]->ixType().toIntVect());
 
-            //Take care of the unstable cells
-            amrex::ParallelFor(tb, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+            //Take care of the unstable cells.
+            // amrex::For: iterations scatter-add into neighboring faces of Venl
+            // (no SIMD pragma, see issue #7097)
+            amrex::For(tb, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
 
                 if (S(i, j, k) <= 0) { return; }
 
@@ -348,7 +350,10 @@ void FiniteDifferenceSolver::EvolveBCartesianECT (
                         kp = k;
                     }
 
-                    Venl_dim(ip, jp, kp) += rho_enl * borrowing_dim_area[ind];
+                    // Atomic add: different unstable faces can borrow area from
+                    // the same intruded face, i.e., different iterations can
+                    // update the same element (a data race on GPU without the atomic)
+                    amrex::Gpu::Atomic::AddNoRet(&Venl_dim(ip, jp, kp), rho_enl * borrowing_dim_area[ind]);
 
                 }
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
@@ -350,9 +350,9 @@ void FiniteDifferenceSolver::EvolveBCartesianECT (
                         kp = k;
                     }
 
-                    // Atomic add: different unstable faces can borrow area from
-                    // the same intruded face, i.e., different iterations can
-                    // update the same element (a data race on GPU without the atomic)
+                    // Atomic because different unstable faces can borrow area
+                    // from the same intruded face, i.e., different iterations can
+                    // update the same element.
                     amrex::Gpu::Atomic::AddNoRet(&Venl_dim(ip, jp, kp), rho_enl * borrowing_dim_area[ind]);
 
                 }

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -1114,6 +1114,12 @@ void ImplicitSolver::FinishMassMatrices ()
             });
 
 #elif AMREX_SPACEDIM == 2
+            // In-place fold of the mass matrices: for every (ncomp_x, ncomp_y)
+            // combination, the components written at iv_dst are disjoint from
+            // the components read at any i-offset source, so iterations of the
+            // vectorized i loop are independent, as required by ParallelFor
+            // (see issue #7097). Reads across j rely on the serial ascending j
+            // loop on CPU and must not be reordered.
             amrex::ParallelFor( Sbx, Sby, Sbz,
 
                 [=] AMREX_GPU_DEVICE (int i, int j, int k)

--- a/Source/Fluids/WarpXFluidContainer.cpp
+++ b/Source/Fluids/WarpXFluidContainer.cpp
@@ -372,6 +372,11 @@ void WarpXFluidContainer::ApplyBcFluidsAndComms (ablastr::fields::MultiFabRegist
         //Grow the tilebox
         tile_box.grow(1);
 
+        // In-place update: iterations write only the two outermost boundary
+        // planes (domain end +/- 1) and read two cells inward (+/- 2), so the
+        // written and read index sets are disjoint and the iterations are
+        // independent, as required by ParallelFor. A +/- 1 stencil would break
+        // this and require amrex::For (see issue #7097).
         amrex::ParallelFor(tile_box,
             [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {

--- a/Source/NonlinearSolvers/MatrixPC.H
+++ b/Source/NonlinearSolvers/MatrixPC.H
@@ -394,8 +394,10 @@ int MatrixPC<T,Ops>::Assemble (const T& a_U)
 
                 auto dof_arr = dofs_mfarrvec[lev][dir]->const_array(mfi);
 
-                // Set row indices and identity diagonal (unconditional)
-                ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                // Set row indices and identity diagonal (unconditional).
+                // amrex::For: iterations share the nnz_actual overflow counter
+                // (no SIMD pragma, see issue #7097)
+                For(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
                     const int ridx_l = dof_arr(i,j,k,0);
                     if (ridx_l < 0) { return; }
@@ -445,7 +447,9 @@ int MatrixPC<T,Ops>::Assemble (const T& a_U)
                                                           dofs_mfarrvec[lev][tdir2]->const_array(mfi) ) }};
 #endif
 
-                    ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                    // amrex::For: iterations share the nnz_actual overflow counter
+                    // (no SIMD pragma, see issue #7097)
+                    For(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
                     {
                         const int ridx_l = dof_arr(i,j,k,0);
                         if (ridx_l < 0) { return; }
@@ -768,7 +772,9 @@ int MatrixPC<T,Ops>::Assemble (const T& a_U)
                         MM_width[space_dir] = (MM_ncomp[space_dir] - 1)/2;
                     }
 
-                    ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                    // amrex::For: iterations share the nnz_actual overflow counter
+                    // (no SIMD pragma, see issue #7097)
+                    For(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
                     {
                         const int ridx_l = dof_arr(i,j,k,0);
                         if (ridx_l < 0) { return; }

--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -547,7 +547,8 @@ public:
 
                 ABLASTR_PROFILE_VAR("BinaryCollision::doCollisionsWithinTile::findDensityTemperatures::atomics", prof_findDensityTemperatures_atomics);
                 // Loop over particles and compute quantities needed for energy conservation and the collsion parameters
-                amrex::ParallelFor( np1,
+                // amrex::For: iterations scatter-add into shared per-cell sums (no SIMD pragma, see issue #7097)
+                amrex::For( np1,
                     [=] AMREX_GPU_DEVICE (int ip) noexcept
                     {
                         if (correct_energy_momentum) {
@@ -720,7 +721,8 @@ public:
                 amrex::ParticleReal const energy_fraction = m_energy_fraction;
 
                 ABLASTR_PROFILE_VAR("BinaryCollision::doCollisionsWithinTile::correctEnergyMomentum", prof_correctEnergyMomentum);
-                amrex::ParallelFor( np1,
+                // amrex::For: iterations scatter-add into shared per-cell sums (no SIMD pragma, see issue #7097)
+                amrex::For( np1,
                     [=] AMREX_GPU_DEVICE (int i1) noexcept
                     {
 
@@ -737,7 +739,8 @@ public:
                     }
                 );
 
-                amrex::ParallelFor( np1,
+                // amrex::For: iterations scatter-add into shared per-cell sums (no SIMD pragma, see issue #7097)
+                amrex::For( np1,
                     [=] AMREX_GPU_DEVICE (int i1) noexcept
                     {
 
@@ -764,9 +767,10 @@ public:
                 const int energy_correction_sort_by_weight_flag = m_energy_correction_sort_by_weight ? sort : no_sort;
                 auto heapSortDecreasing = ParticleUtils::HeapSortDecreasing();
 
-                amrex::ParallelFor(amrex::TypeList<amrex::CompileTimeOptions<no_sort,sort>>{},
-                                   {energy_correction_sort_by_weight_flag},
-                                   n_cells,
+                // amrex::For: iterations share the failed-corrections counter (no SIMD pragma, see issue #7097)
+                amrex::For(amrex::TypeList<amrex::CompileTimeOptions<no_sort,sort>>{},
+                           {energy_correction_sort_by_weight_flag},
+                           n_cells,
                     [=] AMREX_GPU_DEVICE (int i_cell, auto energy_correction_sort_by_weight_control) noexcept
                     {
 
@@ -1079,7 +1083,8 @@ public:
 
                 // Loop over particles and compute quantities needed for energy conservation and the collsion parameters
                 ABLASTR_PROFILE_VAR("BinaryCollision::doCollisionsWithinTile::findDensityTemperatures::atomics", prof_findDensityTemperatures_atomics);
-                amrex::ParallelFor( std::max(np1, np2),
+                // amrex::For: iterations scatter-add into shared per-cell sums (no SIMD pragma, see issue #7097)
+                amrex::For( std::max(np1, np2),
                     [=] AMREX_GPU_DEVICE (int ip) noexcept
                     {
                         if (correct_energy_momentum) {
@@ -1328,7 +1333,8 @@ public:
                 amrex::ParticleReal const energy_fraction = m_energy_fraction;
 
                 ABLASTR_PROFILE_VAR("BinaryCollision::doCollisionsWithinTile::correctEnergyMomentum", prof_correctEnergyMomentum);
-                amrex::ParallelFor( std::max(np1, np2),
+                // amrex::For: iterations scatter-add into shared per-cell sums (no SIMD pragma, see issue #7097)
+                amrex::For( std::max(np1, np2),
                     [=] AMREX_GPU_DEVICE (int ip) noexcept
                     {
 
@@ -1399,9 +1405,10 @@ public:
                 const int energy_correction_sort_by_weight_flag = m_energy_correction_sort_by_weight ? sort : no_sort;
                 auto heapSortDecreasing = ParticleUtils::HeapSortDecreasing();
 
-                amrex::ParallelFor(amrex::TypeList<amrex::CompileTimeOptions<no_sort,sort>>{},
-                                   {energy_correction_sort_by_weight_flag},
-                                   n_cells,
+                // amrex::For: iterations share the failed-corrections counter (no SIMD pragma, see issue #7097)
+                amrex::For(amrex::TypeList<amrex::CompileTimeOptions<no_sort,sort>>{},
+                           {energy_correction_sort_by_weight_flag},
+                           n_cells,
                     [=] AMREX_GPU_DEVICE (int i_cell, auto energy_correction_sort_by_weight_control) noexcept
                     {
                         // The particles from species1 that are in the cell `i_cell` are

--- a/Source/Particles/Collision/InverseBremsstrahlung/InverseBremsstrahlung.cpp
+++ b/Source/Particles/Collision/InverseBremsstrahlung/InverseBremsstrahlung.cpp
@@ -182,8 +182,9 @@ void InverseBremsstrahlung::doInverseBremsstrahlungWithinTile (
     amrex::ParticleReal * const AMREX_RESTRICT uy_electrons = soa_electrons.m_rdata[PIdx::uy];
     amrex::ParticleReal * const AMREX_RESTRICT uz_electrons = soa_electrons.m_rdata[PIdx::uz];
 
-    // Loop over photons
-    amrex::ParallelFor(np_photons,
+    // Loop over photons.
+    // amrex::For: iterations scatter-add into shared per-cell sums (no SIMD pragma, see issue #7097)
+    amrex::For(np_photons,
         [=] AMREX_GPU_DEVICE (int ip) noexcept
         {
             const int i_cell = bins_photons_ptr[ip];
@@ -236,16 +237,18 @@ void InverseBremsstrahlung::doInverseBremsstrahlungWithinTile (
 
         });
 
-    // Need total electron weight to determine how much momentum is given to each electron
-    amrex::ParallelFor(np_electrons,
+    // Need total electron weight to determine how much momentum is given to each electron.
+    // amrex::For: iterations scatter-add into shared per-cell sums (no SIMD pragma, see issue #7097)
+    amrex::For(np_electrons,
         [=] AMREX_GPU_DEVICE (int ie) noexcept
         {
             const int i_cell = bins_electrons_ptr[ie];
             amrex::Gpu::Atomic::AddNoRet(&w_sum_electrons_in_each_cell[i_cell], w_electrons[ie]);
         });
 
-    // Distribute momentum absorbed from photons to electrons
-    amrex::ParallelFor(np_electrons,
+    // Distribute momentum absorbed from photons to electrons.
+    // amrex::For: iterations scatter-add into shared per-cell sums (no SIMD pragma, see issue #7097)
+    amrex::For(np_electrons,
         [=] AMREX_GPU_DEVICE (int ie) noexcept
         {
             const int i_cell = bins_electrons_ptr[ie];
@@ -292,8 +295,10 @@ void InverseBremsstrahlung::doInverseBremsstrahlungWithinTile (
     const amrex::ParticleReal energy_fraction = m_energy_fraction;
 
     // Distribute any remaining energy to the electrons using the pairwise
-    // operation (that does not affect the total momentum)
-    amrex::ParallelFor(n_cells,
+    // operation (that does not affect the total momentum).
+    // amrex::For: iterations share the failed-corrections counter, which gates
+    // the fallback below (no SIMD pragma, see issue #7097)
+    amrex::For(n_cells,
         [=] AMREX_GPU_DEVICE (int i_cell) noexcept
         {
 

--- a/Source/Particles/Collision/PulsedDecay/PulsedDecay.cpp
+++ b/Source/Particles/Collision/PulsedDecay/PulsedDecay.cpp
@@ -193,7 +193,8 @@ PulsedDecay::doCollisions (amrex::Real cur_time, amrex::Real dt, MultiParticleCo
             amrex::ParticleReal* AMREX_RESTRICT w1 = soa_1.m_rdata[PIdx::w];
             uint64_t* AMREX_RESTRICT idcpu1 = soa_1.m_idcpu;
 
-            amrex::ParallelFor( np1,
+            // amrex::For: iterations scatter-add into shared per-cell sums (no SIMD pragma, see issue #7097)
+            amrex::For( np1,
                 [=] AMREX_GPU_DEVICE (int ip) noexcept
                 {
                     if (idcpu1[ip] == amrex::ParticleIdCpus::Invalid) { return; }

--- a/Source/Particles/Deposition/ChargeDeposition.H
+++ b/Source/Particles/Deposition/ChargeDeposition.H
@@ -59,8 +59,11 @@ void doChargeDepositionShapeN (const GetParticlePosition<PIdx>& GetPosition,
     constexpr int NODE = amrex::IndexType::NODE;
     constexpr int CELL = amrex::IndexType::CELL;
 
-    // Loop over particles and deposit into rho_fab
-    amrex::ParallelFor(
+    // Loop over particles and deposit into rho_fab.
+    // amrex::For instead of amrex::ParallelFor: iterations are not independent
+    // (particles scatter-add into shared rho nodes), so the CPU SIMD pragma of
+    // ParallelFor must not be used here (see issue #7097).
+    amrex::For(
             np_to_deposit,
             [=] AMREX_GPU_DEVICE (long ip) {
             // --- Get particle quantities
@@ -265,7 +268,8 @@ void doChargeDepositionSharedShapeN (const GetParticlePosition<PIdx>& GetPositio
                   nblocks, threads_per_block, shared_mem_bytes, amrex::Gpu::gpuStream(),
                   [=] AMREX_GPU_DEVICE () noexcept
 #else // defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)
-    amrex::ParallelFor(np_to_deposit, [=] AMREX_GPU_DEVICE (long ip_orig) noexcept
+    // amrex::For: iterations scatter-add into shared rho nodes (no SIMD pragma, see issue #7097)
+    amrex::For(np_to_deposit, [=] AMREX_GPU_DEVICE (long ip_orig) noexcept
 #endif
       {
 #if defined(AMREX_USE_CUDA) || defined(AMREX_USE_HIP)

--- a/Source/Particles/Deposition/CurrentDeposition.H
+++ b/Source/Particles/Deposition/CurrentDeposition.H
@@ -330,8 +330,9 @@ void doDepositionShapeN (const GetParticlePosition<PIdx>& GetPosition,
     amrex::IntVect const jy_type = jy_fab.box().type();
     amrex::IntVect const jz_type = jz_fab.box().type();
 
-    // Loop over particles and deposit into jx_fab, jy_fab and jz_fab
-    amrex::ParallelFor(
+    // Loop over particles and deposit into jx_fab, jy_fab and jz_fab.
+    // amrex::For: iterations scatter-add into shared J nodes (no SIMD pragma, see issue #7097)
+    amrex::For(
         np_to_deposit,
         [=] AMREX_GPU_DEVICE (long ip) {
             amrex::ParticleReal xp, yp, zp;
@@ -415,8 +416,9 @@ void doDepositionShapeNImplicit(const GetParticlePosition<PIdx>& GetPosition,
     amrex::IntVect const jy_type = jy_fab.box().type();
     amrex::IntVect const jz_type = jz_fab.box().type();
 
-    // Loop over particles and deposit into jx_fab, jy_fab and jz_fab
-    amrex::ParallelFor(
+    // Loop over particles and deposit into jx_fab, jy_fab and jz_fab.
+    // amrex::For: iterations scatter-add into shared J nodes (no SIMD pragma, see issue #7097)
+    amrex::For(
             np_to_deposit,
             [=] AMREX_GPU_DEVICE (long ip) {
             amrex::ParticleReal xp, yp, zp;
@@ -721,7 +723,8 @@ void doEsirkepovDepositionShapeN (const GetParticlePosition<PIdx>& GetPosition,
     enum eb_flags : int { has_reduced_shape, no_reduced_shape };
     const int reduce_shape_runtime_flag = (enable_reduced_shape && (depos_order>1))? has_reduced_shape : no_reduced_shape;
 
-    amrex::ParallelFor( TypeList<CompileTimeOptions<has_reduced_shape,no_reduced_shape>>{},
+    // amrex::For: iterations scatter-add into shared J nodes (no SIMD pragma, see issue #7097)
+    amrex::For( TypeList<CompileTimeOptions<has_reduced_shape,no_reduced_shape>>{},
         {reduce_shape_runtime_flag},
         np_to_deposit, [=] AMREX_GPU_DEVICE (long ip, auto reduce_shape_control) {
             // --- Get particle quantities
@@ -1158,8 +1161,9 @@ void doChargeConservingDepositionShapeNImplicit ([[maybe_unused]]const amrex::Pa
     Real constexpr one_sixth = 1.0_rt / 6.0_rt;
 #endif
 
-    // Loop over particles and deposit into Jx_arr, Jy_arr and Jz_arr
-    amrex::ParallelFor(
+    // Loop over particles and deposit into Jx_arr, Jy_arr and Jz_arr.
+    // amrex::For: iterations scatter-add into shared J nodes (no SIMD pragma, see issue #7097)
+    amrex::For(
         np_to_deposit,
         [=] AMREX_GPU_DEVICE (long const ip) {
 
@@ -2214,8 +2218,9 @@ void doVillasenorDepositionShapeNExplicit (const GetParticlePosition<PIdx>& GetP
 
     const amrex::Real invvol = dinv.x*dinv.y*dinv.z;
 
-    // Loop over particles and deposit into Jx_arr, Jy_arr and Jz_arr
-    amrex::ParallelFor(
+    // Loop over particles and deposit into Jx_arr, Jy_arr and Jz_arr.
+    // amrex::For: iterations scatter-add into shared J nodes (no SIMD pragma, see issue #7097)
+    amrex::For(
         np_to_deposit,
         [=] AMREX_GPU_DEVICE (long const ip) {
 
@@ -2311,8 +2316,9 @@ void doVillasenorDepositionShapeNImplicit ([[maybe_unused]]const amrex::Particle
 
     const amrex::Real invvol = dinv.x*dinv.y*dinv.z;
 
-    // Loop over particles and deposit into Jx_arr, Jy_arr and Jz_arr
-    amrex::ParallelFor(
+    // Loop over particles and deposit into Jx_arr, Jy_arr and Jz_arr.
+    // amrex::For: iterations scatter-add into shared J nodes (no SIMD pragma, see issue #7097)
+    amrex::For(
         np_to_deposit,
         [=] AMREX_GPU_DEVICE (long const ip) {
 
@@ -2443,8 +2449,9 @@ void doVayDepositionShapeN (const GetParticlePosition<PIdx>& GetPosition,
     amrex::Array4<amrex::Real> const& Dy_arr = Dy_fab.array();
     amrex::Array4<amrex::Real> const& Dz_arr = Dz_fab.array();
 
-    // Loop over particles and deposit (Dx,Dy,Dz) into Dx_fab, Dy_fab and Dz_fab
-    amrex::ParallelFor(np_to_deposit, [=] AMREX_GPU_DEVICE (long ip)
+    // Loop over particles and deposit (Dx,Dy,Dz) into Dx_fab, Dy_fab and Dz_fab.
+    // amrex::For: iterations scatter-add into shared nodes (no SIMD pragma, see issue #7097)
+    amrex::For(np_to_deposit, [=] AMREX_GPU_DEVICE (long ip)
     {
         // Inverse of Lorentz factor gamma
         const amrex::Real invgam = 1._rt / std::sqrt(1._rt + uxp[ip] * uxp[ip] * PhysConst::inv_c2

--- a/Source/Particles/Deposition/MassMatricesDeposition.H
+++ b/Source/Particles/Deposition/MassMatricesDeposition.H
@@ -642,8 +642,9 @@ void doDirectSigmaDeposition (const GetParticlePosition<PIdx>& GetPosition,
     enum exteb_flags : int { no_exteb, has_exteb };
     const int exteb_runtime_flag = getExternalEB.isNoOp() ? no_exteb : has_exteb;
 
-    // Loop over particles and deposit mass matrices
-    amrex::ParallelFor(
+    // Loop over particles and deposit mass matrices.
+    // amrex::For: iterations scatter-add into shared J/Sigma nodes (no SIMD pragma, see issue #7097)
+    amrex::For(
         amrex::TypeList<amrex::CompileTimeOptions<no_exteb, has_exteb>>{},
         {exteb_runtime_flag},
         np_to_deposit,
@@ -1882,8 +1883,9 @@ void doVillasenorSigmaDeposition ([[maybe_unused]] const amrex::ParticleReal* xp
     enum exteb_flags : int { no_exteb, has_exteb };
     const int exteb_runtime_flag = getExternalEB.isNoOp() ? no_exteb : has_exteb;
 
-    // Loop over particles and deposit mass matrices
-    amrex::ParallelFor(
+    // Loop over particles and deposit mass matrices.
+    // amrex::For: iterations scatter-add into shared J/Sigma nodes (no SIMD pragma, see issue #7097)
+    amrex::For(
         amrex::TypeList<amrex::CompileTimeOptions<no_exteb, has_exteb>>{},
         {exteb_runtime_flag},
         np_to_deposit,

--- a/Source/Particles/Deposition/TemperatureDeposition.H
+++ b/Source/Particles/Deposition/TemperatureDeposition.H
@@ -480,8 +480,9 @@ void doVarianceDepositionShapeN (const GetParticlePosition<PIdx>& GetPosition,
     const amrex::IntVect & vary_type = vary_fab.box().type();
     const amrex::IntVect & varz_type = varz_fab.box().type();
 
-    // Loop over particles and deposit into the deposition buffers
-    amrex::ParallelFor(
+    // Loop over particles and deposit into the deposition buffers.
+    // amrex::For: iterations scatter-add into shared cells (no SIMD pragma, see issue #7097)
+    amrex::For(
         np_to_deposit,
         [=] AMREX_GPU_DEVICE (long ip) {
             amrex::ParticleReal xp, yp, zp;

--- a/Source/Particles/Pusher/ImplicitPushPX.cpp
+++ b/Source/Particles/Pusher/ImplicitPushPX.cpp
@@ -44,6 +44,7 @@
 #include <AMReX_ParticleContainerBase.H>
 #include <AMReX_AmrParticles.H>
 #include <AMReX_ParticleTile.H>
+#include <AMReX_Reduce.H>
 #include <AMReX_Scan.H>
 #include <AMReX_Utility.H>
 
@@ -279,26 +280,21 @@ PhysicalParticleContainer::FindSuborbitParticles (WarpXParIter & pti,
     // If no particles, do not do anything
     if (np_to_push == 0) { return; }
 
-    amrex::Gpu::Buffer<amrex::Long> unconverged_particles({0});
-    amrex::Long* unconverged_particles_ptr = unconverged_particles.data();
     int *nsuborbits = (HasiAttrib("nsuborbits") ? pti.GetiAttribs("nsuborbits").dataPtr() + offset : nullptr);
 
-    amrex::ParallelFor(
-        np_to_push, [=] AMREX_GPU_DEVICE (long ip)
+    // Count how many particles did not converge.
+    // A proper reduction is used here: a shared counter updated with
+    // Gpu::Atomic::Add inside a ParallelFor is not thread/SIMD safe on CPU
+    // (see issue #7097).
+    num_unconverged_particles = amrex::Reduce::Sum<amrex::Long>(
+        np_to_push, [=] AMREX_GPU_DEVICE (long ip) -> amrex::Long
     {
-
-        if (nsuborbits && nsuborbits[ip] > 1) {
-            // write signaling flag: how many particles did not converge?
-            amrex::Gpu::Atomic::Add(unconverged_particles_ptr, amrex::Long(1));
-            return;
-        }
-
+        return (nsuborbits && nsuborbits[ip] > 1) ? 1 : 0;
     });
 
     // Setup for handling the suborbit particles. A list of their indices is
     // gathered, their weights saved, and their weight set to zero (so they
     // don't contribute to the current density).
-    num_unconverged_particles = *(unconverged_particles.copyToHost());
     SetupSuborbitParticles(pti, offset, np_to_push, num_unconverged_particles,
                            unconverged_indices, saved_weights);
 
@@ -556,14 +552,16 @@ PhysicalParticleContainer::ImplicitPushXP (WarpXParIter & pti,
     amrex::Long* unconverged_particles_ptr = unconverged_particles.data();
     int *nsuborbits = (HasiAttrib("nsuborbits") ? pti.GetiAttribs("nsuborbits").dataPtr() + offset: nullptr);
 
-    // Using this version of ParallelFor with compile time options
+    // Using this version of For with compile time options
     // improves performance when qed or external EB are not used by reducing
     // register pressure.
-    amrex::ParallelFor(amrex::TypeList<amrex::CompileTimeOptions<no_exteb,has_exteb>,
-                                       amrex::CompileTimeOptions<no_qed  ,has_qed>>{},
-                       {exteb_runtime_flag, qed_runtime_flag},
-                       np_to_push, [=] AMREX_GPU_DEVICE (long ip, auto exteb_control,
-                                                         auto qed_control)
+    // amrex::For: iterations share the unconverged-particles counter
+    // (no SIMD pragma, see issue #7097)
+    amrex::For(amrex::TypeList<amrex::CompileTimeOptions<no_exteb,has_exteb>,
+                               amrex::CompileTimeOptions<no_qed  ,has_qed>>{},
+               {exteb_runtime_flag, qed_runtime_flag},
+               np_to_push, [=] AMREX_GPU_DEVICE (long ip, auto exteb_control,
+                                                 auto qed_control)
     {
 
         // Skip any particles that require suborbits
@@ -916,14 +914,16 @@ PhysicalParticleContainer::ImplicitPushXPSubOrbits (WarpXParIter& pti,
     long * unconverged_i = unconverged_indices.data() + index_offset;
     amrex::ParticleReal * saved_w = saved_weights.data() + index_offset;
 
-    // Using this version of ParallelFor with compile time options
+    // Using this version of For with compile time options
     // improves performance when qed or external EB are not used by reducing
     // register pressure.
-    amrex::ParallelFor(amrex::TypeList<amrex::CompileTimeOptions<no_exteb,has_exteb>,
-                                       amrex::CompileTimeOptions<no_qed  ,has_qed>,
-                                       amrex::CompileTimeOptions<order_one, order_two, order_three, order_four >>{},
-                       {exteb_runtime_flag, qed_runtime_flag, depos_order_flag},
-                       num_unconverged_particles, [=] AMREX_GPU_DEVICE (long i,
+    // amrex::For: iterations scatter-add into shared J/Sigma nodes
+    // (no SIMD pragma, see issue #7097)
+    amrex::For(amrex::TypeList<amrex::CompileTimeOptions<no_exteb,has_exteb>,
+                               amrex::CompileTimeOptions<no_qed  ,has_qed>,
+                               amrex::CompileTimeOptions<order_one, order_two, order_three, order_four >>{},
+               {exteb_runtime_flag, qed_runtime_flag, depos_order_flag},
+               num_unconverged_particles, [=] AMREX_GPU_DEVICE (long i,
                                                                  auto exteb_control, auto qed_control, auto depos_order_control)
     {
 

--- a/Source/Particles/Pusher/ImplicitPushPX.cpp
+++ b/Source/Particles/Pusher/ImplicitPushPX.cpp
@@ -283,9 +283,6 @@ PhysicalParticleContainer::FindSuborbitParticles (WarpXParIter & pti,
     int *nsuborbits = (HasiAttrib("nsuborbits") ? pti.GetiAttribs("nsuborbits").dataPtr() + offset : nullptr);
 
     // Count how many particles did not converge.
-    // A proper reduction is used here: a shared counter updated with
-    // Gpu::Atomic::Add inside a ParallelFor is not thread/SIMD safe on CPU
-    // (see issue #7097).
     num_unconverged_particles = amrex::Reduce::Sum<amrex::Long>(
         np_to_push, [=] AMREX_GPU_DEVICE (long ip) -> amrex::Long
     {

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2000,7 +2000,8 @@ WarpXParticleContainer::DepositTotalNGPTemperature (int lev)
         amrex::Array4<amrex::Real> const& uy_array = uy_mf.array(pti);
         amrex::Array4<amrex::Real> const& uz_array = uz_mf.array(pti);
 
-        amrex::ParallelFor(np,
+        // amrex::For: iterations scatter-add into shared cells (no SIMD pragma, see issue #7097)
+        amrex::For(np,
             [=] AMREX_GPU_DEVICE (long ip) {
                 // Get position in AMReX convention to calculate corresponding index.
                 const auto p = WarpXParticleContainer::ParticleType(ptd, ip);
@@ -2058,7 +2059,8 @@ WarpXParticleContainer::DepositTotalNGPTemperature (int lev)
         amrex::Array4<amrex::Real> const& uz_array = uz_mf.array(pti);
         amrex::Array4<amrex::Real> const& temp_array = temperature.array(pti);
 
-        amrex::ParallelFor(np,
+        // amrex::For: iterations scatter-add into shared cells (no SIMD pragma, see issue #7097)
+        amrex::For(np,
             [=] AMREX_GPU_DEVICE (long ip) {
                 // Get position in AMReX convention to calculate corresponding index.
                 const auto p = WarpXParticleContainer::ParticleType(ptd, ip);

--- a/Source/Utils/WarpXMovingWindow.cpp
+++ b/Source/Utils/WarpXMovingWindow.cpp
@@ -92,6 +92,10 @@ namespace
 
         AMREX_ALWAYS_ASSERT(ng[dir] >= std::abs(num_shift));
 
+        // The temporary copy is required for correctness (not just convenience):
+        // the shifted copy below reads from tmpmf while writing to mf, both under
+        // AMREX_PARALLEL_FOR_4D whose CPU SIMD pragma asserts iteration
+        // independence. An in-place shift of mf would violate that (see issue #7097).
         amrex::MultiFab tmpmf(ba, dm, nc, ng);
         amrex::MultiFab::Copy(tmpmf, mf, 0, 0, nc, ng);
 


### PR DESCRIPTION
Fix #7097: on CPU builds (`-DWarpX_COMPUTE=[NOACC,OMP])` modern compilers will try to auto-vectorize in `amrex::ParallelFor`. This causes issues if the operations per index are not truly independent. `amrex::For` ([docs](https://amrex-codes.github.io/amrex/docs_html/GPU.html?highlight=simd#launching-c-nested-loops)) is used in that case, keeping CPU instructions scalar with no false promise to the compiler, and GPU kernels identical.

First seen by @RemiLehe for deposition kernels under GCC 15+.

- [x] depends on https://github.com/AMReX-Codes/amrex/pull/5581 via #7098

List of fixes:
  - Fix invalid `ParallelFor` in **particle deposition kernels**.
  Error if vectorized: SIMD lanes depositing into the same
  grid node keep only one lane's `+=`, so charge/current/temperature are
  under-deposited — the observed "rho 4× too small" failure — and an
  undercounted suborbit counter trips the `num_flagged == num_unconverged_particles` assert or drops particles.
  - Fix invalid `ParallelFor` in **collision modules**.
    Error: undercounted per-cell density/temperature sums bias the Coulomb log and collision rates (unconditionally, for Coulomb/Bremsstrahlung); a wrong electron-weight divisor mis-distributes absorbed momentum; a zeroed `failed_corrections` counter silently skips the required fallback; `PulsedDecay` creates too few decay products.
  - Fix invalid `ParallelFor` in **ECT solver and MatrixPC**.
    Error: lost updates on borrowed-area contributions corrupt `Venl` and hence `B` in cut cells (plus the neighbor += was a GPU race — now `Gpu::Atomic::AddNoRet`); a lost `Gpu::Atomic::Max` lets `MatrixPC::Update` exit with a silently truncated preconditioner matrix.
  - Fix invalid `ParallelFor` in **binned reduced diagnostics**.
    Error (NOACC builds only): undercounted _histogram bins_, an undercounted `ChargeOnEB` _surface integral_ (a scalar reduction, the easiest pattern for a vectorizer to break), and permanently corrupted _differential luminosity_ since it accumulates across steps.
  - Document SIMD-safety constraints of in-place kernels (moving window, fluid BCs, BTD 1D branch, implicit mass-matrix fold). No functional change — records why each is currently legal and what edit would break it.
  - Updated developer-facing documentation to advertise `amrex::For` and `amrex::ParallelFor` equally and with validity range.

Typing assisted by Claude (Fabel 5).
