### PR TITLE
Python: Improved `Config`

### DIFF
--- a/Source/Python/CMakeLists.txt
+++ b/Source/Python/CMakeLists.txt
@@ -13,6 +13,7 @@ foreach(D IN LISTS WarpX_DIMS)
         target_sources(pyWarpX_${SD}
           PRIVATE
             # pybind11
+            Config.cpp
             MultiFabRegister.cpp
             WarpX.cpp
         )

--- a/Source/Python/Config.cpp
+++ b/Source/Python/Config.cpp
@@ -5,6 +5,9 @@
  */
 #include "pyWarpX.H"
 
+#include <WarpX.H>
+
+#include <AMReX.H>
 #include <AMReX_SIMD.H>
 
 #ifdef WARPX_USE_OPENPMD
@@ -86,6 +89,7 @@ void init_Config (py::module& m)
 
     std::shared_ptr<ConfigMap const> const config = std::make_shared<ConfigMap>(
         ConfigMap{
+            {"amrex_version", amrex::Version()},
             {"gpu_backend", gpu_backend},
             {"have_fft",
 #ifdef WARPX_USE_FFT
@@ -151,9 +155,26 @@ void init_Config (py::module& m)
 #endif
             },
             {"simd_size",
-                static_cast<int>(amrex::simd::native_simd_size_particlereal)}
+                static_cast<int>(amrex::simd::native_simd_size_particlereal)},
+            {"warpx_version", WarpX::Version()}
         }
     );
+
+    std::map<std::string, char const *> const doc = {
+        {"amrex_version", "AMReX library version used to build WarpX"},
+        {"gpu_backend", "GPU backend ('CUDA', 'HIP' or 'SYCL'), None without GPU support"},
+        {"have_fft", "Build supports FFT-based (spectral) solvers and features"},
+        {"have_gpu", "Build supports GPUs"},
+        {"have_mpi", "Build supports MPI"},
+        {"have_omp", "Build supports OpenMP"},
+        {"have_openpmd", "Build supports openPMD I/O"},
+        {"have_simd", "Build supports explicit SIMD vectorization"},
+        {"openpmd_backends", "Available openPMD-api backends and if they are enabled"},
+        {"precision", "Floating point precision of amrex::Real ('SINGLE' or 'DOUBLE')"},
+        {"precision_particles", "Floating point precision of amrex::ParticleReal ('SINGLE' or 'DOUBLE')"},
+        {"simd_size", "Number of amrex::ParticleReal elements in a native SIMD vector"},
+        {"warpx_version", "WarpX version"}
+    };
 
     // create a custom metaclass deriving from pybind11's metaclass, so that
     // repr(Config) prints the full build configuration in interactive use
