### PR TITLE
C++20 : introduce std::ranges in TextMsg.cpp and MsgLogger.cpp

### DIFF
--- a/Source/ablastr/utils/TextMsg.cpp
+++ b/Source/ablastr/utils/TextMsg.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <ranges>
 #include <sstream>
 #include <vector>
 
@@ -42,7 +43,7 @@ namespace
 
         std::stringstream ss_out;
 
-        std::for_each(std::begin(wrapped_text), std::end(wrapped_text),
+        std::ranges::for_each (wrapped_text,
             [&,ln=0](const auto& line) mutable {
                 ss_out << ((ln++ == 0) ? msg_prefix : msg_line_prefix);
                 ss_out << line << "\n";

--- a/Source/ablastr/utils/msg_logger/MsgLogger.cpp
+++ b/Source/ablastr/utils/msg_logger/MsgLogger.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <array>
 #include <numeric>
+#include <ranges>
 
 namespace abl_msg_logger = ablastr::utils::msg_logger;
 namespace abl_ser = ablastr::utils::serialization;

--- a/Source/ablastr/utils/msg_logger/MsgLogger.cpp
+++ b/Source/ablastr/utils/msg_logger/MsgLogger.cpp
@@ -337,7 +337,7 @@ std::pair<int,int> Logger::find_gather_rank_and_its_msgs(int how_many_msgs) cons
 
     const auto m_am_i_io = (m_rank == m_io_rank);
     if (m_am_i_io){
-        const auto it_max = std::max_element(num_msg.begin(), num_msg.end());
+        const auto it_max = std::ranges::max_element(num_msg);
         max_items = *it_max;
 
         //In case of an "ex aequo" the I/O rank should be the gather rank
@@ -460,7 +460,7 @@ Logger::compute_msgs_with_counter_and_ranks(
 
     // Sort affected ranks lists
     for(auto& el : msgs_with_counter_and_ranks){
-        std::sort(el.ranks.begin(), el.ranks.end());
+        std::ranges::sort(el.ranks);
     }
 
     return msgs_with_counter_and_ranks;


### PR DESCRIPTION
Ranges are a new way of expressing (composable) transformations on a collection of data in C++20.

Their use is currently **not enforced** in AMReX, as [older versions of the clang compilers have some bugs with some use-cases of ranges](https://github.com/AMReX-Codes/amrex/blob/09dcef899fc3cf290e284516a5a3d2e59ee98095/CONTRIBUTING.md?plain=1#L253).

This PR is intended as a first, limited, test to see if we can use `ranges` in WarpX. Therefore, only two files are affected.

The PR simply replaces some rather convoluted expressions with their `ranges`-based equivalent. 
For instance : 
```
const auto it_max = std::max_element(num_msg.begin(), num_msg.end());
```
becomes
```
const auto it_max = std::ranges::max_element(num_msg);
```

If no issues are observed related to this small change, expanding the usage of ranges in WarpX can be considered. Otherwise, the change can be simply reverted.