### PR TITLE
Add PICMI Particle EB Parameter to Grid Objects

### DIFF
--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -1261,7 +1261,7 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
     warpx_potential_hi_z: float, default=0.
        Electrostatic potential on the upper z boundary
 
-    warpx_particle_eb: string, default="Absorbing", optional
+    warpx_boundary_particle_eb: string, default="Absorbing", optional
        The boundary condition applied to the particles when they reach the surface
        of the embedded boundary. Absorbing, Reflecting, or None
 
@@ -1286,7 +1286,7 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
         self.blocking_factor_x = kw.pop("warpx_blocking_factor_x", None)
         self.blocking_factor_y = kw.pop("warpx_blocking_factor_y", None)
 
-        self.particle_eb = kw.pop("warpx_particle_eb", None)
+        self.particle_boundary_eb = kw.pop("warpx_boundary_particle_eb", None)
         self.potential_xmin = kw.pop("warpx_potential_lo_x", None)
         self.potential_xmax = kw.pop("warpx_potential_hi_x", None)
         self.potential_ymin = None
@@ -1320,7 +1320,7 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
         pywarpx.amr.blocking_factor_y = self.blocking_factor_y
 
         # Boundary conditions
-        pywarpx.boundary.particle_eb = self.particle_eb
+        pywarpx.boundary.particle_eb = self.particle_boundary_eb
         pywarpx.boundary.field_lo = [
             BC_map[bc] for bc in self.lower_boundary_conditions
         ]
@@ -1403,7 +1403,7 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
     warpx_potential_hi_z: float, default=0.
        Electrostatic potential on the upper z boundary
 
-    warpx_particle_eb: string, default="Absorbing", optional
+    warpx_boundary_particle_eb: string, default="Absorbing", optional
        The boundary condition applied to the particles when they reach the surface
        of the embedded boundary. Absorbing, Reflecting, or None
 
@@ -1430,7 +1430,7 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
         self.blocking_factor_y = kw.pop("warpx_blocking_factor_y", None)
         self.blocking_factor_z = kw.pop("warpx_blocking_factor_z", None)
 
-        self.particle_eb = kw.pop("warpx_particle_eb", None)
+        self.particle_boundary_eb = kw.pop("warpx_boundary_particle_eb", None)
         self.potential_xmin = kw.pop("warpx_potential_lo_x", None)
         self.potential_xmax = kw.pop("warpx_potential_hi_x", None)
         self.potential_ymin = kw.pop("warpx_potential_lo_y", None)
@@ -1466,7 +1466,7 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
         pywarpx.amr.blocking_factor_z = self.blocking_factor_z
 
         # Boundary conditions
-        pywarpx.boundary.particle_eb = self.particle_eb
+        pywarpx.boundary.particle_eb = self.particle_boundary_eb
         pywarpx.boundary.field_lo = [
             BC_map[bc] for bc in self.lower_boundary_conditions
         ]

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -1261,6 +1261,10 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
     warpx_potential_hi_z: float, default=0.
        Electrostatic potential on the upper z boundary
 
+    warpx_particle_eb: string, default="Absorbing", optional
+       The boundary condition applied to the particles when they reach the surface
+       of the embedded boundary. Absorbing, Reflecting, or Transparent
+
     warpx_start_moving_window_step: int, default=0
        The timestep at which the moving window starts
 
@@ -1282,6 +1286,7 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
         self.blocking_factor_x = kw.pop("warpx_blocking_factor_x", None)
         self.blocking_factor_y = kw.pop("warpx_blocking_factor_y", None)
 
+        self.particle_eb = kw.pop("warpx_particle_eb", None)
         self.potential_xmin = kw.pop("warpx_potential_lo_x", None)
         self.potential_xmax = kw.pop("warpx_potential_hi_x", None)
         self.potential_ymin = None
@@ -1315,6 +1320,7 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
         pywarpx.amr.blocking_factor_y = self.blocking_factor_y
 
         # Boundary conditions
+        pywarpx.boundary.particle_eb = self.particle_eb
         pywarpx.boundary.field_lo = [
             BC_map[bc] for bc in self.lower_boundary_conditions
         ]
@@ -1397,6 +1403,10 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
     warpx_potential_hi_z: float, default=0.
        Electrostatic potential on the upper z boundary
 
+    warpx_particle_eb: string, default="Absorbing", optional
+       The boundary condition applied to the particles when they reach the surface
+       of the embedded boundary. Absorbing, Reflecting, or Transparent
+
     warpx_start_moving_window_step: int, default=0
        The timestep at which the moving window starts
 
@@ -1420,6 +1430,7 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
         self.blocking_factor_y = kw.pop("warpx_blocking_factor_y", None)
         self.blocking_factor_z = kw.pop("warpx_blocking_factor_z", None)
 
+        self.particle_eb = kw.pop("warpx_particle_eb", None)
         self.potential_xmin = kw.pop("warpx_potential_lo_x", None)
         self.potential_xmax = kw.pop("warpx_potential_hi_x", None)
         self.potential_ymin = kw.pop("warpx_potential_lo_y", None)
@@ -1455,6 +1466,7 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
         pywarpx.amr.blocking_factor_z = self.blocking_factor_z
 
         # Boundary conditions
+        pywarpx.boundary.particle_eb = self.particle_eb
         pywarpx.boundary.field_lo = [
             BC_map[bc] for bc in self.lower_boundary_conditions
         ]

--- a/Python/pywarpx/picmi.py
+++ b/Python/pywarpx/picmi.py
@@ -1263,7 +1263,7 @@ class Cartesian2DGrid(picmistandard.PICMI_Cartesian2DGrid):
 
     warpx_particle_eb: string, default="Absorbing", optional
        The boundary condition applied to the particles when they reach the surface
