### PR TITLE
Background collisions: evaluate parsers at Cartesian coordinates

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3018,12 +3018,18 @@ Details about the collision models can be found in the :ref:`theory section <mul
     is used for the background density, the input parameter ``<collision_name>.max_background_density``
     must also be provided to calculate the maximum collision probability.
 
+    The arguments ``x``, ``y`` and ``z`` are the Cartesian coordinates of the macroparticle, in every
+    geometry. In ``RZ``, ``RCYLINDER`` and ``RSPHERE`` geometry this means that the radius must be
+    written as ``sqrt(x**2+y**2)`` (``RZ``, ``RCYLINDER``) or ``sqrt(x**2+y**2+z**2)`` (``RSPHERE``),
+    and in 2D (``XZ``) geometry ``y`` is always 0.
+
 .. pp:param:: <collision_name>.background_temperature
     :type: ``float``
 
     Only for ``background_mcc`` and ``background_stopping``. The temperature of the background in Kelvin.
     Can also provide ``<collision_name>.background_temperature(x,y,z,t)`` using the parser
-    initialization style for spatially and temporally varying temperature.
+    initialization style for spatially and temporally varying temperature. The arguments follow the
+    same convention as for :pp:param:`<collision_name>.background_density`.
 
 .. pp:param:: <collision_name>.background_mass
     :type: ``float``

--- a/Source/Particles/Collision/BackgroundMCC/BackgroundMCCCollision.cpp
+++ b/Source/Particles/Collision/BackgroundMCC/BackgroundMCCCollision.cpp
@@ -339,9 +339,7 @@ void BackgroundMCCCollision::doBackgroundCollisionsWithinTile
                               if (amrex::Random(engine) > total_collision_prob) { return; }
 
                               // The background density and temperature parsers take Cartesian
-                              // coordinates as arguments, in all geometries. (In RZ, this
-                              // matches the convention used by the ionization functors in
-                              // ImpactIonization.H, which call `get_particle_position`.)
+                              // coordinates as arguments, in all geometries.
                               amrex::ParticleReal x, y, z;
                               GetPosition(ip, x, y, z);
 

--- a/Source/Particles/Collision/BackgroundMCC/BackgroundMCCCollision.cpp
+++ b/Source/Particles/Collision/BackgroundMCC/BackgroundMCCCollision.cpp
@@ -338,8 +338,12 @@ void BackgroundMCCCollision::doBackgroundCollisionsWithinTile
                               // determine if this particle should collide
                               if (amrex::Random(engine) > total_collision_prob) { return; }
 
+                              // The background density and temperature parsers take Cartesian
+                              // coordinates as arguments, in all geometries. (In RZ, this
+                              // matches the convention used by the ionization functors in
+                              // ImpactIonization.H, which call `get_particle_position`.)
                               amrex::ParticleReal x, y, z;
-                              GetPosition.AsStored(ip, x, y, z);
+                              GetPosition(ip, x, y, z);
 
                               const amrex::ParticleReal n_a = n_a_func(x, y, z, t);
                               const amrex::ParticleReal T_a = T_a_func(x, y, z, t);

--- a/Source/Particles/Collision/BackgroundStopping/BackgroundStopping.cpp
+++ b/Source/Particles/Collision/BackgroundStopping/BackgroundStopping.cpp
@@ -165,8 +165,10 @@ void BackgroundStopping::doBackgroundStoppingOnElectronsWithinTile (WarpXParIter
         [=] AMREX_GPU_HOST_DEVICE (long ip)
         {
 
+            // The background density and temperature parsers take Cartesian
+            // coordinates as arguments, in all geometries.
             amrex::ParticleReal x, y, z;
-            GetPosition.AsStored(ip, x, y, z);
+            GetPosition(ip, x, y, z);
             amrex::ParticleReal const n_e = n_e_func(x, y, z, t);
             amrex::ParticleReal const T_e = T_e_func(x, y, z, t)*PhysConst::kb;
 
@@ -240,8 +242,10 @@ void BackgroundStopping::doBackgroundStoppingOnIonsWithinTile (WarpXParIter& pti
         [=] AMREX_GPU_HOST_DEVICE (long ip)
         {
 
+            // The background density and temperature parsers take Cartesian
+            // coordinates as arguments, in all geometries.
             amrex::ParticleReal x, y, z;
-            GetPosition.AsStored(ip, x, y, z);
+            GetPosition(ip, x, y, z);
             amrex::ParticleReal const n_i = n_i_func(x, y, z, t);
             amrex::ParticleReal const T_i = T_i_func(x, y, z, t)*PhysConst::kb;
 


### PR DESCRIPTION
In the development branch, `background_mcc` and `background_stopping` evaluated the parsed `background_density(x,y,z,t)` and `background_temperature(x,y,z,t)` passing the stored coordinates (`(r, theta, z)` in RZ and RCYLINDER, `(r, theta, phi)` in RSPHERE) as `x`, `y`, `z`. This is probably not what the user expected, and is inconsistent with the conventions used e.g. for plasma initialization (`density_function(x, y, z)`) which always uses the Cartesian coordinates `x`, `y`, `z` of the particles even in RZ and RSPHERE. 

Instead, this PR uses the Cartesian coordinates everywhere and document it. Cartesian geometries are unaffected, since there `AsStored` and `operator()` are identical.