### PR TITLE
Docs: convert `GOVERNANCE.rst` to `GOVERNANCE.md`

### DIFF
--- a/Docs/requirements.txt
+++ b/Docs/requirements.txt
@@ -8,6 +8,7 @@
 -e ../Python
 breathe
 docutils>=0.17.1
+myst-parser
 
 # PICMI API docs
 # note: keep in sync with version in ../requirements.txt
@@ -17,7 +18,6 @@ picmistandard==0.34.0
 
 pybtex
 pygments
-recommonmark
 # Sphinx<7.2 because we are waiting for
 #   https://github.com/breathe-doc/breathe/issues/943
 sphinx>=5.3,<7.2

--- a/Docs/source/conf.py
+++ b/Docs/source/conf.py
@@ -73,6 +73,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinx_design",
     "breathe",
+    "myst_parser",
     "sphinxcontrib.bibtex",
     "sphinxcontrib.googleanalytics",
     "parmparse",
@@ -115,8 +116,7 @@ bibtex_default_style = "warpxbibstyle"
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
-# source_suffix = ['.rst', '.md']
-source_suffix = ".rst"
+source_suffix = [".rst", ".md"]
 
 # The master toctree document.
 master_doc = "index"

--- a/Docs/source/governance.md
+++ b/Docs/source/governance.md
@@ -1,0 +1,1 @@
+../../GOVERNANCE.md

--- a/Docs/source/governance.rst
+++ b/Docs/source/governance.rst
@@ -1,1 +1,0 @@
-../../GOVERNANCE.rst

--- a/Docs/spack.yaml
+++ b/Docs/spack.yaml
@@ -21,9 +21,9 @@ spack:
   - python
   - py-openpmd-viewer
   - py-breathe
+  - py-myst-parser
   - py-pybtex
   - py-pygments
-  - py-recommonmark
   - py-sphinx
   - py-sphinx-copybutton
   - py-sphinx-design

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -7,9 +7,9 @@ WarpX is led in an open governance model, described in this file.
 
 ### Current Roster
 
