### PR TITLE
Use the automated checkpoint/restart of the MultiFab registry

### DIFF
--- a/Source/BoundaryConditions/PML.H
+++ b/Source/BoundaryConditions/PML.H
@@ -193,9 +193,6 @@ public:
 
     [[nodiscard]] bool ok () const { return m_ok; }
 
-    void CheckPoint (ablastr::fields::MultiFabRegister& fields, const std::string& dir) const;
-    void Restart (ablastr::fields::MultiFabRegister& fields, const std::string& dir);
-
     static void Exchange (amrex::MultiFab& pml, amrex::MultiFab& reg, const amrex::Geometry& geom, int do_pml_in_domain);
 
 private:

--- a/Source/BoundaryConditions/PML.cpp
+++ b/Source/BoundaryConditions/PML.cpp
@@ -849,16 +849,16 @@ PML::PML (const int lev, const BoxArray& grid_ba,
     const amrex::BoxArray ba_Ex = amrex::convert(ba, fields.get(FieldType::Efield_fp, Direction{0}, 0)->ixType().toIntVect());
     const amrex::BoxArray ba_Ey = amrex::convert(ba, fields.get(FieldType::Efield_fp, Direction{1}, 0)->ixType().toIntVect());
     const amrex::BoxArray ba_Ez = amrex::convert(ba, fields.get(FieldType::Efield_fp, Direction{2}, 0)->ixType().toIntVect());
-    fields.alloc_init(FieldType::pml_E_fp, Direction{0}, lev, ba_Ex, dm, ncompe, nge, 0.0_rt, false, false);
-    fields.alloc_init(FieldType::pml_E_fp, Direction{1}, lev, ba_Ey, dm, ncompe, nge, 0.0_rt, false, false);
-    fields.alloc_init(FieldType::pml_E_fp, Direction{2}, lev, ba_Ez, dm, ncompe, nge, 0.0_rt, false, false);
+    fields.alloc_init(FieldType::pml_E_fp, Direction{0}, lev, ba_Ex, dm, ncompe, nge, 0.0_rt, false, false, true);
+    fields.alloc_init(FieldType::pml_E_fp, Direction{1}, lev, ba_Ey, dm, ncompe, nge, 0.0_rt, false, false, true);
+    fields.alloc_init(FieldType::pml_E_fp, Direction{2}, lev, ba_Ez, dm, ncompe, nge, 0.0_rt, false, false, true);
 
     const amrex::BoxArray ba_Bx = amrex::convert(ba, fields.get(FieldType::Bfield_fp, Direction{0}, 0)->ixType().toIntVect());
     const amrex::BoxArray ba_By = amrex::convert(ba, fields.get(FieldType::Bfield_fp, Direction{1}, 0)->ixType().toIntVect());
     const amrex::BoxArray ba_Bz = amrex::convert(ba, fields.get(FieldType::Bfield_fp, Direction{2}, 0)->ixType().toIntVect());
-    fields.alloc_init(FieldType::pml_B_fp, Direction{0}, lev, ba_Bx, dm, ncompb, ngb, 0.0_rt, false, false);
-    fields.alloc_init(FieldType::pml_B_fp, Direction{1}, lev, ba_By, dm, ncompb, ngb, 0.0_rt, false, false);
-    fields.alloc_init(FieldType::pml_B_fp, Direction{2}, lev, ba_Bz, dm, ncompb, ngb, 0.0_rt, false, false);
+    fields.alloc_init(FieldType::pml_B_fp, Direction{0}, lev, ba_Bx, dm, ncompb, ngb, 0.0_rt, false, false, true);
+    fields.alloc_init(FieldType::pml_B_fp, Direction{1}, lev, ba_By, dm, ncompb, ngb, 0.0_rt, false, false, true);
+    fields.alloc_init(FieldType::pml_B_fp, Direction{2}, lev, ba_Bz, dm, ncompb, ngb, 0.0_rt, false, false, true);
 
     const amrex::BoxArray ba_jx = amrex::convert(ba, fields.get(FieldType::current_fp, Direction{0}, 0)->ixType().toIntVect());
     const amrex::BoxArray ba_jy = amrex::convert(ba, fields.get(FieldType::current_fp, Direction{1}, 0)->ixType().toIntVect());
@@ -987,16 +987,16 @@ PML::PML (const int lev, const BoxArray& grid_ba,
         const amrex::BoxArray cba_Ex = amrex::convert(cba, fields.get(FieldType::Efield_cp, Direction{0}, 1)->ixType().toIntVect());
         const amrex::BoxArray cba_Ey = amrex::convert(cba, fields.get(FieldType::Efield_cp, Direction{1}, 1)->ixType().toIntVect());
         const amrex::BoxArray cba_Ez = amrex::convert(cba, fields.get(FieldType::Efield_cp, Direction{2}, 1)->ixType().toIntVect());
-        fields.alloc_init(FieldType::pml_E_cp, Direction{0}, lev, cba_Ex, cdm, ncompe, nge, 0.0_rt, false, false);
-        fields.alloc_init(FieldType::pml_E_cp, Direction{1}, lev, cba_Ey, cdm, ncompe, nge, 0.0_rt, false, false);
-        fields.alloc_init(FieldType::pml_E_cp, Direction{2}, lev, cba_Ez, cdm, ncompe, nge, 0.0_rt, false, false);
+        fields.alloc_init(FieldType::pml_E_cp, Direction{0}, lev, cba_Ex, cdm, ncompe, nge, 0.0_rt, false, false, true);
+        fields.alloc_init(FieldType::pml_E_cp, Direction{1}, lev, cba_Ey, cdm, ncompe, nge, 0.0_rt, false, false, true);
+        fields.alloc_init(FieldType::pml_E_cp, Direction{2}, lev, cba_Ez, cdm, ncompe, nge, 0.0_rt, false, false, true);
 
         const amrex::BoxArray cba_Bx = amrex::convert(cba, fields.get(FieldType::Bfield_cp, Direction{0}, 1)->ixType().toIntVect());
         const amrex::BoxArray cba_By = amrex::convert(cba, fields.get(FieldType::Bfield_cp, Direction{1}, 1)->ixType().toIntVect());
         const amrex::BoxArray cba_Bz = amrex::convert(cba, fields.get(FieldType::Bfield_cp, Direction{2}, 1)->ixType().toIntVect());
-        fields.alloc_init(FieldType::pml_B_cp, Direction{0}, lev, cba_Bx, cdm, ncompb, ngb, 0.0_rt, false, false);
-        fields.alloc_init(FieldType::pml_B_cp, Direction{1}, lev, cba_By, cdm, ncompb, ngb, 0.0_rt, false, false);
-        fields.alloc_init(FieldType::pml_B_cp, Direction{2}, lev, cba_Bz, cdm, ncompb, ngb, 0.0_rt, false, false);
+        fields.alloc_init(FieldType::pml_B_cp, Direction{0}, lev, cba_Bx, cdm, ncompb, ngb, 0.0_rt, false, false, true);
+        fields.alloc_init(FieldType::pml_B_cp, Direction{1}, lev, cba_By, cdm, ncompb, ngb, 0.0_rt, false, false, true);
+        fields.alloc_init(FieldType::pml_B_cp, Direction{2}, lev, cba_Bz, cdm, ncompb, ngb, 0.0_rt, false, false, true);
 
         if (m_dive_cleaning)
         {
@@ -1237,72 +1237,6 @@ PML::FillBoundary (amrex::MultiFab & mf_pml, PatchType patch_type, std::optional
         m_cgeom->periodicity();
 
     ablastr::utils::communication::FillBoundary(mf_pml, WarpX::do_single_precision_comms, period, nodal_sync);
-}
-
-void
-PML::CheckPoint (
-    ablastr::fields::MultiFabRegister& fields,
-    const std::string& dir
-) const
-{
-    using ablastr::fields::Direction;
-
-    if (fields.has_vector(FieldType::pml_E_fp, 0))
-    {
-        ablastr::fields::VectorField pml_E_fp = fields.get_alldirs(FieldType::pml_E_fp, 0);
-        ablastr::fields::VectorField pml_B_fp = fields.get_alldirs(FieldType::pml_B_fp, 0);
-        VisMF::AsyncWrite(*pml_E_fp[0], dir+"_Ex_fp");
-        VisMF::AsyncWrite(*pml_E_fp[1], dir+"_Ey_fp");
-        VisMF::AsyncWrite(*pml_E_fp[2], dir+"_Ez_fp");
-        VisMF::AsyncWrite(*pml_B_fp[0], dir+"_Bx_fp");
-        VisMF::AsyncWrite(*pml_B_fp[1], dir+"_By_fp");
-        VisMF::AsyncWrite(*pml_B_fp[2], dir+"_Bz_fp");
-    }
-
-    if (fields.has_vector(FieldType::pml_E_cp, 0))
-    {
-        ablastr::fields::VectorField pml_E_cp = fields.get_alldirs(FieldType::pml_E_cp, 0);
-        ablastr::fields::VectorField pml_B_cp = fields.get_alldirs(FieldType::pml_B_cp, 0);
-        VisMF::AsyncWrite(*pml_E_cp[0], dir+"_Ex_cp");
-        VisMF::AsyncWrite(*pml_E_cp[1], dir+"_Ey_cp");
-        VisMF::AsyncWrite(*pml_E_cp[2], dir+"_Ez_cp");
-        VisMF::AsyncWrite(*pml_B_cp[0], dir+"_Bx_cp");
-        VisMF::AsyncWrite(*pml_B_cp[1], dir+"_By_cp");
-        VisMF::AsyncWrite(*pml_B_cp[2], dir+"_Bz_cp");
-    }
-}
-
-void
-PML::Restart (
-    ablastr::fields::MultiFabRegister& fields,
-    const std::string& dir
-)
-{
-    using ablastr::fields::Direction;
-
-    if (fields.has_vector(FieldType::pml_E_fp, 0))
-    {
-        ablastr::fields::VectorField pml_E_fp = fields.get_alldirs(FieldType::pml_E_fp, 0);
-        ablastr::fields::VectorField pml_B_fp = fields.get_alldirs(FieldType::pml_B_fp, 0);
-        VisMF::Read(*pml_E_fp[0], dir+"_Ex_fp");
-        VisMF::Read(*pml_E_fp[1], dir+"_Ey_fp");
-        VisMF::Read(*pml_E_fp[2], dir+"_Ez_fp");
-        VisMF::Read(*pml_B_fp[0], dir+"_Bx_fp");
-        VisMF::Read(*pml_B_fp[1], dir+"_By_fp");
-        VisMF::Read(*pml_B_fp[2], dir+"_Bz_fp");
-    }
-
-    if (fields.has_vector(FieldType::pml_E_cp, 0))
-    {
-        ablastr::fields::VectorField pml_E_cp = fields.get_alldirs(FieldType::pml_E_cp, 0);
-        ablastr::fields::VectorField pml_B_cp = fields.get_alldirs(FieldType::pml_B_cp, 0);
-        VisMF::Read(*pml_E_cp[0], dir+"_Ex_cp");
-        VisMF::Read(*pml_E_cp[1], dir+"_Ey_cp");
-        VisMF::Read(*pml_E_cp[2], dir+"_Ez_cp");
-        VisMF::Read(*pml_B_cp[0], dir+"_Bx_cp");
-        VisMF::Read(*pml_B_cp[1], dir+"_By_cp");
-        VisMF::Read(*pml_B_cp[2], dir+"_Bz_cp");
-    }
 }
 
 #ifdef WARPX_USE_FFT

--- a/Source/BoundaryConditions/PML_RZ.H
+++ b/Source/BoundaryConditions/PML_RZ.H
@@ -49,9 +49,6 @@ public:
     void FillBoundaryB (ablastr::fields::MultiFabRegister& fields, PatchType patch_type,
         bool do_single_precision_comms, std::optional<bool> nodal_sync=std::nullopt);
 
-    void CheckPoint (ablastr::fields::MultiFabRegister& fields, std::string const& dir) const;
-    void Restart (ablastr::fields::MultiFabRegister& fields, std::string const& dir);
-
 private:
 
     int m_ncell;

--- a/Source/BoundaryConditions/PML_RZ.cpp
+++ b/Source/BoundaryConditions/PML_RZ.cpp
@@ -49,15 +49,19 @@ PML_RZ::PML_RZ (int lev, amrex::BoxArray const& grid_ba, amrex::DistributionMapp
     amrex::MultiFab const& Et_fp = *fields.get(FieldType::Efield_fp, Direction{1}, lev);
     amrex::BoxArray const ba_Er = amrex::convert(grid_ba, Er_fp.ixType().toIntVect());
     amrex::BoxArray const ba_Et = amrex::convert(grid_ba, Et_fp.ixType().toIntVect());
-    fields.alloc_init(FieldType::pml_E_fp, Direction{0}, lev, ba_Er, grid_dm, Er_fp.nComp(), Er_fp.nGrowVect(), 0.0_rt);
-    fields.alloc_init(FieldType::pml_E_fp, Direction{1}, lev, ba_Et, grid_dm, Et_fp.nComp(), Et_fp.nGrowVect(), 0.0_rt);
+    fields.alloc_init(FieldType::pml_E_fp, Direction{0}, lev, ba_Er, grid_dm, Er_fp.nComp(), Er_fp.nGrowVect(), 0.0_rt,
+                      true, true, true);
+    fields.alloc_init(FieldType::pml_E_fp, Direction{1}, lev, ba_Et, grid_dm, Et_fp.nComp(), Et_fp.nGrowVect(), 0.0_rt,
+                      true, true, true);
 
     amrex::MultiFab const& Br_fp = *fields.get(FieldType::Bfield_fp,Direction{0},lev);
     amrex::MultiFab const& Bt_fp = *fields.get(FieldType::Bfield_fp,Direction{1},lev);
     amrex::BoxArray const ba_Br = amrex::convert(grid_ba, Br_fp.ixType().toIntVect());
     amrex::BoxArray const ba_Bt = amrex::convert(grid_ba, Bt_fp.ixType().toIntVect());
-    fields.alloc_init(FieldType::pml_B_fp, Direction{0}, lev, ba_Br, grid_dm, Br_fp.nComp(), Br_fp.nGrowVect(), 0.0_rt);
-    fields.alloc_init(FieldType::pml_B_fp, Direction{1}, lev, ba_Bt, grid_dm, Bt_fp.nComp(), Bt_fp.nGrowVect(), 0.0_rt);
+    fields.alloc_init(FieldType::pml_B_fp, Direction{0}, lev, ba_Br, grid_dm, Br_fp.nComp(), Br_fp.nGrowVect(), 0.0_rt,
+                      true, true, true);
+    fields.alloc_init(FieldType::pml_B_fp, Direction{1}, lev, ba_Bt, grid_dm, Bt_fp.nComp(), Bt_fp.nGrowVect(), 0.0_rt,
+                      true, true, true);
 
 }
 
@@ -154,32 +158,6 @@ PML_RZ::FillBoundaryB (ablastr::fields::MultiFabRegister& fields, PatchType patc
         amrex::Periodicity const& period = m_geom->periodicity();
         const amrex::Vector<amrex::MultiFab*> mf = {pml_Br, pml_Bt};
         ablastr::utils::communication::FillBoundary(mf, do_single_precision_comms, period, nodal_sync);
-    }
-}
-
-void
-PML_RZ::CheckPoint (ablastr::fields::MultiFabRegister& fields, std::string const& dir) const
-{
-    using ablastr::fields::Direction;
-
-    if (fields.has(FieldType::pml_E_fp, Direction{0}, 0)) {
-        amrex::VisMF::AsyncWrite(*fields.get(FieldType::pml_E_fp, Direction{0}, 0), dir+"_Er_fp");
-        amrex::VisMF::AsyncWrite(*fields.get(FieldType::pml_E_fp, Direction{1}, 0), dir+"_Et_fp");
-        amrex::VisMF::AsyncWrite(*fields.get(FieldType::pml_B_fp, Direction{0}, 0), dir+"_Br_fp");
-        amrex::VisMF::AsyncWrite(*fields.get(FieldType::pml_B_fp, Direction{1}, 0), dir+"_Bt_fp");
-    }
-}
-
-void
-PML_RZ::Restart (ablastr::fields::MultiFabRegister& fields, std::string const& dir)
-{
-    using ablastr::fields::Direction;
-
-    if (fields.has(FieldType::pml_E_fp, Direction{0}, 0)) {
-        amrex::VisMF::Read(*fields.get(FieldType::pml_E_fp, Direction{0}, 0), dir+"_Er_fp");
-        amrex::VisMF::Read(*fields.get(FieldType::pml_E_fp, Direction{1}, 0), dir+"_Et_fp");
-        amrex::VisMF::Read(*fields.get(FieldType::pml_B_fp, Direction{0}, 0), dir+"_Br_fp");
-        amrex::VisMF::Read(*fields.get(FieldType::pml_B_fp, Direction{1}, 0), dir+"_Bt_fp");
     }
 }
 

--- a/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
+++ b/Source/Diagnostics/FlushFormats/FlushFormatCheckpoint.cpp
@@ -80,44 +80,6 @@ FlushFormatCheckpoint::WriteToFile (
 
     for (int lev = 0; lev < nlev; ++lev)
     {
-        VisMF::Write(*warpx.m_fields.get(FieldType::Efield_fp, Direction{0}, lev),
-                     amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ex_fp"));
-        VisMF::Write(*warpx.m_fields.get(FieldType::Efield_fp, Direction{1}, lev),
-                     amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ey_fp"));
-        VisMF::Write(*warpx.m_fields.get(FieldType::Efield_fp, Direction{2}, lev),
-                     amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ez_fp"));
-        if (warpx.m_fields.has_vector(FieldType::E_old, lev)) {
-            VisMF::Write(*warpx.m_fields.get(FieldType::E_old, Direction{0}, lev),
-                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ex_old"));
-            VisMF::Write(*warpx.m_fields.get(FieldType::E_old, Direction{1}, lev),
-                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ey_old"));
-            VisMF::Write(*warpx.m_fields.get(FieldType::E_old, Direction{2}, lev),
-                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ez_old"));
-        }
-        VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_fp, Direction{0}, lev),
-                     amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Bx_fp"));
-        VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_fp, Direction{1}, lev),
-                     amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "By_fp"));
-        VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_fp, Direction{2}, lev),
-                     amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Bz_fp"));
-
-        if (WarpX::fft_do_time_averaging)
-        {
-            VisMF::Write(*warpx.m_fields.get(FieldType::Efield_avg_fp, Direction{0}, lev),
-                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ex_avg_fp"));
-            VisMF::Write(*warpx.m_fields.get(FieldType::Efield_avg_fp, Direction{1}, lev),
-                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ey_avg_fp"));
-            VisMF::Write(*warpx.m_fields.get(FieldType::Efield_avg_fp, Direction{2}, lev),
-                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ez_avg_fp"));
-
-            VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_avg_fp, Direction{0}, lev),
-                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Bx_avg_fp"));
-            VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_avg_fp, Direction{1}, lev),
-                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "By_avg_fp"));
-            VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_avg_fp, Direction{2}, lev),
-                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Bz_avg_fp"));
-        }
-
         if (warpx.getis_synchronized()) {
             // Need to save j if synchronized because after restart we need j to evolve E by dt/2.
             VisMF::Write(*warpx.m_fields.get(FieldType::current_fp, Direction{0}, lev),
@@ -130,36 +92,6 @@ FlushFormatCheckpoint::WriteToFile (
 
         if (lev > 0)
         {
-            VisMF::Write(*warpx.m_fields.get(FieldType::Efield_cp, Direction{0}, lev),
-                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ex_cp"));
-            VisMF::Write(*warpx.m_fields.get(FieldType::Efield_cp, Direction{1}, lev),
-                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ey_cp"));
-            VisMF::Write(*warpx.m_fields.get(FieldType::Efield_cp, Direction{2}, lev),
-                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ez_cp"));
-            VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_cp, Direction{0}, lev),
-                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Bx_cp"));
-            VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_cp, Direction{1}, lev),
-                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "By_cp"));
-            VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_cp, Direction{2}, lev),
-                         amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Bz_cp"));
-
-            if (WarpX::fft_do_time_averaging)
-            {
-                VisMF::Write(*warpx.m_fields.get(FieldType::Efield_avg_cp, Direction{0}, lev),
-                             amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ex_avg_cp"));
-                VisMF::Write(*warpx.m_fields.get(FieldType::Efield_avg_cp, Direction{1}, lev),
-                             amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ey_avg_cp"));
-                VisMF::Write(*warpx.m_fields.get(FieldType::Efield_avg_cp, Direction{2}, lev),
-                             amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Ez_avg_cp"));
-
-                VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_avg_cp, Direction{0}, lev),
-                             amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Bx_avg_cp"));
-                VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_avg_cp, Direction{1}, lev),
-                             amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "By_avg_cp"));
-                VisMF::Write(*warpx.m_fields.get(FieldType::Bfield_avg_cp, Direction{2}, lev),
-                             amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "Bz_avg_cp"));
-            }
-
             if (warpx.getis_synchronized()) {
                 // Need to save j if synchronized because after restart we need j to evolve E by dt/2.
                 VisMF::Write(*warpx.m_fields.get(FieldType::current_cp, Direction{0}, lev),
@@ -169,21 +101,6 @@ FlushFormatCheckpoint::WriteToFile (
                 VisMF::Write(*warpx.m_fields.get(FieldType::current_cp, Direction{2}, lev),
                              amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "jz_cp"));
             }
-        }
-
-        if (warpx.DoPML()) {
-            if (warpx.GetPML(lev)) {
-                warpx.GetPML(lev)->CheckPoint(
-                    warpx.m_fields,
-                    amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "pml"));
-            }
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
-            if (warpx.GetPML_RZ(lev)) {
-                warpx.GetPML_RZ(lev)->CheckPoint(
-                    warpx.m_fields,
-                    amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, "pml_rz"));
-            }
-#endif
         }
 
         warpx.m_fields.write_checkpoints(lev, amrex::MultiFabFileFullPrefix(lev, checkpointname, default_level_prefix, ""));

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -220,6 +220,8 @@ WarpX::InitFromCheckpoint ()
         // and can be read in from the restart data.
         mypc->AllocData();
 
+        InitPML();
+
         ExecutePythonCallback("allocdata");
 
         mypc->ReadHeader(is);
@@ -312,46 +314,6 @@ WarpX::InitFromCheckpoint ()
             }
         }
 
