### PR TITLE
clang-tidy CI test: bump version of clang from 19 to 20

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -49,6 +49,7 @@ Checks: '
     performance-*,
         -performance-enum-size,
     portability-*,
+        -portability-template-virtual-member-function,
     readability-*,
         -readability-avoid-nested-conditional-operator,
         -readability-convert-member-functions-to-static,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -34,6 +34,7 @@ Checks: '
         -misc-no-recursion,
         -misc-non-private-member-variables-in-classes,
         -misc-include-cleaner,
+        -misc-redundant-expression,
         -misc-use-internal-linkage,
     modernize-*,
         -modernize-avoid-c-arrays,
@@ -93,6 +94,7 @@ HeaderFilterRegex: 'Source[a-z_A-Z0-9\/]+\.H$'
 
 # TODO Consider enabling the following checks:
 # -bugprone-unused-local-non-trivial-variable
+# -misc-redundant-expression
 # -misc-use-internal-linkage
 # -performance-enum-size
 # -readability-container-contains

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -32,7 +32,7 @@ jobs:
     - name: install dependencies
       if: ${{ needs.check_changes.outputs.has_non_docs_changes == 'true' }}
       run: |
-        .github/workflows/dependencies/clang.sh 19
+        .github/workflows/dependencies/clang.sh 20
     - name: set up cache
       if: ${{ needs.check_changes.outputs.has_non_docs_changes == 'true' }}
       uses: actions/cache@v6
@@ -50,8 +50,8 @@ jobs:
         export CCACHE_EXTRAFILES=${{ github.workspace }}/.clang-tidy
         export CCACHE_LOGFILE=${{ github.workspace }}/ccache.log.txt
         ccache -z
-        export CXX=$(which clang++-19)
-        export CC=$(which clang-19)
+        export CXX=$(which clang++-20)
+        export CC=$(which clang-20)
 
         ##### FOR DEBUG ONLY: CLEAR CACHE ######################
         # clearing the cache forces running clang-tidy on all
@@ -74,7 +74,7 @@ jobs:
         cmake --build build_clang_tidy -j 4
         ${{github.workspace}}/.github/workflows/source/makeMakefileForClangTidy.py --input ${{github.workspace}}/ccache.log.txt
         make -j4 --keep-going -f clang-tidy-ccache-misses.mak \
-            CLANG_TIDY=clang-tidy-19 \
+            CLANG_TIDY=clang-tidy-20 \
             CLANG_TIDY_ARGS="--config-file=${{github.workspace}}/.clang-tidy --warnings-as-errors=*"
         ccache -s
         du -hs ~/.cache/ccache

--- a/Docs/source/developers/how_to_run_clang_tidy.rst
+++ b/Docs/source/developers/how_to_run_clang_tidy.rst
@@ -36,7 +36,7 @@ Few optional environment variables can be set to tune the behavior of the script
 
 * ``CLANG``, ``CLANGXX``, and ``CLANGTIDY``: set the version of the compiler and the linter.
 
-For continuous integration we currently use clang version 19 and it is recommended to use this version locally as well.
+For continuous integration we currently use clang version 20 and it is recommended to use this version locally as well.
 A newer version may find issues not currently covered by CI tests (checks are opt-in), while older versions may not find all the issues.
 
 Here's an example of how to run the script after setting the appropriate environment variables:
@@ -44,8 +44,8 @@ Here's an example of how to run the script after setting the appropriate environ
 .. code-block:: bash
 
    export WARPX_TOOLS_LINTER_PARALLEL=12
-   export CLANG=clang-19
-   export CLANGXX=clang++-19
-   export CLANGTIDY=clang-tidy-19
+   export CLANG=clang-20
+   export CLANGXX=clang++-20
+   export CLANGTIDY=clang-tidy-20
 
    ./Tools/Linter/runClangTidy.sh

--- a/Source/Diagnostics/WarpXOpenPMD.cpp
+++ b/Source/Diagnostics/WarpXOpenPMD.cpp
@@ -365,7 +365,7 @@ namespace detail
                                           {openPMD::UnitDimension::L, -2},
                                           {openPMD::UnitDimension::I,  1},
                                   });
