### PR TITLE
QEDInternals: use designated initializers (C++20) to clarify the initialization of some structures

### DIFF
--- a/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.cpp
+++ b/Source/Particles/ElementaryProcess/QEDInternals/BreitWheelerEngineWrapper.cpp
@@ -131,8 +131,10 @@ BreitWheelerEngine::get_default_ctrl() const
 {
     namespace pxr_bw = picsar::multi_physics::phys::breit_wheeler;
     return PicsarBreitWheelerCtrl{
-        pxr_bw::default_dndt_lookup_table_params<amrex::ParticleReal>,
-        pxr_bw::default_pair_prod_lookup_table_params<amrex::ParticleReal>
+        .dndt_params =
+            pxr_bw::default_dndt_lookup_table_params<amrex::ParticleReal>,
+        .pair_prod_params =
+            pxr_bw::default_pair_prod_lookup_table_params<amrex::ParticleReal>
     };
 }
 

--- a/Source/Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper.cpp
+++ b/Source/Particles/ElementaryProcess/QEDInternals/QuantumSyncEngineWrapper.cpp
@@ -130,8 +130,10 @@ QuantumSynchrotronEngine::get_default_ctrl() const
 {
     namespace pxr_qs = picsar::multi_physics::phys::quantum_sync;
     return PicsarQuantumSyncCtrl{
-        pxr_qs::default_dndt_lookup_table_params<amrex::ParticleReal>,
-        pxr_qs::default_photon_emission_lookup_table_params<amrex::ParticleReal>
+        .dndt_params =
+            pxr_qs::default_dndt_lookup_table_params<amrex::ParticleReal>,
+        .phot_em_params =
+            pxr_qs::default_photon_emission_lookup_table_params<amrex::ParticleReal>
     };
 }
 


### PR DESCRIPTION
Designated initializers are a C++20 feature that can clarify the initialization of a `struct`, e.g. : 

```cpp
auto foo = MyStruct{1, 2, "hello"};
```
becomes
```cpp
auto foo = MyStruct{ .start = 1, .end = 2, .name = "hello"};
```

This PR uses this new feature in two cases in `QEDInternals`.