### PR TITLE
Shape factors cleanup: remove superfluous parenthesis, avoid unneeded division

### DIFF
--- a/Source/Particles/ShapeFactors.H
+++ b/Source/Particles/ShapeFactors.H
@@ -57,10 +57,10 @@ struct Compute_shape_factor
         else if constexpr (depos_order == 3){
             const auto j = static_cast<int>(xmid);
             const T xint = xmid - T(j);
-            sx[0] = T(1.0)/T(6.0)*(T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - xint);
-            sx[1] = T(2.0)/T(3.0) - xint*xint*(T(1.0) - T(0.5)*xint);
-            sx[2] = T(2.0)/T(3.0) - (T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - T(0.5)*(T(1.0) - xint));
-            sx[3] = T(1.0)/T(6.0)*xint*xint*xint;
+            sx[0] = T(1.0/6.0)*(T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - xint);
+            sx[1] = T(2.0/3.0) - xint*xint*(T(1.0) - T(0.5)*xint);
+            sx[2] = T(2.0/3.0) - (T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - T(0.5)*(T(1.0) - xint));
+            sx[3] = T(1.0/6.0)*xint*xint*xint;
             // index of the leftmost cell where particle deposits
             return j-1;
         }

--- a/Source/Particles/ShapeFactors.H
+++ b/Source/Particles/ShapeFactors.H
@@ -67,11 +67,11 @@ struct Compute_shape_factor
         else if constexpr (depos_order == 4){
             const auto j = static_cast<int>(xmid + T(0.5));
             const T xint = xmid - T(j);
-            sx[0] = T(1.0)/T(24.0)*(T(0.5) - xint)*(T(0.5) - xint)*(T(0.5) - xint)*(T(0.5) - xint);
-            sx[1] = T(1.0)/T(24.0)*(T(4.75) - T(11.0)*xint + T(4.0)*xint*xint*(T(1.5) + xint - xint*xint));
-            sx[2] = T(1.0)/T(24.0)*(T(14.375) + T(6.0)*xint*xint*(xint*xint - T(2.5)));
-            sx[3] = T(1.0)/T(24.0)*(T(4.75) + T(11.0)*xint + T(4.0)*xint*xint*(T(1.5) - xint - xint*xint));
-            sx[4] = T(1.0)/T(24.0)*(T(0.5) + xint)*(T(0.5) + xint)*(T(0.5) + xint)*(T(0.5)+xint);
+            sx[0] = T(1.0/24.0)*(T(0.5) - xint)*(T(0.5) - xint)*(T(0.5) - xint)*(T(0.5) - xint);
+            sx[1] = T(1.0/24.0)*(T(4.75) - T(11.0)*xint + T(4.0)*xint*xint*(T(1.5) + xint - xint*xint));
+            sx[2] = T(1.0/24.0)*(T(14.375) + T(6.0)*xint*xint*(xint*xint - T(2.5)));
+            sx[3] = T(1.0/24.0)*(T(4.75) + T(11.0)*xint + T(4.0)*xint*xint*(T(1.5) - xint - xint*xint));
+            sx[4] = T(1.0/24.0)*(T(0.5) + xint)*(T(0.5) + xint)*(T(0.5) + xint)*(T(0.5)+xint);
             // index of the leftmost cell where particle deposits
             return j-2;
         }

--- a/Source/Particles/ShapeFactors.H
+++ b/Source/Particles/ShapeFactors.H
@@ -57,21 +57,21 @@ struct Compute_shape_factor
         else if constexpr (depos_order == 3){
             const auto j = static_cast<int>(xmid);
             const T xint = xmid - T(j);
-            sx[0] = (T(1.0))/(T(6.0))*(T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - xint);
-            sx[1] = (T(2.0))/(T(3.0)) - xint*xint*(T(1.0) - xint/(T(2.0)));
-            sx[2] = (T(2.0))/(T(3.0)) - (T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - T(0.5)*(T(1.0) - xint));
-            sx[3] = (T(1.0))/(T(6.0))*xint*xint*xint;
+            sx[0] = T(1.0)/T(6.0)*(T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - xint);
+            sx[1] = T(2.0)/T(3.0) - xint*xint*(T(1.0) - T(0.5)*xint);
+            sx[2] = T(2.0)/T(3.0) - (T(1.0) - xint)*(T(1.0) - xint)*(T(1.0) - T(0.5)*(T(1.0) - xint));
+            sx[3] = T(1.0)/T(6.0)*xint*xint*xint;
             // index of the leftmost cell where particle deposits
             return j-1;
         }
         else if constexpr (depos_order == 4){
             const auto j = static_cast<int>(xmid + T(0.5));
             const T xint = xmid - T(j);
-            sx[0] = (T(1.0))/(T(24.0))*(T(0.5) - xint)*(T(0.5) - xint)*(T(0.5) - xint)*(T(0.5) - xint);
-            sx[1] = (T(1.0))/(T(24.0))*(T(4.75) - T(11.0)*xint + T(4.0)*xint*xint*(T(1.5) + xint - xint*xint));
-            sx[2] = (T(1.0))/(T(24.0))*(T(14.375) + T(6.0)*xint*xint*(xint*xint - T(2.5)));
-            sx[3] = (T(1.0))/(T(24.0))*(T(4.75) + T(11.0)*xint + T(4.0)*xint*xint*(T(1.5) - xint - xint*xint));
-            sx[4] = (T(1.0))/(T(24.0))*(T(0.5) + xint)*(T(0.5) + xint)*(T(0.5) + xint)*(T(0.5)+xint);
+            sx[0] = T(1.0)/T(24.0)*(T(0.5) - xint)*(T(0.5) - xint)*(T(0.5) - xint)*(T(0.5) - xint);
+            sx[1] = T(1.0)/T(24.0)*(T(4.75) - T(11.0)*xint + T(4.0)*xint*xint*(T(1.5) + xint - xint*xint));
+            sx[2] = T(1.0)/T(24.0)*(T(14.375) + T(6.0)*xint*xint*(xint*xint - T(2.5)));
+            sx[3] = T(1.0)/T(24.0)*(T(4.75) + T(11.0)*xint + T(4.0)*xint*xint*(T(1.5) - xint - xint*xint));
+            sx[4] = T(1.0)/T(24.0)*(T(0.5) + xint)*(T(0.5) + xint)*(T(0.5) + xint)*(T(0.5)+xint);
             // index of the leftmost cell where particle deposits
             return j-2;
         }


### PR DESCRIPTION
This is a pure-cleanup PR. It slightly simplifies the code for the shape factors and makes it a bit more readable.