-       of the embedded boundary. Absorbing, Reflecting, or Transparent
+       of the embedded boundary. Absorbing, Reflecting, or None
 
     warpx_start_moving_window_step: int, default=0
        The timestep at which the moving window starts
@@ -1405,7 +1405,7 @@ class Cartesian3DGrid(picmistandard.PICMI_Cartesian3DGrid):
 
     warpx_particle_eb: string, default="Absorbing", optional
        The boundary condition applied to the particles when they reach the surface
-       of the embedded boundary. Absorbing, Reflecting, or Transparent
+       of the embedded boundary. Absorbing, Reflecting, or None
 
     warpx_start_moving_window_step: int, default=0
        The timestep at which the moving window starts

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -1262,9 +1262,7 @@ void MultiParticleContainer::ScrapeParticlesAtEB (
             }
         }
     } else if(WarpX::eb_particle_boundary == ParticleBoundaryType::None) {
-        for (auto& pc : allcontainers) {
-            // scrapeParticlesAtEB(*pc, distance_to_eb, ParticleBoundaryProcess::NoOp()); # do nothing
-        }
+        // No particle scraping required for ParticleBoundaryType::None.
     } else {
         for (auto& pc : allcontainers) {
             scrapeParticlesAtEB(*pc, distance_to_eb, ParticleBoundaryProcess::Absorb());

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -1261,6 +1261,10 @@ void MultiParticleContainer::ScrapeParticlesAtEB (
                         dt_lev, mass, WarpX::eb_particle_boundary, uth});
             }
         }
+    } else if(WarpX::eb_particle_boundary == ParticleBoundaryType::None) {
+        for (auto& pc : allcontainers) {
+            scrapeParticlesAtEB(*pc, distance_to_eb, ParticleBoundaryProcess::NoOp());
+        }
     } else {
         for (auto& pc : allcontainers) {
             scrapeParticlesAtEB(*pc, distance_to_eb, ParticleBoundaryProcess::Absorb());

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -1263,7 +1263,7 @@ void MultiParticleContainer::ScrapeParticlesAtEB (
         }
     } else if(WarpX::eb_particle_boundary == ParticleBoundaryType::None) {
         for (auto& pc : allcontainers) {
-            scrapeParticlesAtEB(*pc, distance_to_eb, ParticleBoundaryProcess::NoOp());
+            // scrapeParticlesAtEB(*pc, distance_to_eb, ParticleBoundaryProcess::NoOp()); # do nothing
         }
     } else {
         for (auto& pc : allcontainers) {

--- a/Source/Particles/ParticleCreation/AddParticles.cpp
+++ b/Source/Particles/ParticleCreation/AddParticles.cpp
@@ -1213,7 +1213,7 @@ PhysicalParticleContainer::AddPlasma (PlasmaInjector& plasma_injector, int lev, 
 
     // Remove particles that are inside the embedded boundaries
 #ifdef AMREX_USE_EB
-    if (EB::enabled())
+    if (EB::enabled() && WarpX::eb_particle_boundary != ParticleBoundaryType::None)
     {
         using warpx::fields::FieldType;
         auto & warpx = WarpX::GetInstance();

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -339,7 +339,7 @@ WarpXParticleContainer::AddNParticles (int /*lev*/, long n,
 
     // Remove particles that are inside the embedded boundaries
 #ifdef AMREX_USE_EB
-    if (EB::enabled()) {
+    if (EB::enabled() && WarpX::eb_particle_boundary != ParticleBoundaryType::None) {
         auto & warpx = WarpX::GetInstance();
         scrapeParticlesAtEB(
             *this,

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -298,8 +298,9 @@ void WarpX::MakeWarpX ()
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             eb_particle_boundary == ParticleBoundaryType::Absorbing ||
             eb_particle_boundary == ParticleBoundaryType::Reflecting ||
-            eb_particle_boundary == ParticleBoundaryType::Thermal,
-            "boundary.particle_eb must be Absorbing, Reflecting, or Thermal");
+            eb_particle_boundary == ParticleBoundaryType::Thermal ||
+            eb_particle_boundary == ParticleBoundaryType::None,
+            "boundary.particle_eb must be Absorbing, Reflecting, Thermal, or None");
     }
 
     CheckGriddingForRZSpectral();


### PR DESCRIPTION
Currently there is no way to define the particle boundary condition on embedded boundaries in PICMI models. This PR adds a  `warpx_particle_eb` parameter to picmi.Cartesian2DGrid and picmi.Cartesian3DGrid objects. 

This PR also allows for a "None" option for transparent boundary conditions. This is useful for modeling transparent grids which have a potential, but particles can pass though. Because only one eb can be defined in WarpX, use of this option is limited to very specific problems. A mask or allowing for setting multiple particle embedded boundaries would be useful. The "None" string option might get confused with a None datatype; however the "None" string allows use of the already defined `ParticleBoundaryType::None`. A new `ParticleBoundaryType::Transparent` type would allow use of "Transparent" string option. 

Example below.
```
grid = picmi.Cartesian2DGrid(
    number_of_cells=[nx, nz],
    warpx_max_grid_size=64,
    lower_bound=[xmin, zmin],
    upper_bound=[xmax, zmax],
    bc_xmin="neumann",
    bc_xmax="neumann",
    bc_ymin="dirichlet",
    bc_ymax="dirichlet",
    lower_boundary_conditions_particles=["absorbing", "absorbing"],
    upper_boundary_conditions_particles=["absorbing", "absorbing"],
    warpx_potential_lo_z=0.0,
    warpx_potential_hi_z=0.0,
    warpx_particle_eb = "Absorbing"  # <-- THIS PARAMETER IS NEW
)
```

