### PR TITLE
Docs: Restore `governance` Anchor Lost in Markdown Conversion

### DIFF
--- a/Docs/source/developers/how_to_test_on_gpus.rst
+++ b/Docs/source/developers/how_to_test_on_gpus.rst
@@ -40,7 +40,7 @@ Who can add the label?
 ----------------------
 
 Anyone in the `warpx-contributors team <https://github.com/orgs/BLAST-WarpX/teams/warpx-contributors>`__ on GitHub can add the ``bot: run GPU`` label.
-Membership is restricted to vetted contributors who are known, identifiable individuals personally accountable for their actions, and is granted by members of the WarpX :ref:`Technical Committee <governance>`.
+Membership is restricted to vetted contributors who are known, identifiable individuals personally accountable for their actions, and is granted by members of the WarpX :ref:`Technical Committee <technical-committee>`.
 
 .. warning::
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,3 +1,4 @@
+(governance)=
 # WarpX Governance
 
 WarpX is led in an open governance model, described in this file.
@@ -40,6 +41,7 @@ As a SC member, regularly attending and contributing to the weekly developer mee
 SC members can resign or be removed by majority vote, e.g., due to inactivity, bad acting or other reasons.
 
 
+(technical-committee)=
 ## Technical Committee
 
 ### Current Roster


### PR DESCRIPTION
Follow-up to https://github.com/BLAST-WarpX/warpx/pull/6949 and https://github.com/BLAST-WarpX/warpx/pull/7115.

## TL;DR

RTD build errors, links fixed.
- https://warpx--7150.org.readthedocs.build/en/7150/developers/how_to_test_on_gpus.html#who-can-add-the-label
- https://warpx--7150.org.readthedocs.build/en/7150/governance.html#technical-committee

## Problem

Read the Docs builds with `sphinx -W`, so one warning fails the entire documentation build. `development` — and therefore every PR branched from it — is currently red with:

```
Docs/source/developers/how_to_test_on_gpus.rst:42: WARNING: undefined label: 'governance'
build finished with problems, 1 warning.
```

It is an interaction between two merged PRs, neither of which is wrong on its own:

* #7115 converted `GOVERNANCE.rst` to `GOVERNANCE.md`. The reStructuredText file began with an explicit `.. _governance:` target; the Markdown conversion dropped it, so no `governance` label is defined any more.
* #6949 then added ``:ref:`Technical Committee <governance>``` in `Docs/source/developers/how_to_test_on_gpus.rst`, which needs exactly that label.

## Fix

Restore the target in MyST syntax — `(governance)=` is the Markdown equivalent of the `.. _governance:` we had before — and add `(technical-committee)=` so the sentence links to the section it actually names rather than the top of the page.

## Why not `myst_heading_anchors`?

It was the obvious candidate, but it does not solve this, verified with a minimal Sphinx project:

* with `myst_heading_anchors = 3`, MyST emits HTML ids (`governance.html#technical-committee`) but registers **no `std:label`** entries, so a `:ref:` from a reStructuredText file still does not resolve — those anchors are only reachable from Markdown links, `[text](governance.md#technical-committee)`;
* the anchors would be ambiguous in this particular file: "Current Roster", "Role" and "Decision Process" each appear twice (Steering vs. Technical Committee), and Sphinx assigns the second occurrence the opaque fallback `id="id1"`.

With an explicit target, both labels resolve:

```
std:label 'governance'          -> governance.html#governance
std:label 'technical-committee' -> governance.html#technical-committee
```

## Trade-off

GitHub's Markdown renderer shows `(governance)=` literally, so `GOVERNANCE.md` gains a stray line above its title and above the Technical Committee heading when browsed on github.com. The alternative — ``:doc:`Technical Committee </governance>``` — leaves the repository-root file untouched but can only link to the top of the page. Happy to switch if reviewers prefer that.

## Testing

Full local Sphinx build with the same flags RTD uses (`-T -W --keep-going -b html`):

* zero undefined-label warnings;
* `how_to_test_on_gpus.html` links to `../governance.html#technical-committee`;
* `governance.html` contains both `id="governance"` and `id="technical-committee"`.

This unblocks the docs build on `development` and on all open PRs branched from #6949, including https://github.com/BLAST-WarpX/warpx/pull/7143 and https://github.com/BLAST-WarpX/warpx/pull/7144.
