### PR TITLE
Fix docstring typo in ElectrostaticSolver's computeB

### DIFF
--- a/Source/FieldSolver/ElectrostaticSolvers/ElectrostaticSolver.H
+++ b/Source/FieldSolver/ElectrostaticSolvers/ElectrostaticSolver.H
@@ -129,7 +129,7 @@ public:
      *\f]
      *(this represents the term \f$\vec{\nabla} \times \vec{A}\f$, in the case of a moving source)
      *
-     *\param[inout] B Electric field on the grid
+     *\param[inout] B Magnetic field on the grid
      *\param[in] phi The potential from which to compute the electric field
      *\param[in] beta Represents the velocity of the source of `phi`
      */


### PR DESCRIPTION
Fix typo in the docstring of the `computeB` method of the `ElectrostaticSolver` class.