-        } else if (field_name.substr(0,3) == "rho"){ // charge density
+        } else if (field_name.starts_with("rho")){ // charge density
             mesh.setUnitDimension({
                                           {openPMD::UnitDimension::L, -3},
                                           {openPMD::UnitDimension::I,  1},

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -518,7 +518,7 @@ void ParticleBoundaryBuffer::gatherParticlesFromEmbeddedBoundaries (
                 for (PIter pti(pc, lev); pti.isValid(); ++pti) {
                     auto phiarr = (*distance_to_eb[lev])[pti].array();  // signed distance function
                     auto index = std::make_pair(pti.index(), pti.LocalTileIndex());
-                    if (plevel.find(index) == plevel.end()) { continue; }
+                    if (!plevel.contains(index)) { continue; }
 
                     const auto getPosition = GetParticlePosition<PIdx>(pti);
                     auto &ptile_buffer = species_buffer.DefineAndReturnParticleTile(lev, pti.index(),

--- a/Source/ablastr/utils/msg_logger/MsgLogger.cpp
+++ b/Source/ablastr/utils/msg_logger/MsgLogger.cpp
@@ -423,7 +423,7 @@ Logger::compute_msgs_with_counter_and_ranks(
             #pragma omp critical
 #endif
             {
-                if (tmap.find(msg_with_counter.msg) == tmap.end()){
+                if (!tmap.contains(msg_with_counter.msg)){
                     const auto msg_with_counter_and_ranks =
                         MsgWithCounterAndRanks{
                             msg_with_counter,

--- a/Tools/Linter/runClangTidy.sh
+++ b/Tools/Linter/runClangTidy.sh
@@ -55,13 +55,13 @@ ${CTIDY} --version
 echo
 echo "This can be overridden by setting the environment"
 echo "variables CLANG, CLANGXX, and CLANGTIDY e.g.: "
-echo "$ export CLANG=clang-19"
-echo "$ export CLANGXX=clang++-19"
-echo "$ export CLANGTIDY=clang-tidy-19"
+echo "$ export CLANG=clang-20"
+echo "$ export CLANGXX=clang++-20"
+echo "$ export CLANGTIDY=clang-tidy-20"
 echo "$ ./Tools/Linter/runClangTidy.sh"
 echo
 echo "******************************************************"
-echo "* Warning: clang v19 is currently used in CI tests.  *"
+echo "* Warning: clang v20 is currently used in CI tests.  *"
 echo "* It is therefore recommended to use this version.   *"
 echo "* Otherwise, a newer version may find issues not     *"
 echo "* currently covered by CI tests while older versions *"


### PR DESCRIPTION
⚠️ This PR depends on https://github.com/BLAST-WarpX/warpx/pull/7134 ⚠️

This PR bumps the version of `clang` used for `clang-tidy` CI tests from 19 to 20. It also updates tools and documentation accordingly.

The PR excludes the following new `clang-tidy` check (AMReX does [the same](https://github.com/AMReX-Codes/amrex/blob/development/.clang-tidy)):
- ❌ [portability-template-virtual-member-function](https://releases.llvm.org/20.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/portability/template-virtual-member-function.html)

The PR also excludes this other `clang-tidy`  check (which has been improved in `clang-tidy`  v20) : 
- ❌⚠️ [misc-redundant-expression](https://releases.llvm.org/20.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/misc/redundant-expression.html)
Having this check enabled is probably desirable, but addressing the issues found by the improved check is better suited for a separate PR. Therefore, it has been added to the TODO list in the `.clang-tidy` configuration file.

These new `clang-tidy` checks are enabled by default (`clang-tidy` does not find any related issue):
- ✅ [bugprone-bitwise-pointer-cast](https://releases.llvm.org/20.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/bugprone/bitwise-pointer-cast.html)
- ✅ [bugprone-incorrect-enable-shared-from-this](https://releases.llvm.org/20.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/bugprone/incorrect-enable-shared-from-this.html)
- ✅ [bugprone-nondeterministic-pointer-iteration-order](https://releases.llvm.org/20.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/bugprone/nondeterministic-pointer-iteration-order.html)
- ✅  [bugprone-tagged-union-member-count](https://releases.llvm.org/20.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/bugprone/tagged-union-member-count.html)
- ✅ [modernize-use-integer-sign-comparison](https://releases.llvm.org/20.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize/use-integer-sign-comparison.html)

Finally, the PR fixes a new issue found by the already enabled 🔍 [modernize-use-starts-ends-with](https://releases.llvm.org/20.1.0/tools/clang/tools/extra/docs/clang-tidy/checks/modernize/use-starts-ends-with.html) check (which has been improved in v20 of `clang-tidy`).