-- Jean-Luc Vay (chair)
-- Remi Lehe
-- Axel Huebl
+- Jean-Luc Vay ([@jlvay](https://github.com/jlvay)) (chair)
+- Remi Lehe ([@RemiLehe](https://github.com/RemiLehe))
+- Axel Huebl ([@ax3l](https://github.com/ax3l))
 
 See: [GitHub team](https://github.com/orgs/BLAST-WarpX/teams/warpx-steering-committee)
 
@@ -44,19 +44,19 @@ SC members can resign or be removed by majority vote, e.g., due to inactivity, b
 
 ### Current Roster
 
-- Justin Ray Angus
-- Luca Fedeli
-- Arianna Formenti
-- Roelof Groenewald
-- David Grote
-- Axel Huebl
-- Revathi Jambunathan
-- Remi Lehe
-- Andrew Myers
-- Maxence Thévenet
-- Jean-Luc Vay
-- Weiqun Zhang
-- Edoardo Zoni
+- Justin Ray Angus ([@JustinRayAngus](https://github.com/JustinRayAngus))
+- Luca Fedeli ([@lucafedeli88](https://github.com/lucafedeli88))
+- Arianna Formenti ([@aeriforme](https://github.com/aeriforme))
+- Roelof Groenewald ([@roelof-groenewald](https://github.com/roelof-groenewald))
+- David Grote ([@dpgrote](https://github.com/dpgrote))
+- Axel Huebl ([@ax3l](https://github.com/ax3l))
+- Revathi Jambunathan ([@RevathiJambunathan](https://github.com/RevathiJambunathan))
+- Remi Lehe ([@RemiLehe](https://github.com/RemiLehe))
+- Andrew Myers ([@atmyers](https://github.com/atmyers))
+- Maxence Thévenet ([@MaxThevenet](https://github.com/MaxThevenet))
+- Jean-Luc Vay ([@jlvay](https://github.com/jlvay))
+- Weiqun Zhang ([@WeiqunZhang](https://github.com/WeiqunZhang))
+- Edoardo Zoni ([@EZoni](https://github.com/EZoni))
 
 See: [GitHub team](https://github.com/orgs/BLAST-WarpX/teams/warpx-technical-committee)
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,37 +1,30 @@
-.. _governance:
-
-WarpX Governance
-================
+# WarpX Governance
 
 WarpX is led in an open governance model, described in this file.
 
 
-Steering Committee
-------------------
+## Steering Committee
 
-Current Roster
-^^^^^^^^^^^^^^
+### Current Roster
 
 - Jean-Luc Vay (chair)
 - Remi Lehe
 - Axel Huebl
 
-See: `GitHub team <https://github.com/orgs/BLAST-WarpX/teams/warpx-steering-committee>`__
+See: [GitHub team](https://github.com/orgs/BLAST-WarpX/teams/warpx-steering-committee)
 
-Role
-^^^^
+### Role
 
 Members of the steering committee (SC) can change organizational settings, do administrative operations such as rename/move/archive repositories, change branch protection rules, etc.
 SC members can call votes for decisions (technical or governance).
 
 The SC can veto decisions of the technical committee (TC) by voting in the SC.
 The TC can overwrite a veto with a 2/3rd majority vote in the TC.
-Decisions are documented in the `weekly developer meeting notes <https://docs.google.com/document/d/1eYD8EYCYDI0H7FhiiEuRUDJZ5pPDr6MUL-IibE-Pk50/edit>`__ and/or on the GitHub repository.
+Decisions are documented in the [weekly developer meeting notes](https://docs.google.com/document/d/1eYD8EYCYDI0H7FhiiEuRUDJZ5pPDr6MUL-IibE-Pk50/edit) and/or on the GitHub repository.
 
 The SC can change the governance structure, but only in a unanimous vote.
 
-Decision Process
-^^^^^^^^^^^^^^^^
+### Decision Process
 
 Decision of the SC usually happen in the weekly developer meetings, via e-mail or public chat.
 
@@ -39,8 +32,7 @@ Decisions are made in a non-confidential manner, by majority on the cast votes o
 Votes can be cast in asynchronous manner, e.g., over the time of 1-2 weeks.
 In tie situations, the chair of the SC acts as the tie breaker.
 
-Appointment Process
-^^^^^^^^^^^^^^^^^^^
+### Appointment Process
 
 Appointed by current SC members in an unanimous vote.
 As a SC member, regularly attending and contributing to the weekly developer meetings is expected.
@@ -48,11 +40,9 @@ As a SC member, regularly attending and contributing to the weekly developer mee
 SC members can resign or be removed by majority vote, e.g., due to inactivity, bad acting or other reasons.
 
 
-Technical Committee
--------------------
+## Technical Committee
 
-Current Roster
-^^^^^^^^^^^^^^
+### Current Roster
 
 - Justin Ray Angus
 - Luca Fedeli
@@ -68,10 +58,9 @@ Current Roster
 - Weiqun Zhang
 - Edoardo Zoni
 
-See: `GitHub team <https://github.com/orgs/BLAST-WarpX/teams/warpx-technical-committee>`__
+See: [GitHub team](https://github.com/orgs/BLAST-WarpX/teams/warpx-technical-committee)
 
-Role
-^^^^
+### Role
 
 The technical committee (TC) is the core governance body, where under normal operations most ideas are discussed and decisions are made.
 Individual TC members can approve and merge code changes.
@@ -81,20 +70,18 @@ TC members merge/close PRs and issues, and moderate (including block/mute) bad a
 The TC can propose governance changes to the SC.
 
 
-Decision Process
-^^^^^^^^^^^^^^^^
+### Decision Process
 
 Discussion in the TC usually happens in the weekly developer meetings.
 
 If someone calls for a vote to make a decision: majority based on the cast votes; we need 50% of the committee participating to vote. In the absence of a quorum, the SC will decide according to its voting rules.
 
 Votes are cast in a non-confidential manner.
-Decisions are documented in the `weekly developer meeting notes <https://docs.google.com/document/d/1eYD8EYCYDI0H7FhiiEuRUDJZ5pPDr6MUL-IibE-Pk50/edit>`__ and/or on the GitHub repository.
+Decisions are documented in the [weekly developer meeting notes](https://docs.google.com/document/d/1eYD8EYCYDI0H7FhiiEuRUDJZ5pPDr6MUL-IibE-Pk50/edit) and/or on the GitHub repository.
 
 TC members can individually appoint new contributors, unless a vote is called on an individual.
 
-Appointment Process
-^^^^^^^^^^^^^^^^^^^
+### Appointment Process
 
 TC members are the maintainers of WarpX.
 As a TC member, regularly attending and contributing to the weekly developer meetings is expected.
@@ -105,16 +92,13 @@ Steering committee members can also be TC members.
 TC members can resign or be removed by majority vote by either TC or SC, e.g., due to inactivity, bad acting or other reasons.
 
 
-Contributors
-------------
+## Contributors
 
-Current Roster
-^^^^^^^^^^^^^^
+### Current Roster
 
-See: `GitHub team <https://github.com/orgs/BLAST-WarpX/teams/warpx-contributors>`__
+See: [GitHub team](https://github.com/orgs/BLAST-WarpX/teams/warpx-contributors)
 
-Role
-^^^^
+### Role
 
 Contributors are valuable, vetted developers of WarpX.
 Contributions can be in many forms and not all need to be code contributions.
@@ -123,21 +107,18 @@ Contributors can participate in developer meetings and weigh in on discussions.
 Contributors can "triage" (add labels) to pull requests, issues, and GitHub discussion pages.
 Contributors can comment and review PRs (but not merge).
 
-Decision Process
-^^^^^^^^^^^^^^^^
+### Decision Process
 
 Contributors can individually decide on classification (triage) of pull requests, issues, and GitHub discussion pages.
 
-Appointment Process
-^^^^^^^^^^^^^^^^^^^
+### Appointment Process
 
 Appointed after contributing to WarpX (see above) by any member of the TC.
 
 The role can be lost by resigning or by decision of an individual TC or SC member, e.g., due to inactivity, bad acting or other.
 
 
-Former Members
---------------
+## Former Members
 
 "Former members" are the giants on whose shoulders we stand.
 But, for the purpose of WarpX governance, they are *not* tracked as a governance role in WarpX.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ We invite you to contribute to WarpX in any form following our [Code of Conduct]
 WarpX is hosted by the High Performance Software Foundation (HPSF).
 If your organization wants to help steer the evolution of the HPC software ecosystem, visit [hpsf.io](https://hpsf.io) and consider joining!
 
-The WarpX open governance model is described in [GOVERNANCE.rst](GOVERNANCE.rst).
+The WarpX open governance model is described in [GOVERNANCE.md](GOVERNANCE.md).
 
 ## Copyright Notice
 


### PR DESCRIPTION
LFX Insights identifies project maintainers exclusively from a fixed set of repository files (`GOVERNANCE.md`, `MAINTAINERS.md`, `CODEOWNERS`, etc.) and does not parse reStructuredText: https://insights.linuxfoundation.org/docs/introduction/maintainers/

As a result, the WarpX maintainer roster on
https://insights.linuxfoundation.org/project/warpx is incomplete.

Convert the governance document to (MyST) Markdown so it is picked up, keeping a single source of truth that is still rendered in the Sphinx manual via the established symlink approach
(`Docs/source/governance.md`).

Only content change be sides reformatting is to also add GitHub handles for unique discoverability.

Add `myst-parser` to the documentation dependencies and remove the unused, deprecated `recommonmark` package it supersedes. The `.. _governance:` anchor is dropped since nothing references it.

## After this PR

There are a few heuristics that LFX scans for on a weekly basis:
https://insights.linuxfoundation.org/docs/introduction/maintainers/#data-points-collected

If in 1-2 weeks the maintainer list in 
  https://insights.linuxfoundation.org/project/warpx
is still incomplete, we can seed in a few of the keywords listed in the link above into the [TC section](https://warpx.readthedocs.io/en/latest/governance.html#technical-committee).

## Sphinx

[Before](https://warpx.readthedocs.io/en/latest/governance.html) | [After](https://warpx--7115.org.readthedocs.build/en/7115/governance.html)

Should render near-identical besides the now-added GitHub handles.