### PR TITLE
Restrict warpx.do_subcycling to the electromagnetic solvers

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -4078,7 +4078,9 @@ Additional parameters
     :pp:param:`warpx.do_electrostatic`), with the hybrid-PIC solver
     (``algo.maxwell_solver = hybrid``), nor with the spectral solver
     (``algo.maxwell_solver = psatd``); WarpX aborts if sub-cycling is requested
-    with any of these solvers.
+    with any of these solvers. It also requires the explicit evolve scheme
+    (:pp:param:`algo.evolve_scheme` = ``explicit``, the default), since the
+    implicit and semi-implicit schemes do not sub-cycle.
 
 .. pp:param:: warpx.override_sync_intervals
     :type: ``string``

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -4068,8 +4068,16 @@ Additional parameters
     evolves with its own time step, set to its own CFL limit. In practice, it
     means that when level 0 performs one iteration, level 1 performs two
     iterations. Currently, this option is only supported when
-    :pp:param:`amr.max_level = 1`. More information can be found at
-    https://ieeexplore.ieee.org/document/8659392.
+    :pp:param:`amr.max_level = 1` and when the refinement ratio
+    :pp:param:`amr.ref_ratio` is 2 in all directions. More information can be
+    found at https://ieeexplore.ieee.org/document/8659392.
+
+    Sub-cycling is only implemented for the electromagnetic solvers
+    (``algo.maxwell_solver = yee``, ``ckc`` or ``ect``). It is not supported
+    with the electrostatic and magnetostatic solvers (see
+    :pp:param:`warpx.do_electrostatic`), nor with the hybrid-PIC solver
+    (``algo.maxwell_solver = hybrid``); WarpX aborts if sub-cycling is requested
+    with one of these solvers.
 
 .. pp:param:: warpx.override_sync_intervals
     :type: ``string``

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -4072,12 +4072,13 @@ Additional parameters
     :pp:param:`amr.ref_ratio` is 2 in all directions. More information can be
     found at https://ieeexplore.ieee.org/document/8659392.
 
-    Sub-cycling is only implemented for the electromagnetic solvers
-    (``algo.maxwell_solver = yee``, ``ckc`` or ``ect``). It is not supported
-    with the electrostatic and magnetostatic solvers (see
-    :pp:param:`warpx.do_electrostatic`), nor with the hybrid-PIC solver
-    (``algo.maxwell_solver = hybrid``); WarpX aborts if sub-cycling is requested
-    with one of these solvers.
+    Sub-cycling is only implemented for the finite-difference electromagnetic
+    solvers (``algo.maxwell_solver = yee``, ``ckc`` or ``ect``). It is not
+    supported with the electrostatic and magnetostatic solvers (see
+    :pp:param:`warpx.do_electrostatic`), with the hybrid-PIC solver
+    (``algo.maxwell_solver = hybrid``), nor with the spectral solver
+    (``algo.maxwell_solver = psatd``); WarpX aborts if sub-cycling is requested
+    with any of these solvers.
 
 .. pp:param:: warpx.override_sync_intervals
     :type: ``string``

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -745,7 +745,7 @@ WarpX::ReadParameters ()
         }
 
         // Sub-cycling is only implemented for the finite-difference electromagnetic
-        // solvers, in the mesh-refinement PIC loop WarpX::OneStep_sub1. 
+        // solvers, in the mesh-refinement PIC loop WarpX::OneStep_sub1.
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             !m_do_subcycling ||
             electromagnetic_solver_id == ElectromagneticSolverAlgo::Yee ||

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -744,19 +744,24 @@ WarpX::ReadParameters ()
             electromagnetic_solver_id = ElectromagneticSolverAlgo::None;
         }
 
-        // Sub-cycling is only implemented in the mesh-refinement PIC loop of the
-        // electromagnetic solvers (see WarpX::OneStep_sub1). It is silently ignored
-        // by the electrostatic/magnetostatic and hybrid-PIC PIC loops, so abort here
-        // instead, in order to avoid running with a time-stepping scheme that differs
-        // from the one requested by the user.
+        // Sub-cycling is only implemented for the finite-difference electromagnetic
+        // solvers, in the mesh-refinement PIC loop WarpX::OneStep_sub1. With the
+        // electrostatic/magnetostatic and hybrid-PIC solvers, WarpX::OneStep dispatches
+        // to a PIC loop that never sub-cycles, yet WarpX::ComputeDt still scales dt[0]
+        // by the refinement ratio: the simulation clock would then advance
+        // inconsistently with the particle push. Sub-cycling is not supported with
+        // PSATD either. This check is written as an allow-list, so that all the
+        // unsupported solvers abort here with an explicit message.
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             !m_do_subcycling ||
-            (electromagnetic_solver_id != ElectromagneticSolverAlgo::None &&
-             electromagnetic_solver_id != ElectromagneticSolverAlgo::HybridPIC),
+            electromagnetic_solver_id == ElectromagneticSolverAlgo::Yee ||
+            electromagnetic_solver_id == ElectromagneticSolverAlgo::CKC ||
+            electromagnetic_solver_id == ElectromagneticSolverAlgo::ECT,
             "warpx.do_subcycling = 1 is only supported with the electromagnetic solvers "
