### PR TITLE
Small refactor in hybrid-PIC Te calculation to reduce code duplication

### DIFF
--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H
@@ -195,13 +195,20 @@ public:
     /**
      * \brief Fill the electron pressure multifab given the kinetic particle
      * charge density (and assumption of quasi-neutrality) using the user
-     * specified electron equation of state.
+     * specified electron equation of state. The closure's electron temperature,
+     * T_e = T0 (n_e/n0)^(gamma-1), is filled at the same time (P_e = n_e T_e
+     * is formed from it). That T_e is diagnostic-only on this path: with
+     * solve_electron_energy_equation on, this function is not called and
+     * T_e is owned by the QDSMC entropy transport, which fills Te/Pe at
+     * this same point in the field loop.
      *
      * \param[out] Pe_field scalar electron pressure MultiFab at a given level
+     * \param[out] Te_field scalar electron temperature MultiFab (in Kelvin) at a given level
      * \param[in] rho_field scalar ion charge density Multifab at a given level
      */
     void FillElectronPressureMF (
         amrex::MultiFab& Pe_field,
+        amrex::MultiFab& Te_field,
         amrex::MultiFab const& rho_field ) const;
 
     /**
@@ -508,12 +515,24 @@ public:
  */
 struct ElectronPressure {
 
+    /** Electron temperature implied by the polytropic closure,
+     *  T_e = T0 (n_e/n0)^(gamma-1), returned in the units of T0. */
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    static amrex::Real get_temperature (amrex::Real const n0,
+                                        amrex::Real const T0,
+                                        amrex::Real const gamma,
+                                        amrex::Real const ne) {
+        return T0 * std::pow(ne/n0, gamma - amrex::Real(1.0));
+    }
+
+    /** Electron pressure P_e = n_e T_e = n0 T0 (n_e/n0)^gamma, in the units
+     *  of n0 T0. */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     static amrex::Real get_pressure (amrex::Real const n0,
                                      amrex::Real const T0,
                                      amrex::Real const gamma,
-                                     amrex::Real const rho) {
-        return n0 * T0 * std::pow((rho/PhysConst::q_e)/n0, gamma);
+                                     amrex::Real const ne) {
+        return ne * get_temperature(n0, T0, gamma, ne);
     }
 };
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H
@@ -507,33 +507,4 @@ public:
     std::unique_ptr<QdsmcParticleContainer> m_qdsmc_pc;
 };
 
