### PR TITLE
picmi: actually select the preconditioner passed to NewtonNonlinearSolver

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -1747,7 +1747,9 @@ class CurlCurlMLMGPreconditioner(PreconditionerBase):
         self.relative_tolerance = relative_tolerance
         self.absolute_tolerance = absolute_tolerance
 
-    def preconditioner_type_initialize_inputs(self):
+    def preconditioner_type_initialize_inputs(self, jacobian=None):
+        if jacobian is not None:
+            jacobian.pc_type = "pc_curl_curl_mlmg"
         pc_curl_curl_mlmg = pywarpx.warpx.get_bucket("pc_curl_curl_mlmg")
         pc_curl_curl_mlmg.verbose = self.verbose
         pc_curl_curl_mlmg.bottom_verbose = self.bottom_verbose
@@ -1790,7 +1792,9 @@ class JacobiPreconditioner(PreconditionerBase):
         self.relative_tolerance = relative_tolerance
         self.absolute_tolerance = absolute_tolerance
 
-    def preconditioner_type_initialize_inputs(self):
+    def preconditioner_type_initialize_inputs(self, jacobian=None):
+        if jacobian is not None:
+            jacobian.pc_type = "pc_jacobi"
         pc_jacobi = pywarpx.warpx.get_bucket("pc_jacobi")
         pc_jacobi.verbose = self.verbose
         pc_jacobi.max_iter = self.max_iter
@@ -1839,7 +1843,9 @@ class PETScPreconditioner(PreconditionerBase):
         self.hypre_type = hypre_type
         self.euclid_factor_levels = euclid_factor_levels
 
-    def preconditioner_type_initialize_inputs(self):
+    def preconditioner_type_initialize_inputs(self, jacobian=None):
+        if jacobian is not None:
+            jacobian.pc_type = "pc_petsc"
         pc_petsc = pywarpx.warpx.get_bucket("pc_petsc")
         pc_petsc.type = self.type
         pc_petsc.asm_overlap = self.asm_overlap
@@ -1981,7 +1987,8 @@ class NewtonNonlinearSolver(NonlinearSolverBase):
             self.linear_solver.linear_solver_initialize_inputs(newton)
 
         if self.pc_type is not None:
-            self.pc_type.preconditioner_type_initialize_inputs()
+            jacobian = pywarpx.warpx.get_bucket("jacobian")
+            self.pc_type.preconditioner_type_initialize_inputs(jacobian)
 
 
 class PicardNonlinearSolver(NonlinearSolverBase):


### PR DESCRIPTION
## Bug

`NewtonNonlinearSolver(pc_type=...)` accepts a `CurlCurlMLMGPreconditioner`, `JacobiPreconditioner`, or `PETScPreconditioner` instance, and each class's `preconditioner_type_initialize_inputs` writes its parameter block (`pc_curl_curl_mlmg.*`, `pc_jacobi.*`, `pc_petsc.*`) — but nothing ever writes the **`jacobian.pc_type` selector** that `NewtonSolver` actually reads (`ParmParse pp_jac("jacobian"); pp_jac.query("pc_type", ...)`).

As a result, any picmi-driven implicit deck that requests a preconditioner silently runs **without one**: the solver banner reports `Preconditioner type: none` while the `pc_*` parameter blocks sit unread. The native-input implicit tests (`Examples/Tests/implicit/inputs_test_2d_curl_curl_petsc_pc`, etc.) set `jacobian.pc_type` directly and are unaffected, which is why CI never caught it.

## Fix

The solver class hands the `jacobian` parameter group to the preconditioner during input initialization, and each preconditioner writes its selector through it — mirroring how `linear_solver_initialize_inputs(nonlinear_solver)` receives the nonlinear-solver group and writes `newton.linear_solver`:

```python
# NewtonNonlinearSolver.nonlinear_solver_initialize_inputs
if self.pc_type is not None:
    jacobian = pywarpx.warpx.get_bucket("jacobian")
    self.pc_type.preconditioner_type_initialize_inputs(jacobian)

# each preconditioner class
def preconditioner_type_initialize_inputs(self, jacobian=None):
    if jacobian is not None:
        jacobian.pc_type = "pc_jacobi"   # / pc_curl_curl_mlmg / pc_petsc
    ...
```

The selector strings match the `PreconditionerType` AMREX_ENUM names used as the ParmParse prefixes.

## Validation

Verified end-to-end on a theta-implicit deck driven through picmi: with the fix, `warpx_used_inputs` contains `jacobian.pc_type = "pc_jacobi"` and the solver banner reports the preconditioner (and the Newton/GMRES iteration counts drop accordingly); before the fix both showed `none` with the identical deck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyFeNNpr5jir3ygSakbZCm