### PR TITLE
C++20 : expand usage of container.contains() feature

### DIFF
--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -518,7 +518,7 @@ void ParticleBoundaryBuffer::gatherParticlesFromEmbeddedBoundaries (
                 for (PIter pti(pc, lev); pti.isValid(); ++pti) {
                     auto phiarr = (*distance_to_eb[lev])[pti].array();  // signed distance function
                     auto index = std::make_pair(pti.index(), pti.LocalTileIndex());
-                    if (plevel.find(index) == plevel.end()) { continue; }
+                    if (!plevel.contains(index)) { continue; }
 
                     const auto getPosition = GetParticlePosition<PIdx>(pti);
                     auto &ptile_buffer = species_buffer.DefineAndReturnParticleTile(lev, pti.index(),

--- a/Source/ablastr/utils/msg_logger/MsgLogger.cpp
+++ b/Source/ablastr/utils/msg_logger/MsgLogger.cpp
@@ -423,7 +423,7 @@ Logger::compute_msgs_with_counter_and_ranks(
             #pragma omp critical
 #endif
             {
-                if (tmap.find(msg_with_counter.msg) == tmap.end()){
+                if (!tmap.contains(msg_with_counter.msg)){
                     const auto msg_with_counter_and_ranks =
                         MsgWithCounterAndRanks{
                             msg_with_counter,


### PR DESCRIPTION
We are already using the nice C++20 feature `container.contains()`  (see https://github.com/BLAST-WarpX/warpx/pull/6885), and we are enforcing its usage with `clang-tidy`. However `clang-tidy` v 19 has some [false negatives](https://releases.llvm.org/20.1.0/tools/clang/tools/extra/docs/ReleaseNotes.html#changes-in-existing-checks). 

I've run `clang-tidy` v21 on my machine, and this PR fixes the two additional issues found by this newer version.