-/**
- * \brief
- * This struct contains only static functions to compute the electron pressure
- * using the particle density at a given point and the user provided reference
- * density and temperatures.
- */
-struct ElectronPressure {
-
-    /** Electron temperature implied by the polytropic closure,
-     *  T_e = T0 (n_e/n0)^(gamma-1), returned in the units of T0. */
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    static amrex::Real get_temperature (amrex::Real const n0,
-                                        amrex::Real const T0,
-                                        amrex::Real const gamma,
-                                        amrex::Real const ne) {
-        return T0 * std::pow(ne/n0, gamma - amrex::Real(1.0));
-    }
-
-    /** Electron pressure P_e = n_e T_e = n0 T0 (n_e/n0)^gamma, in the units
-     *  of n0 T0. */
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    static amrex::Real get_pressure (amrex::Real const n0,
-                                     amrex::Real const T0,
-                                     amrex::Real const gamma,
-                                     amrex::Real const ne) {
-        return ne * get_temperature(n0, T0, gamma, ne);
-    }
-};
-
 #endif // WARPX_HYBRIDPICMODEL_H_

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -604,7 +604,7 @@ void HybridPICModel::FillElectronPressureMF (
 {
     const auto n0_ref = m_n0_ref;
     const auto elec_temp = m_elec_temp;
-    const auto gamma = m_gamma;
+    const auto gamma_minus_1 = m_gamma - 1.0_rt;
 
     // Loop through the grids, and over the tiles within each grid
 #ifdef AMREX_USE_OMP
@@ -621,13 +621,11 @@ void HybridPICModel::FillElectronPressureMF (
         const Box& tilebox  = mfi.tilebox();
 
         ParallelFor(tilebox, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-            // The closure gives the electron temperature in Joules (the units
-            // of elec_temp); P_e = n_e T_e follows from it, but the "Te"
-            // diagnostic wants Kelvin.
+            // Polytropic closure: T_e = T0 (n_e/n0)^(gamma-1), in the units of
+            // elec_temp (Joules), with P_e = n_e T_e following from it. The
+            // "Te" diagnostic wants Kelvin.
             const Real ne = rho(i, j, k) / PhysConst::q_e;
-            const Real Te_joule = ElectronPressure::get_temperature(
-                n0_ref, elec_temp, gamma, ne
-            );
+            const Real Te_joule = elec_temp * std::pow(ne/n0_ref, gamma_minus_1);
             Pe(i, j, k) = ne * Te_joule;
             Te(i, j, k) = Te_joule / PhysConst::kb;
         });

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -577,44 +577,17 @@ void HybridPICModel::CalculateElectronPressure(const int lev) const
     ABLASTR_PROFILE("WarpX::CalculateElectronPressure()");
 
     auto& warpx = WarpX::GetInstance();
+    ablastr::fields::ScalarField electron_temperature_fp = warpx.m_fields.get(FieldType::hybrid_electron_temperature_fp, lev);
     ablastr::fields::ScalarField electron_pressure_fp = warpx.m_fields.get(FieldType::hybrid_electron_pressure_fp, lev);
     ablastr::fields::ScalarField rho_fp = warpx.m_fields.get(FieldType::rho_fp, lev);
 
-    // Calculate the electron pressure using rho^{n+1}.
+    // Calculate the electron pressure (and its implied temperature) using rho^{n+1}.
     FillElectronPressureMF(
         *electron_pressure_fp,
+        *electron_temperature_fp,
         *rho_fp
     );
     warpx.ApplyElectronPressureBoundary(lev, PatchType::fine);
-
-    // Mirror the closure's implied electron temperature,
-    // T_e = P_e / (n_e k_B), into hybrid_electron_temperature_fp so the "Te"
-    // diagnostic is meaningful. Diagnostic-only on this path: with
-    // solve_electron_energy_equation on, this function is not called and
-    // T_e is owned by the QDSMC entropy transport, which fills Te/Pe at
-    // this same point in the field loop.
-    {
-        amrex::MultiFab       & Te  = *warpx.m_fields.get(FieldType::hybrid_electron_temperature_fp, lev);
-        amrex::MultiFab const & Pe  = *electron_pressure_fp;
-        amrex::MultiFab const & rho = *rho_fp;
-        auto const rho_floor = PhysConst::q_e * m_n_floor;
-#ifdef AMREX_USE_OMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-        for (amrex::MFIter mfi(Te, TilingIfNotGPU()); mfi.isValid(); ++mfi)
-        {
-            amrex::Array4<amrex::Real>       const & Te_arr  = Te.array(mfi);
-            amrex::Array4<amrex::Real const> const & Pe_arr  = Pe.const_array(mfi);
-            amrex::Array4<amrex::Real const> const & rho_arr = rho.const_array(mfi);
-            amrex::Box const & tbox = mfi.tilebox();
-            amrex::ParallelFor(tbox, [=] AMREX_GPU_DEVICE (int i, int j, int k)
-            {
-                amrex::Real const rho_val = std::max(rho_arr(i,j,k), rho_floor);
-                amrex::Real const ne      = rho_val / PhysConst::q_e;
-                Te_arr(i,j,k) = Pe_arr(i,j,k) / (ne * PhysConst::kb);
-            });
-        }
-    }
 
     ablastr::utils::communication::FillBoundary(
         *electron_pressure_fp,
@@ -625,6 +598,7 @@ void HybridPICModel::CalculateElectronPressure(const int lev) const
 
 void HybridPICModel::FillElectronPressureMF (
     amrex::MultiFab& Pe_field,
+    amrex::MultiFab& Te_field,
     amrex::MultiFab const& rho_field
 ) const
 {
@@ -640,15 +614,22 @@ void HybridPICModel::FillElectronPressureMF (
     {
         // Extract field data for this grid/tile
         Array4<Real const> const& rho = rho_field.const_array(mfi);
+        Array4<Real> const& Te = Te_field.array(mfi);
         Array4<Real> const& Pe = Pe_field.array(mfi);
 
         // Extract tileboxes for which to loop
         const Box& tilebox  = mfi.tilebox();
 
         ParallelFor(tilebox, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-            Pe(i, j, k) = ElectronPressure::get_pressure(
-                n0_ref, elec_temp, gamma, rho(i, j, k)
+            // The closure gives the electron temperature in Joules (the units
+            // of elec_temp); P_e = n_e T_e follows from it, but the "Te"
+            // diagnostic wants Kelvin.
+            const Real ne = rho(i, j, k) / PhysConst::q_e;
+            const Real Te_joule = ElectronPressure::get_temperature(
+                n0_ref, elec_temp, gamma, ne
             );
+            Pe(i, j, k) = ne * Te_joule;
+            Te(i, j, k) = Te_joule / PhysConst::kb;
         });
     }
 }


### PR DESCRIPTION
I noticed while reviewing #7128 that there is opportunity for code simplification / reduction in the current Te calculation in the hybrid-PIC scheme.