### PR TITLE
Fix non-docs CI filter for nested markdown/rst files

### DIFF
--- a/.github/workflows/check_changes.yml
+++ b/.github/workflows/check_changes.yml
@@ -22,8 +22,8 @@ jobs:
               - '!.zenodo.json'
               - '!Docs/**'
               - '!Tools/machines/**'
-              - '!**.rst'
-              - '!**.md'
+              - '!**/*.rst'
+              - '!**/*.md'
           predicate-quantifier: 'every'
       - id: set-output
         run: |


### PR DESCRIPTION
I think we need this fix for nested markdown/rst files. I noticed the problem in #7155, where changes to .claude/skills/*/SKILL.md triggered all CI checks.