### PR TITLE
Update guidance for tests in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,4 +146,4 @@ When a change removes or renames a user-facing input parameter, add a guard to t
 
 - Main branch: `development` (not `main`)
 - Fork-and-branch workflow; PRs target `development`
-- Pull requests with features and bug fixes need to add a test for coverage.
+- Pull requests with new features need to add a test for coverage.


### PR DESCRIPTION
The guidance was a bit too strict, as it's unclear whether bug fixes systematically need tests (it might lead to a proliferation of tests, which eventually could become difficult to manage).

For bug fixes, whether or not to add a test would probably be a judgement call from the PR reviewer.