-        if (m_fields.has_vector(FieldType::E_old, lev)) {
-            VisMF::Read(*m_fields.get(FieldType::E_old, Direction{0}, lev),
-                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ex_old"));
-            VisMF::Read(*m_fields.get(FieldType::E_old, Direction{1}, lev),
-                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ey_old"));
-            VisMF::Read(*m_fields.get(FieldType::E_old, Direction{2}, lev),
-                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ez_old"));
-        }
-
-        VisMF::Read(*m_fields.get(FieldType::Efield_fp, Direction{0}, lev),
-                    amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ex_fp"));
-        VisMF::Read(*m_fields.get(FieldType::Efield_fp, Direction{1}, lev),
-                    amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ey_fp"));
-        VisMF::Read(*m_fields.get(FieldType::Efield_fp, Direction{2}, lev),
-                    amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ez_fp"));
-
-        VisMF::Read(*m_fields.get(FieldType::Bfield_fp, Direction{0}, lev),
-                    amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bx_fp"));
-        VisMF::Read(*m_fields.get(FieldType::Bfield_fp, Direction{1}, lev),
-                    amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "By_fp"));
-        VisMF::Read(*m_fields.get(FieldType::Bfield_fp, Direction{2}, lev),
-                    amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bz_fp"));
-
-        if (WarpX::fft_do_time_averaging)
-        {
-            VisMF::Read(*m_fields.get(FieldType::Efield_avg_fp, Direction{0}, lev),
-                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ex_avg_fp"));
-            VisMF::Read(*m_fields.get(FieldType::Efield_avg_fp, Direction{1}, lev),
-                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ey_avg_fp"));
-            VisMF::Read(*m_fields.get(FieldType::Efield_avg_fp, Direction{2}, lev),
-                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ez_avg_fp"));
-
-            VisMF::Read(*m_fields.get(FieldType::Bfield_avg_fp, Direction{0}, lev),
-                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bx_avg_fp"));
-            VisMF::Read(*m_fields.get(FieldType::Bfield_avg_fp, Direction{1}, lev),
-                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "By_avg_fp"));
-            VisMF::Read(*m_fields.get(FieldType::Bfield_avg_fp, Direction{2}, lev),
-                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bz_avg_fp"));
-        }
-
         if (m_is_synchronized) {
             VisMF::Read(*m_fields.get(FieldType::current_fp, Direction{0}, lev),
                         amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "jx_fp"));
@@ -363,37 +325,6 @@ WarpX::InitFromCheckpoint ()
 
         if (lev > 0)
         {
-            VisMF::Read(*m_fields.get(FieldType::Efield_cp, Direction{0}, lev),
-                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ex_cp"));
-            VisMF::Read(*m_fields.get(FieldType::Efield_cp, Direction{1}, lev),
-                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ey_cp"));
-            VisMF::Read(*m_fields.get(FieldType::Efield_cp, Direction{2}, lev),
-                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ez_cp"));
-
-            VisMF::Read(*m_fields.get(FieldType::Bfield_cp, Direction{0}, lev),
-                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bx_cp"));
-            VisMF::Read(*m_fields.get(FieldType::Bfield_cp, Direction{1}, lev),
-                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "By_cp"));
-            VisMF::Read(*m_fields.get(FieldType::Bfield_cp, Direction{2}, lev),
-                        amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bz_cp"));
-
-            if (WarpX::fft_do_time_averaging)
-            {
-                VisMF::Read(*m_fields.get(FieldType::Efield_avg_cp, Direction{0}, lev),
-                            amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ex_avg_cp"));
-                VisMF::Read(*m_fields.get(FieldType::Efield_avg_cp, Direction{1}, lev),
-                            amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ey_avg_cp"));
-                VisMF::Read(*m_fields.get(FieldType::Efield_avg_cp, Direction{2}, lev),
-                            amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Ez_avg_cp"));
-
-                VisMF::Read(*m_fields.get(FieldType::Bfield_avg_cp, Direction{0}, lev),
-                            amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bx_avg_cp"));
-                VisMF::Read(*m_fields.get(FieldType::Bfield_avg_cp, Direction{1}, lev),
-                            amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "By_avg_cp"));
-                VisMF::Read(*m_fields.get(FieldType::Bfield_avg_cp, Direction{2}, lev),
-                            amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "Bz_avg_cp"));
-            }
-
             if (m_is_synchronized) {
                 VisMF::Read(*m_fields.get(FieldType::current_cp, Direction{0}, lev),
                             amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "jx_cp"));
@@ -406,21 +337,6 @@ WarpX::InitFromCheckpoint ()
 
         m_fields.read_restarts(lev, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, ""));
 
-    }
-
-    InitPML();
-    if (do_pml)
-    {
-        for (int lev = 0; lev < nlevs; ++lev) {
-            if (pml[lev]) {
-                pml[lev]->Restart(m_fields, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "pml"));
-            }
-#if (defined WARPX_DIM_RZ) && (defined WARPX_USE_FFT)
-            if (pml_rz[lev]) {
-                pml_rz[lev]->Restart(m_fields, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, "pml_rz"));
-            }
-#endif
-        }
     }
 
     if (EB::enabled()) { InitializeEBGridData(maxLevel()); }

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -2494,18 +2494,28 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     // Set global rho nodal flag to know about rho index type when rho MultiFab is not allocated
     m_rho_nodal_flag = rho_nodal_flag;
 
+    bool remake = true;
+    bool redistribute_on_remake = true;
+    bool checkpoint_restart = true;
+
     //
     // The fine patch
     //
     const std::array<Real,3> dx = CellSize(lev);
 
-    m_fields.alloc_init(FieldType::Bfield_fp, Direction{0}, lev, amrex::convert(ba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-    m_fields.alloc_init(FieldType::Bfield_fp, Direction{1}, lev, amrex::convert(ba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-    m_fields.alloc_init(FieldType::Bfield_fp, Direction{2}, lev, amrex::convert(ba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+    m_fields.alloc_init(FieldType::Bfield_fp, Direction{0}, lev, amrex::convert(ba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                        remake, redistribute_on_remake, checkpoint_restart);
+    m_fields.alloc_init(FieldType::Bfield_fp, Direction{1}, lev, amrex::convert(ba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                        remake, redistribute_on_remake, checkpoint_restart);
+    m_fields.alloc_init(FieldType::Bfield_fp, Direction{2}, lev, amrex::convert(ba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                        remake, redistribute_on_remake, checkpoint_restart);
 
-    m_fields.alloc_init(FieldType::Efield_fp, Direction{0}, lev, amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-    m_fields.alloc_init(FieldType::Efield_fp, Direction{1}, lev, amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-    m_fields.alloc_init(FieldType::Efield_fp, Direction{2}, lev, amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+    m_fields.alloc_init(FieldType::Efield_fp, Direction{0}, lev, amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                        remake, redistribute_on_remake, checkpoint_restart);
+    m_fields.alloc_init(FieldType::Efield_fp, Direction{1}, lev, amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                        remake, redistribute_on_remake, checkpoint_restart);
+    m_fields.alloc_init(FieldType::Efield_fp, Direction{2}, lev, amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                        remake, redistribute_on_remake, checkpoint_restart);
 
     m_fields.alloc_init(FieldType::current_fp, Direction{0}, lev, amrex::convert(ba, jx_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
     m_fields.alloc_init(FieldType::current_fp, Direction{1}, lev, amrex::convert(ba, jy_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
@@ -2522,11 +2532,14 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
                             amrex::convert(ba, jz_nodal_flag), dm, ncomps, ngJ, 0.0_rt);
 
         m_fields.alloc_init(FieldType::E_old, Direction{0}, lev,
-                            amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+                            amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                            remake, redistribute_on_remake, checkpoint_restart);
         m_fields.alloc_init(FieldType::E_old, Direction{1}, lev,
-                            amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+                            amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                            remake, redistribute_on_remake, checkpoint_restart);
         m_fields.alloc_init(FieldType::E_old, Direction{2}, lev,
-                            amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+                            amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                            remake, redistribute_on_remake, checkpoint_restart);
     }
 
     if (do_current_centering)
@@ -2589,13 +2602,19 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
 
     if (fft_do_time_averaging)
     {
-        m_fields.alloc_init(FieldType::Bfield_avg_fp, Direction{0}, lev, amrex::convert(ba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Bfield_avg_fp, Direction{1}, lev, amrex::convert(ba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Bfield_avg_fp, Direction{2}, lev, amrex::convert(ba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::Bfield_avg_fp, Direction{0}, lev, amrex::convert(ba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                            remake, redistribute_on_remake, checkpoint_restart);
+        m_fields.alloc_init(FieldType::Bfield_avg_fp, Direction{1}, lev, amrex::convert(ba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                            remake, redistribute_on_remake, checkpoint_restart);
+        m_fields.alloc_init(FieldType::Bfield_avg_fp, Direction{2}, lev, amrex::convert(ba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                            remake, redistribute_on_remake, checkpoint_restart);
 
-        m_fields.alloc_init(FieldType::Efield_avg_fp, Direction{0}, lev, amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Efield_avg_fp, Direction{1}, lev, amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Efield_avg_fp, Direction{2}, lev, amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::Efield_avg_fp, Direction{0}, lev, amrex::convert(ba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                            remake, redistribute_on_remake, checkpoint_restart);
+        m_fields.alloc_init(FieldType::Efield_avg_fp, Direction{1}, lev, amrex::convert(ba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                            remake, redistribute_on_remake, checkpoint_restart);
+        m_fields.alloc_init(FieldType::Efield_avg_fp, Direction{2}, lev, amrex::convert(ba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                            remake, redistribute_on_remake, checkpoint_restart);
     }
 
     if (EB::enabled()) {
@@ -2935,24 +2954,36 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
         const std::array<Real,3> cdx = CellSize(lev-1);
 
         // Create the MultiFabs for B
-        m_fields.alloc_init(FieldType::Bfield_cp, Direction{0}, lev, amrex::convert(cba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Bfield_cp, Direction{1}, lev, amrex::convert(cba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Bfield_cp, Direction{2}, lev, amrex::convert(cba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::Bfield_cp, Direction{0}, lev, amrex::convert(cba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                            remake, redistribute_on_remake, checkpoint_restart);
+        m_fields.alloc_init(FieldType::Bfield_cp, Direction{1}, lev, amrex::convert(cba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                            remake, redistribute_on_remake, checkpoint_restart);
+        m_fields.alloc_init(FieldType::Bfield_cp, Direction{2}, lev, amrex::convert(cba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                            remake, redistribute_on_remake, checkpoint_restart);
 
         // Create the MultiFabs for E
-        m_fields.alloc_init(FieldType::Efield_cp, Direction{0}, lev, amrex::convert(cba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Efield_cp, Direction{1}, lev, amrex::convert(cba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-        m_fields.alloc_init(FieldType::Efield_cp, Direction{2}, lev, amrex::convert(cba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+        m_fields.alloc_init(FieldType::Efield_cp, Direction{0}, lev, amrex::convert(cba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                            remake, redistribute_on_remake, checkpoint_restart);
+        m_fields.alloc_init(FieldType::Efield_cp, Direction{1}, lev, amrex::convert(cba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                            remake, redistribute_on_remake, checkpoint_restart);
+        m_fields.alloc_init(FieldType::Efield_cp, Direction{2}, lev, amrex::convert(cba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                            remake, redistribute_on_remake, checkpoint_restart);
 
         if (fft_do_time_averaging)
         {
-            m_fields.alloc_init(FieldType::Bfield_avg_cp, Direction{0}, lev, amrex::convert(cba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-            m_fields.alloc_init(FieldType::Bfield_avg_cp, Direction{1}, lev, amrex::convert(cba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-            m_fields.alloc_init(FieldType::Bfield_avg_cp, Direction{2}, lev, amrex::convert(cba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+            m_fields.alloc_init(FieldType::Bfield_avg_cp, Direction{0}, lev, amrex::convert(cba, Bx_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                                remake, redistribute_on_remake, checkpoint_restart);
+            m_fields.alloc_init(FieldType::Bfield_avg_cp, Direction{1}, lev, amrex::convert(cba, By_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                                remake, redistribute_on_remake, checkpoint_restart);
+            m_fields.alloc_init(FieldType::Bfield_avg_cp, Direction{2}, lev, amrex::convert(cba, Bz_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                                remake, redistribute_on_remake, checkpoint_restart);
 
-            m_fields.alloc_init(FieldType::Efield_avg_cp, Direction{0}, lev, amrex::convert(cba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-            m_fields.alloc_init(FieldType::Efield_avg_cp, Direction{1}, lev, amrex::convert(cba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
-            m_fields.alloc_init(FieldType::Efield_avg_cp, Direction{2}, lev, amrex::convert(cba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt);
+            m_fields.alloc_init(FieldType::Efield_avg_cp, Direction{0}, lev, amrex::convert(cba, Ex_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                                remake, redistribute_on_remake, checkpoint_restart);
+            m_fields.alloc_init(FieldType::Efield_avg_cp, Direction{1}, lev, amrex::convert(cba, Ey_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                                remake, redistribute_on_remake, checkpoint_restart);
+            m_fields.alloc_init(FieldType::Efield_avg_cp, Direction{2}, lev, amrex::convert(cba, Ez_nodal_flag), dm, ncomps, ngEB, 0.0_rt,
+                                remake, redistribute_on_remake, checkpoint_restart);
         }
 
         // Create the MultiFabs for the current

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -2494,9 +2494,9 @@ WarpX::AllocLevelMFs (int lev, const BoxArray& ba, const DistributionMapping& dm
     // Set global rho nodal flag to know about rho index type when rho MultiFab is not allocated
     m_rho_nodal_flag = rho_nodal_flag;
 
-    bool remake = true;
-    bool redistribute_on_remake = true;
-    bool checkpoint_restart = true;
+    const bool remake = true;
+    const bool redistribute_on_remake = true;
+    const bool checkpoint_restart = true;
 
     //
     // The fine patch


### PR DESCRIPTION
PR #7023 added the checkpoint_restart flag to the MultiFab registry. This PR takes advantage of that by flagging all of the MultiFabs that are written out to checkpoint when allocated. This cleans up the checkpoint/restart by removing the need for the code to write and read each of the MultiFabs. It also simplifies the PML since the `Checkpoint` and `Restart` routines are no longer needed.

Note that this will break old checkpoint files since it changes the names of the MultiFabs when written out.