### PR TITLE
Python: Fix WarpX Singleton Lifetime and Leaking Statics

### DIFF
--- a/Python/pywarpx/_libwarpx.py
+++ b/Python/pywarpx/_libwarpx.py
@@ -172,9 +172,12 @@ class LibWarpX:
         """
         # TODO: simplify, part of pyAMReX already
         if self.initialized:
+            self.initialized = False
             del self.warpx
-            # The call to warpx_finalize causes a crash - don't know why
-            # self.libwarpx_so.warpx_finalize()
+            # Destroy the C++ WarpX singleton (and everything it owns) before
+            # tearing down AMReX, so that its MultiFabs are freed while the
+            # Arena that allocated them still exists.
+            self.libwarpx_so.finalize()
             self.libwarpx_so.amrex_finalize()
 
             from pywarpx import callbacks

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -545,6 +545,15 @@ private:
 
     void ReadParameters ();
 
+    /** Guards ReadParameters against running twice for this instance.
+     *
+     * This is deliberately a member and not a function-local static: with the
+     * Python bindings, several WarpX instances can be created and destroyed in
+     * one process, and a process-lifetime flag would leave species_names empty
+     * for every instance after the first.
+     */
+    bool m_params_initialized = false;
+
     void mapSpeciesProduct ();
 
     bool m_do_back_transformed_particles = false;

--- a/Source/Particles/MultiParticleContainer.H
+++ b/Source/Particles/MultiParticleContainer.H
@@ -546,11 +546,6 @@ private:
     void ReadParameters ();
 
     /** Guards ReadParameters against running twice for this instance.
-     *
-     * This is deliberately a member and not a function-local static: with the
-     * Python bindings, several WarpX instances can be created and destroyed in
-     * one process, and a process-lifetime flag would leave species_names empty
-     * for every instance after the first.
      */
     bool m_params_initialized = false;
 

--- a/Source/Particles/MultiParticleContainer.cpp
+++ b/Source/Particles/MultiParticleContainer.cpp
@@ -129,8 +129,7 @@ MultiParticleContainer::MultiParticleContainer (AmrCore* amr_core)
 void
 MultiParticleContainer::ReadParameters ()
 {
-    static bool initialized = false;
-    if (!initialized)
+    if (!m_params_initialized)
     {
         const ParmParse pp_particles("particles");
 
@@ -398,7 +397,7 @@ MultiParticleContainer::ReadParameters ()
                 pp_qed_schwinger, "zmax", m_qed_schwinger_zmax);
         }
 #endif
-        initialized = true;
+        m_params_initialized = true;
     }
 }
 

--- a/Source/Particles/ParticleBoundaryBuffer.H
+++ b/Source/Particles/ParticleBoundaryBuffer.H
@@ -82,6 +82,14 @@ private:
     std::vector<std::string> m_boundary_names;
 
     mutable std::vector<std::string> m_species_names;
+    /** Guards the lazy read of m_species_names for this instance.
+     *
+     * This is deliberately a member and not a function-local static: with the
+     * Python bindings, several WarpX instances can be created and destroyed in
+     * one process, and a process-lifetime flag would leave m_species_names
+     * empty for every instance after the first.
+     */
+    mutable bool m_species_names_initialized = false;
 };
 
 #endif /*WARPX_PARTICLEBOUNDARYBUFFER_H_*/

--- a/Source/Particles/ParticleBoundaryBuffer.H
+++ b/Source/Particles/ParticleBoundaryBuffer.H
@@ -83,11 +83,6 @@ private:
 
     mutable std::vector<std::string> m_species_names;
     /** Guards the lazy read of m_species_names for this instance.
-     *
-     * This is deliberately a member and not a function-local static: with the
-     * Python bindings, several WarpX instances can be created and destroyed in
-     * one process, and a process-lifetime flag would leave m_species_names
-     * empty for every instance after the first.
      */
     mutable bool m_species_names_initialized = false;
 };

--- a/Source/Particles/ParticleBoundaryBuffer.cpp
+++ b/Source/Particles/ParticleBoundaryBuffer.cpp
@@ -332,12 +332,11 @@ void ParticleBoundaryBuffer::redistribute () {
 
 const std::vector<std::string>& ParticleBoundaryBuffer::getSpeciesNames() const
 {
-    static bool initialized = false;
-    if (!initialized)
+    if (!m_species_names_initialized)
     {
         const amrex::ParmParse pp_particles("particles");
         pp_particles.queryarr("species_names", m_species_names);
-        initialized = true;
+        m_species_names_initialized = true;
     }
     return m_species_names;
 }

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -160,14 +160,12 @@ WarpXParticleContainer::WarpXParticleContainer (AmrCore* amr_core, int ispecies,
 void
 WarpXParticleContainer::ReadParameters ()
 {
-    static bool initialized = false;
-
-    if (!initialized)
-    {
-        const ParmParse pp_particles("particles");
-        pp_particles.query("do_tiling", do_tiling);
-        initialized = true;
-    }
+    // note: no static "read once" guard here. do_tiling is a static of the
+    // AMReX particle container base, so a process-lifetime guard would make
+    // every WarpX instance after the first ignore particles.do_tiling. The
+    // query itself is cheap.
+    const ParmParse pp_particles("particles");
+    pp_particles.query("do_tiling", do_tiling);
 }
 
 void

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -160,10 +160,9 @@ WarpXParticleContainer::WarpXParticleContainer (AmrCore* amr_core, int ispecies,
 void
 WarpXParticleContainer::ReadParameters ()
 {
-    // note: no static "read once" guard here. do_tiling is a static of the
+    // do_tiling is a static of the
     // AMReX particle container base, so a process-lifetime guard would make
-    // every WarpX instance after the first ignore particles.do_tiling. The
-    // query itself is cheap.
+    // every WarpX instance after the first ignore particles.do_tiling.
     const ParmParse pp_particles("particles");
     pp_particles.query("do_tiling", do_tiling);
 }

--- a/Source/Python/WarpX.cpp
+++ b/Source/Python/WarpX.cpp
@@ -48,6 +48,7 @@
 #if defined(AMREX_DEBUG) || defined(DEBUG)
 #   include <cstdio>
 #endif
+#include <memory>
 #include <string>
 
 
@@ -103,7 +104,13 @@ void init_WarpX (py::module& m)
     m.def("finalize", &WarpX::Finalize,
         "Close out the WarpX related data");
 
-    py::class_<WarpX> warpx(m, "WarpX");
+    // WarpX is a singleton owned by the C++ side: its lifetime ends in
+    // WarpX::Finalize (i.e. WarpX::ResetInstance), never when the last Python
+    // reference goes away. Without py::nodelete, pybind11's default
+    // return_value_policy for the raw pointer returned by get_instance below is
+    // take_ownership, and destroying the Python object would leave
+    // WarpX::m_instance dangling and WarpX::Finalize double-freeing it.
+    py::class_<WarpX, std::unique_ptr<WarpX, py::nodelete>> warpx(m, "WarpX");
     warpx
         // WarpX is a Singleton Class with a private constructor
         //   https://github.com/BLAST-WarpX/warpx/pull/4104


### PR DESCRIPTION
## Stack (1/3)

GitHub cannot use a fork branch as a PR base, so this is three cross-linked PRs against `development` rather than a true stack. Each PR contains the commits of the ones below it, so please review/merge bottom-up.

1. **This PR** — `Python: Fix WarpX Singleton Lifetime and Leaking Statics`
2. https://github.com/BLAST-WarpX/warpx/pull/7143 — `pywarpx: Add reset()`
3. https://github.com/BLAST-WarpX/warpx/pull/7144 — `Tests: pytest Unit Tests for Charge and Current Deposition`

## What

Four related fixes that make it possible to create and destroy several WarpX instances of the same dimensionality in one Python process. **No functional change for a regular simulation run.**

* **`Source/Python/WarpX.cpp`** — `get_instance` returns a raw `WarpX*` with no `return_value_policy`, so pybind11 defaults to `take_ownership`: the Python wrapper deletes the singleton that `WarpX::m_instance` still points to, and a later `WarpX::Finalize()` double-frees it. This is the crash behind the long-standing comment in `Python/pywarpx/_libwarpx.py`:

  ```python
  # The call to warpx_finalize causes a crash - don't know why
  # self.libwarpx_so.warpx_finalize()
  ```

  Fixed with a `py::nodelete` holder — the singleton is owned by the C++ side and its lifetime ends in `WarpX::ResetInstance()`.

* **`Python/pywarpx/_libwarpx.py`** — with ownership settled, `finalize()` now destroys the singleton via `WarpX::Finalize()` *before* `amrex::Finalize()`, and clears its `initialized` flag.

* **Three `ReadParameters()` implementations** cached per-instance state behind a function-local `static bool initialized`. Invisible in a regular run, but every instance after the first silently kept empty parameters:
  * `MultiParticleContainer::ReadParameters()` left `species_names` empty → `GetParticleContainerFromName()` aborted with `unknown species name`.
  * `ParticleBoundaryBuffer::getSpeciesNames()` — same problem.
  * `WarpXParticleContainer::ReadParameters()` made every instance after the first ignore `particles.do_tiling`. Guard dropped rather than made per-instance, since `do_tiling` is a static of the AMReX particle container base and the `ParmParse` query is cheap.

## Testing

Built 3D + `WarpX_PYTHON=ON` and exercised repeated init/finalize cycles from Python; with the full stack applied, seven consecutive WarpX instances are created and destroyed in one pytest process (verified by 7 WarpX banners and 7 `AMReX ... finalized` lines). The dedicated tests land in part 3 of this stack.