@@ -181,7 +202,8 @@ void init_Config (py::module& m)
             entry.first.c_str(),
             [config, name = entry.first](py::object const &) {
                 return config->at(name);
-            }
+            },
+            doc.at(entry.first)
         );
     }
     pyWarpXConfig.def_static(

--- a/Source/Python/Config.cpp
+++ b/Source/Python/Config.cpp
@@ -97,9 +97,11 @@ void init_Config (py::module& m)
             {"amrex_version", {
                 amrex::Version(),
                 "AMReX library version used to build WarpX"}},
+
             {"gpu_backend", {
                 gpu_backend,
                 "GPU backend ('CUDA', 'HIP' or 'SYCL'), None without GPU support"}},
+
             {"have_fft", {
 #ifdef WARPX_USE_FFT
                 true,
@@ -107,6 +109,7 @@ void init_Config (py::module& m)
                 false,
 #endif
                 "Build supports FFT-based (spectral) solvers and features"}},
+
             {"have_gpu", {
 #ifdef AMREX_USE_GPU
                 true,
@@ -114,6 +117,7 @@ void init_Config (py::module& m)
                 false,
 #endif
                 "Build supports GPUs"}},
+
             {"have_mpi", {
 #ifdef AMREX_USE_MPI
                 true,
@@ -121,6 +125,7 @@ void init_Config (py::module& m)
                 false,
 #endif
                 "Build supports MPI"}},
+
             {"have_omp", {
 #ifdef AMREX_USE_OMP
                 true,
@@ -128,6 +133,7 @@ void init_Config (py::module& m)
                 false,
 #endif
                 "Build supports OpenMP"}},
+
             {"have_openpmd", {
 #ifdef WARPX_USE_OPENPMD
                 true,
@@ -135,6 +141,7 @@ void init_Config (py::module& m)
                 false,
 #endif
                 "Build supports openPMD I/O"}},
+
             {"have_simd", {
 #ifdef AMREX_USE_SIMD
                 true,
@@ -142,6 +149,7 @@ void init_Config (py::module& m)
                 false,
 #endif
                 "Build supports explicit SIMD vectorization"}},
+
             {"openpmd_backends", {
 #ifdef WARPX_USE_OPENPMD
                 openPMD::getVariants(),
@@ -149,6 +157,7 @@ void init_Config (py::module& m)
                 std::map<std::string, bool>{},
 #endif
                 "Available openPMD-api backends and if they are enabled"}},
+
             {"precision", {
 #ifdef AMREX_USE_FLOAT
                 std::string{"SINGLE"},
@@ -156,6 +165,7 @@ void init_Config (py::module& m)
                 std::string{"DOUBLE"},
 #endif
                 "Floating point precision of amrex::Real ('SINGLE' or 'DOUBLE')"}},
+
             {"precision_particles", {
 #ifdef AMREX_SINGLE_PRECISION_PARTICLES
                 std::string{"SINGLE"},
@@ -163,9 +173,11 @@ void init_Config (py::module& m)
                 std::string{"DOUBLE"},
 #endif
                 "Floating point precision of amrex::ParticleReal ('SINGLE' or 'DOUBLE')"}},
+
             {"simd_size", {
                 static_cast<int>(amrex::simd::native_simd_size_particlereal),
                 "Number of amrex::ParticleReal elements in a native SIMD vector"}},
+
             {"warpx_version", {
                 WarpX::Version(),
                 "WarpX version"}}
@@ -192,8 +204,10 @@ void init_Config (py::module& m)
     py::class_<warpx::Config> pyWarpXConfig(
         m, "Config", py::metaclass(config_metaclass)
     );
-    for (auto const & [name, entry] : *config)
+    for (auto const & kv : *config)
     {
+        std::string const & name = kv.first;
+        ConfigEntry const & entry = kv.second;
         pyWarpXConfig.def_property_readonly_static(
             name.c_str(),
             [config, name](py::object const &) {

--- a/Source/Python/Config.cpp
+++ b/Source/Python/Config.cpp
@@ -1,0 +1,194 @@
+/* Copyright 2026 The WarpX Community
+ *
+ * Authors: Axel Huebl
+ * License: BSD-3-Clause-LBNL
+ */
+#include "pyWarpX.H"
+
+#include <AMReX_SIMD.H>
+
+#ifdef WARPX_USE_OPENPMD
+#   include <openPMD/version.hpp>
+#endif
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <variant>
+
+
+namespace warpx {
+    struct Config {};
+}
+
+namespace
+{
+    using ConfigValue = std::variant<
+        bool,
+        int,
+        std::string,
+        std::map<std::string, bool>,
+        std::optional<std::string>
+    >;
+    using ConfigMap = std::map<std::string, ConfigValue>;
+
+    std::string config_repr (std::string const & module_name, ConfigMap const & config)
+    {
+        std::size_t name_width = 0;
+        for (auto const & entry : config)
+        {
+            if (entry.first.size() > name_width)
+            {
+                name_width = entry.first.size();
+            }
+        }
+
+        std::string repr = module_name + ".Config:";
+        for (auto const & [name, value] : config)
+        {
+            repr += "\n    " + name;
+            repr.append(name_width - name.size(), ' ');
+            repr += " = ";
+            if (name == "openpmd_backends")
+            {
+                // show only the enabled backends
+                py::list enabled_backends;
+                auto const & backends = std::get<std::map<std::string, bool>>(value);
+                for (auto const & [backend, enabled] : backends)
+                {
+                    if (enabled)
+                    {
+                        enabled_backends.append(backend);
+                    }
+                }
+                repr += py::repr(enabled_backends).cast<std::string>();
+            }
+            else
+            {
+                repr += py::repr(py::cast(value)).cast<std::string>();
+            }
+        }
+        return repr;
+    }
+}
+
+void init_Config (py::module& m)
+{
+    std::optional<std::string> gpu_backend;
+#ifdef AMREX_USE_CUDA
+    gpu_backend = "CUDA";
+#elif defined(AMREX_USE_HIP)
+    gpu_backend = "HIP";
+#elif defined(AMREX_USE_DPCPP)
+    gpu_backend = "SYCL";
+#endif
+
+    std::shared_ptr<ConfigMap const> const config = std::make_shared<ConfigMap>(
+        ConfigMap{
+            {"gpu_backend", gpu_backend},
+            {"have_fft",
+#ifdef WARPX_USE_FFT
+                true
+#else
+                false
+#endif
+            },
+            {"have_gpu",
+#ifdef AMREX_USE_GPU
+                true
+#else
+                false
+#endif
+            },
+            {"have_mpi",
+#ifdef AMREX_USE_MPI
+                true
+#else
+                false
+#endif
+            },
+            {"have_omp",
+#ifdef AMREX_USE_OMP
+                true
+#else
+                false
+#endif
+            },
+            {"have_openpmd",
+#ifdef WARPX_USE_OPENPMD
+                true
+#else
+                false
+#endif
+            },
+            {"have_simd",
+#ifdef AMREX_USE_SIMD
+                true
+#else
+                false
+#endif
+            },
+            {"openpmd_backends",
+#ifdef WARPX_USE_OPENPMD
+                openPMD::getVariants()
+#else
+                std::map<std::string, bool>{}
+#endif
+            },
+            {"precision",
+#ifdef AMREX_USE_FLOAT
+                std::string{"SINGLE"}
+#else
+                std::string{"DOUBLE"}
+#endif
+            },
+            {"precision_particles",
+#ifdef AMREX_SINGLE_PRECISION_PARTICLES
+                std::string{"SINGLE"}
+#else
+                std::string{"DOUBLE"}
+#endif
+            },
+            {"simd_size",
+                static_cast<int>(amrex::simd::native_simd_size_particlereal)}
+        }
+    );
+
+    // create a custom metaclass deriving from pybind11's metaclass, so that
+    // repr(Config) prints the full build configuration in interactive use
+    py::dict config_metaclass_namespace;
+    config_metaclass_namespace["__module__"] = m.attr("__name__");
+    config_metaclass_namespace["__repr__"] = py::cpp_function(
+        [config, module_name = py::cast<std::string>(m.attr("__name__"))]() {
+            return config_repr(module_name, *config);
+        }
+    );
+    py::object const warpx_class = m.attr("WarpX");
+    py::object const pybind11_metaclass = py::type::of(warpx_class);
+    py::object const config_metaclass = py::type::of(pybind11_metaclass)(
+        "ConfigMeta",
+        py::make_tuple(pybind11_metaclass),
+        config_metaclass_namespace
+    );
+
+    py::class_<warpx::Config> pyWarpXConfig(
+        m, "Config", py::metaclass(config_metaclass)
+    );
+    for (auto const & entry : *config)
+    {
+        pyWarpXConfig.def_property_readonly_static(
+            entry.first.c_str(),
+            [config, name = entry.first](py::object const &) {
+                return config->at(name);
+            }
+        );
+    }
+    pyWarpXConfig.def_static(
+        "to_dict",
+        [config]() {
+            return *config;
+        },
+        "Return the WarpX build configuration as a dictionary."
+    );
+}

--- a/Source/Python/Config.cpp
+++ b/Source/Python/Config.cpp
@@ -34,7 +34,12 @@ namespace
         std::map<std::string, bool>,
         std::optional<std::string>
     >;
-    using ConfigMap = std::map<std::string, ConfigValue>;
+    struct ConfigEntry
+    {
+        ConfigValue value;
+        char const * doc;
+    };
+    using ConfigMap = std::map<std::string, ConfigEntry>;
 
     std::string config_repr (std::string const & module_name, ConfigMap const & config)
     {
@@ -48,7 +53,7 @@ namespace
         }
 
         std::string repr = module_name + ".Config:";
-        for (auto const & [name, value] : config)
+        for (auto const & [name, entry] : config)
         {
             repr += "\n    " + name;
             repr.append(name_width - name.size(), ' ');
@@ -57,7 +62,7 @@ namespace
             {
                 // show only the enabled backends
                 py::list enabled_backends;
-                auto const & backends = std::get<std::map<std::string, bool>>(value);
+                auto const & backends = std::get<std::map<std::string, bool>>(entry.value);
                 for (auto const & [backend, enabled] : backends)
                 {
                     if (enabled)
@@ -69,7 +74,7 @@ namespace
             }
             else
             {
-                repr += py::repr(py::cast(value)).cast<std::string>();
+                repr += py::repr(py::cast(entry.value)).cast<std::string>();
             }
         }
         return repr;
@@ -89,92 +94,83 @@ void init_Config (py::module& m)
 
     std::shared_ptr<ConfigMap const> const config = std::make_shared<ConfigMap>(
         ConfigMap{
-            {"amrex_version", amrex::Version()},
-            {"gpu_backend", gpu_backend},
-            {"have_fft",
+            {"amrex_version", {
+                amrex::Version(),
+                "AMReX library version used to build WarpX"}},
+            {"gpu_backend", {
+                gpu_backend,
+                "GPU backend ('CUDA', 'HIP' or 'SYCL'), None without GPU support"}},
+            {"have_fft", {
 #ifdef WARPX_USE_FFT
-                true
+                true,
 #else
-                false
+                false,
 #endif
-            },
-            {"have_gpu",
+                "Build supports FFT-based (spectral) solvers and features"}},
+            {"have_gpu", {
 #ifdef AMREX_USE_GPU
-                true
+                true,
 #else
-                false
+                false,
 #endif
-            },
-            {"have_mpi",
+                "Build supports GPUs"}},
+            {"have_mpi", {
 #ifdef AMREX_USE_MPI
-                true
+                true,
 #else
-                false
+                false,
 #endif
-            },
-            {"have_omp",
+                "Build supports MPI"}},
+            {"have_omp", {
 #ifdef AMREX_USE_OMP
-                true
+                true,
 #else
-                false
+                false,
 #endif
-            },
-            {"have_openpmd",
+                "Build supports OpenMP"}},
+            {"have_openpmd", {
 #ifdef WARPX_USE_OPENPMD
-                true
+                true,
 #else
-                false
+                false,
 #endif
-            },
-            {"have_simd",
+                "Build supports openPMD I/O"}},
+            {"have_simd", {
 #ifdef AMREX_USE_SIMD
-                true
+                true,
 #else
-                false
+                false,
 #endif
-            },
-            {"openpmd_backends",
+                "Build supports explicit SIMD vectorization"}},
+            {"openpmd_backends", {
 #ifdef WARPX_USE_OPENPMD
-                openPMD::getVariants()
+                openPMD::getVariants(),
 #else
-                std::map<std::string, bool>{}
+                std::map<std::string, bool>{},
 #endif
-            },
-            {"precision",
+                "Available openPMD-api backends and if they are enabled"}},
+            {"precision", {
 #ifdef AMREX_USE_FLOAT
-                std::string{"SINGLE"}
+                std::string{"SINGLE"},
 #else
-                std::string{"DOUBLE"}
+                std::string{"DOUBLE"},
 #endif
-            },
-            {"precision_particles",
+                "Floating point precision of amrex::Real ('SINGLE' or 'DOUBLE')"}},
+            {"precision_particles", {
 #ifdef AMREX_SINGLE_PRECISION_PARTICLES
-                std::string{"SINGLE"}
+                std::string{"SINGLE"},
 #else
-                std::string{"DOUBLE"}
+                std::string{"DOUBLE"},
 #endif
-            },
-            {"simd_size",
-                static_cast<int>(amrex::simd::native_simd_size_particlereal)},
-            {"warpx_version", WarpX::Version()}
+                "Floating point precision of amrex::ParticleReal ('SINGLE' or 'DOUBLE')"}},
+            {"simd_size", {
+                static_cast<int>(amrex::simd::native_simd_size_particlereal),
+                "Number of amrex::ParticleReal elements in a native SIMD vector"}},
+            {"warpx_version", {
+                WarpX::Version(),
+                "WarpX version"}}
         }
     );
-
-    std::map<std::string, char const *> const doc = {
-        {"amrex_version", "AMReX library version used to build WarpX"},
-        {"gpu_backend", "GPU backend ('CUDA', 'HIP' or 'SYCL'), None without GPU support"},
-        {"have_fft", "Build supports FFT-based (spectral) solvers and features"},
-        {"have_gpu", "Build supports GPUs"},
-        {"have_mpi", "Build supports MPI"},
-        {"have_omp", "Build supports OpenMP"},
-        {"have_openpmd", "Build supports openPMD I/O"},
-        {"have_simd", "Build supports explicit SIMD vectorization"},
-        {"openpmd_backends", "Available openPMD-api backends and if they are enabled"},
-        {"precision", "Floating point precision of amrex::Real ('SINGLE' or 'DOUBLE')"},
-        {"precision_particles", "Floating point precision of amrex::ParticleReal ('SINGLE' or 'DOUBLE')"},
-        {"simd_size", "Number of amrex::ParticleReal elements in a native SIMD vector"},
-        {"warpx_version", "WarpX version"}
-    };
 
     // create a custom metaclass deriving from pybind11's metaclass, so that
     // repr(Config) prints the full build configuration in interactive use
@@ -196,20 +192,25 @@ void init_Config (py::module& m)
     py::class_<warpx::Config> pyWarpXConfig(
         m, "Config", py::metaclass(config_metaclass)
     );
-    for (auto const & entry : *config)
+    for (auto const & [name, entry] : *config)
     {
         pyWarpXConfig.def_property_readonly_static(
-            entry.first.c_str(),
-            [config, name = entry.first](py::object const &) {
-                return config->at(name);
+            name.c_str(),
+            [config, name](py::object const &) {
+                return config->at(name).value;
             },
-            doc.at(entry.first)
+            entry.doc
         );
     }
     pyWarpXConfig.def_static(
         "to_dict",
         [config]() {
-            return *config;
+            py::dict d;
+            for (auto const & [name, entry] : *config)
+            {
+                d[name.c_str()] = entry.value;
+            }
+            return d;
         },
         "Return the WarpX build configuration as a dictionary."
     );

--- a/Source/Python/WarpX.cpp
+++ b/Source/Python/WarpX.cpp
@@ -43,7 +43,6 @@
 #include <AMReX.H>
 #include <AMReX_ParmParse.H>
 #include <AMReX_ParallelDescriptor.H>
-#include <AMReX_SIMD.H>
 #include <AMReX_OpenMP.H>
 
 #if defined(AMREX_DEBUG) || defined(DEBUG)
@@ -53,10 +52,6 @@
 
 
 //using namespace warpx;
-
-namespace warpx {
-    struct Config {};
-}
 
 namespace detail
 {
@@ -287,83 +282,4 @@ void init_WarpX (py::module& m)
             "Gets the number of substeps to take in the hybrid solver."
         )
     ;
-
-    py::class_<warpx::Config>(m, "Config")
-//        .def_property_readonly_static(
-//            "warpx_version",
-//            [](py::object) { return Version(); },
-//            "WarpX version")
-        .def_property_readonly_static(
-            "have_mpi",
-            [](py::object){
-#ifdef AMREX_USE_MPI
-                return true;
-#else
-                return false;
-#endif
-            })
-        .def_property_readonly_static(
-            "have_gpu",
-            [](py::object){
-#ifdef AMREX_USE_GPU
-                return true;
-#else
-                return false;
-#endif
-            })
-        .def_property_readonly_static(
-            "have_omp",
-            [](py::object){
-#ifdef AMREX_USE_OMP
-                return true;
-#else
-                return false;
-#endif
-        })
-        .def_property_readonly_static(
-            "have_simd",
-            [](py::object const &){
-#ifdef AMREX_USE_SIMD
-                return true;
-#else
-                return false;
-#endif
-        })
-        .def_property_readonly_static(
-            "simd_size",
-            [](py::object const &){
-                return amrex::simd::native_simd_size_particlereal;
-        })
-        .def_property_readonly_static(
-            "gpu_backend",
-            [](py::object){
-#ifdef AMREX_USE_CUDA
-                return "CUDA";
-#elif defined(AMREX_USE_HIP)
-                return "HIP";
-#elif defined(AMREX_USE_DPCPP)
-                return "SYCL";
-#else
-                return py::none();
-#endif
-        })
-        .def_property_readonly_static(
-            "precision",
-            [](py::object){
-#ifdef AMREX_USE_FLOAT
-                return "SINGLE";
-#else
-                return "DOUBLE";
-#endif
-        })
-        .def_property_readonly_static(
-            "precision_particles",
-            [](py::object){
-#ifdef AMREX_SINGLE_PRECISION_PARTICLES
-                return "SINGLE";
-#else
-                return "DOUBLE";
-#endif
-        })
-        ;
 }

--- a/Source/Python/pyWarpX.cpp
+++ b/Source/Python/pyWarpX.cpp
@@ -35,6 +35,7 @@
 
 // forward declarations of exposed classes
 void init_BoundaryBufferParIter (py::module&);
+void init_Config (py::module&);
 void init_MultiParticleContainer (py::module&);
 void init_MultiFabRegister (py::module&);
 void init_ParticleBoundaryBuffer (py::module&);
@@ -70,6 +71,7 @@ PYBIND11_MODULE(PYWARPX_MODULE_NAME, m) {
     init_ParticleBoundaryBuffer(m);
     init_MultiParticleContainer(m);
     init_WarpX(m);
+    init_Config(m);  // must come after init_WarpX
 
     // expose our amrex module
     m.attr("amr") = amr;


### PR DESCRIPTION
Improve and separate out the `warpx.Config` object into its own translation unit `Source/Python/Config.cpp`. Make it exportable to Python dictionaries via `to_dict()` and ensure it prints nicely in interactive (IPython/Jupyter) usage, showing all build options at a glance.

Also add the `have_fft`, `have_openpmd` and `openpmd_backends` entries, for feature parity with ImpactX.

This ports https://github.com/BLAST-ImpactX/impactx/pull/1580 to WarpX.