-            "(algo.maxwell_solver = yee, ckc or ect). It is not supported with the "
-            "electrostatic/magnetostatic solvers (warpx.do_electrostatic) nor with the "
-            "hybrid-PIC solver (algo.maxwell_solver = hybrid).");
+            "algo.maxwell_solver = yee, ckc or ect. It is not supported with the "
+            "electrostatic/magnetostatic solvers (warpx.do_electrostatic), with the "
+            "hybrid-PIC solver (algo.maxwell_solver = hybrid), nor with the spectral "
+            "solver (algo.maxwell_solver = psatd).");
 
 #if defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(electrostatic_solver_id == ElectrostaticSolverAlgo::None,

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -757,6 +757,13 @@ WarpX::ReadParameters ()
             "hybrid-PIC solver (algo.maxwell_solver = hybrid), nor with the spectral "
             "solver (algo.maxwell_solver = psatd).");
 
+        // Sub-cycling is reached only from the explicit branch of WarpX::OneStep.
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+            !m_do_subcycling || evolve_scheme == EvolveScheme::Explicit,
+            "warpx.do_subcycling = 1 is only supported with algo.evolve_scheme = explicit. "
+            "The implicit and semi-implicit evolve schemes advance all mesh-refinement "
+            "levels with the same time step and do not sub-cycle.");
+
 #if defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(electrostatic_solver_id == ElectrostaticSolverAlgo::None,
                   "Electrostatic solver not supported with 1D cylindrical and spherical");

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -744,6 +744,20 @@ WarpX::ReadParameters ()
             electromagnetic_solver_id = ElectromagneticSolverAlgo::None;
         }
 
+        // Sub-cycling is only implemented in the mesh-refinement PIC loop of the
+        // electromagnetic solvers (see WarpX::OneStep_sub1). It is silently ignored
+        // by the electrostatic/magnetostatic and hybrid-PIC PIC loops, so abort here
+        // instead, in order to avoid running with a time-stepping scheme that differs
+        // from the one requested by the user.
+        WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+            !m_do_subcycling ||
+            (electromagnetic_solver_id != ElectromagneticSolverAlgo::None &&
+             electromagnetic_solver_id != ElectromagneticSolverAlgo::HybridPIC),
+            "warpx.do_subcycling = 1 is only supported with the electromagnetic solvers "
+            "(algo.maxwell_solver = yee, ckc or ect). It is not supported with the "
+            "electrostatic/magnetostatic solvers (warpx.do_electrostatic) nor with the "
+            "hybrid-PIC solver (algo.maxwell_solver = hybrid).");
+
 #if defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(electrostatic_solver_id == ElectrostaticSolverAlgo::None,
                   "Electrostatic solver not supported with 1D cylindrical and spherical");

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -745,13 +745,7 @@ WarpX::ReadParameters ()
         }
 
         // Sub-cycling is only implemented for the finite-difference electromagnetic
-        // solvers, in the mesh-refinement PIC loop WarpX::OneStep_sub1. With the
-        // electrostatic/magnetostatic and hybrid-PIC solvers, WarpX::OneStep dispatches
-        // to a PIC loop that never sub-cycles, yet WarpX::ComputeDt still scales dt[0]
-        // by the refinement ratio: the simulation clock would then advance
-        // inconsistently with the particle push. Sub-cycling is not supported with
-        // PSATD either. This check is written as an allow-list, so that all the
-        // unsupported solvers abort here with an explicit message.
+        // solvers, in the mesh-refinement PIC loop WarpX::OneStep_sub1. 
         WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
             !m_do_subcycling ||
             electromagnetic_solver_id == ElectromagneticSolverAlgo::Yee ||


### PR DESCRIPTION
Sub-cycling is only implemented in the mesh-refinement PIC loop of the electromagnetic solvers (`WarpX::OneStep_sub1`). With the electrostatic/magnetostatic solvers and with the hybrid-PIC solver, `WarpX::OneStep` dispatches to a different PIC loop and `warpx.do_subcycling` is silently ignored.

Add an assertion in `WarpX::ReadParameters` so that WarpX aborts (instead of silently running a different time-stepping scheme than the one requested), and document the restriction. Also document the refinement-ratio requirement introduced in BLAST-WarpX/warpx#6755.