### PR TITLE
[WIP] Particle initialization: add distributed reading of u_mean/u_std from openPMD files

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -1770,6 +1770,15 @@ Particle initialization
           an openPMD vector record ``u_mean`` with components ``x``, ``y`` and ``z``. See
           `this file <https://github.com/BLAST-WarpX/warpx/blob/development/Examples/Tests/initial_distribution/inputs_test_3d_initial_distribution_prepare.py>`__
           for an example of how to prepare the openPMD data file.
+          There is another optional parameter,
+          ``<species_name>.read_u_mean_distributed``, which controls how the openPMD
+          data are distributed among processes. If it is set to false, the openPMD data
+          are loaded and duplicated on every process. If it is set to true, the openPMD
+          data required for initializing ``u_mean`` are distributed among MPI processes.
+          It defaults to true for the injection styles that inject particles cell by cell
+          (``NRandomPerCell`` and ``NUniformPerCell``) when the moving window is off, and
+          to false otherwise: these are the only cases in which distributed reading is
+          supported.
 
       * ``<species_name>.maxwellian_u_std_distribution_type`` (`string`, default ``constant``):
         Specifies the distribution type for the thermal spread (standard deviation) of the
@@ -1793,6 +1802,15 @@ Particle initialization
           an openPMD vector record ``u_std`` with components ``x``, ``y`` and ``z``. See
           `this file <https://github.com/BLAST-WarpX/warpx/blob/development/Examples/Tests/initial_distribution/inputs_test_3d_initial_distribution_prepare.py>`__
           for an example of how to prepare the openPMD data file.
+          There is another optional parameter,
+          ``<species_name>.read_u_std_distributed``, which controls how the openPMD
+          data are distributed among processes. If it is set to false, the openPMD data
+          are loaded and duplicated on every process. If it is set to true, the openPMD
+          data required for initializing ``u_std`` are distributed among MPI processes.
+          It defaults to true for the injection styles that inject particles cell by cell
+          (``NRandomPerCell`` and ``NUniformPerCell``) when the moving window is off, and
+          to false otherwise: these are the only cases in which distributed reading is
+          supported.
 
         Particles may be relativistic in the lab frame, but the sampling model treats them as
         non-relativistic in the drift frame. For a relativistic thermal spread, use ``maxwell_juttner`` instead.
@@ -1835,6 +1853,15 @@ Particle initialization
           an openPMD vector record ``u_mean`` with components ``x``, ``y`` and ``z``. See
           `this file <https://github.com/BLAST-WarpX/warpx/blob/development/Examples/Tests/initial_distribution/inputs_test_3d_initial_distribution_prepare.py>`__
           for an example of how to prepare the openPMD data file.
+          There is another optional parameter,
+          ``<species_name>.read_u_mean_distributed``, which controls how the openPMD
+          data are distributed among processes. If it is set to false, the openPMD data
+          are loaded and duplicated on every process. If it is set to true, the openPMD
+          data required for initializing ``u_mean`` are distributed among MPI processes.
+          It defaults to true for the injection styles that inject particles cell by cell
+          (``NRandomPerCell`` and ``NUniformPerCell``) when the moving window is off, and
+          to false otherwise: these are the only cases in which distributed reading is
+          supported.
 
       * ``<species_name>.theta_distribution_type`` (`string`, default ``constant``):
         Specifies the distribution type for the temperature :math:`\theta`.

--- a/Examples/Tests/initial_distribution/inputs_test_3d_initial_distribution
+++ b/Examples/Tests/initial_distribution/inputs_test_3d_initial_distribution
@@ -199,6 +199,9 @@ gaussian_momentum_from_file.maxwellian_u_mean_distribution_type = "read_from_fil
 gaussian_momentum_from_file.read_u_mean_from_path = "../test_3d_initial_distribution_prepare/example-u-mean.h5"
 gaussian_momentum_from_file.maxwellian_u_std_distribution_type = "read_from_file"
 gaussian_momentum_from_file.read_u_std_from_path = "../test_3d_initial_distribution_prepare/example-u-std.h5"
+# u_mean uses the default (distributed) reading, u_std is read in full on every
+# MPI rank: this covers both code paths in a single test.
+gaussian_momentum_from_file.read_u_std_distributed = 0
 
 #################################
 ########## DIAGNOSTIC ###########

--- a/Source/Fluids/WarpXFluidContainer.cpp
+++ b/Source/Fluids/WarpXFluidContainer.cpp
@@ -183,19 +183,24 @@ void WarpXFluidContainer::InitData(
     const auto problo = geom_lev.ProbLoArray();
     const amrex::Real clight = PhysConst::c;
 
-    // Create local copies of pointers for GPU kernels
-    InjectorMomentum* inj_mom = d_inj_mom;
+    auto get_zlab = [=] (amrex::Real z) -> amrex::Real
+    {
+        return gamma_boost*(z + beta_boost*clight*cur_time);
+    };
 
     if (h_inj_rho && h_inj_rho->needPreparation()) {
-        auto get_zlab = [=] (amrex::Real z) -> amrex::Real
-        {
-            return gamma_boost*(z + beta_boost*clight*cur_time);
-        };
         auto const& mf = *fields.get(name_mf_N, lev);
         h_inj_rho->prepare(mf.boxArray(), mf.DistributionMap(), IntVect(0), get_zlab);
 #ifdef AMREX_USE_GPU
         amrex::Gpu::htod_memcpy_async(d_inj_rho, h_inj_rho.get(), sizeof(InjectorDensity));
 #endif
+    }
+
+    // Only distributed data need to be prepared here: data that are not
+    // distributed have already been read in full, in SpeciesUtils::parseMomentum.
+    if (h_inj_mom && h_inj_mom->distributed()) {
+        auto const& mf = *fields.get(name_mf_N, lev);
+        h_inj_mom->prepare(mf.boxArray(), mf.DistributionMap(), IntVect(0), get_zlab);
     }
 
     // Loop through cells and initialize their value
@@ -207,6 +212,11 @@ void WarpXFluidContainer::InitData(
         InjectorDensity* inj_rho = d_inj_rho;
         if (h_inj_rho->distributed()) {
             h_inj_rho->prepare(mfi.LocalIndex(), &inj_rho);
+        }
+
+        InjectorMomentum* inj_mom = d_inj_mom;
+        if (h_inj_mom->distributed()) {
+            h_inj_mom->prepare(mfi.LocalIndex(), &inj_mom);
         }
 
         amrex::Box const tile_box  = mfi.tilebox(fields.get(name_mf_N, lev)->ixType().toIntVect());
@@ -273,9 +283,9 @@ void WarpXFluidContainer::InitData(
             }
         );
 
-        if (h_inj_rho->distributed()) {
-            // h_inj_rho is shared by multiple GPU streams. We need to sync
-            // to avoid race conditions in h_inj_rho->prepare(int).
+        if (h_inj_rho->distributed() || h_inj_mom->distributed()) {
+            // h_inj_rho and h_inj_mom are shared by multiple GPU streams. We
+            // need to sync to avoid race conditions in their prepare(int).
             Gpu::streamSynchronize();
         }
     }

--- a/Source/Initialization/ExternalField.H
+++ b/Source/Initialization/ExternalField.H
@@ -274,12 +274,23 @@ private:
  */
 struct ExternalFieldVectorView
 {
+    ExternalFieldVectorView () = default;
+
     /**
      * \brief Construct the view from the readers of the three components.
      */
     ExternalFieldVectorView (ExternalFieldReader const* x_reader,
                              ExternalFieldReader const* y_reader,
                              ExternalFieldReader const* z_reader) noexcept;
+
+    /**
+     * \brief Construct the view from the readers of the three components, for
+     * the Box whose local index is `li`. This is used when the openPMD data
+     * are distributed among MPI processes.
+     */
+    ExternalFieldVectorView (ExternalFieldReader const* x_reader,
+                             ExternalFieldReader const* y_reader,
+                             ExternalFieldReader const* z_reader, int li);
 
     //! Return the three components of the field, linearly interpolated at the
     //! given position.

--- a/Source/Initialization/ExternalField.cpp
+++ b/Source/Initialization/ExternalField.cpp
@@ -600,4 +600,20 @@ ExternalFieldVectorView::ExternalFieldVectorView (
         m_z_view = z_reader->getView();
     }
 }
+
+ExternalFieldVectorView::ExternalFieldVectorView (
+    ExternalFieldReader const* x_reader,
+    ExternalFieldReader const* y_reader,
+    ExternalFieldReader const* z_reader, int li)
+{
+    if (x_reader) {
+        m_x_view = x_reader->getView(li);
+    }
+    if (y_reader) {
+        m_y_view = y_reader->getView(li);
+    }
+    if (z_reader) {
+        m_z_view = z_reader->getView(li);
+    }
+}
 #endif

--- a/Source/Initialization/GetTemperature.H
+++ b/Source/Initialization/GetTemperature.H
@@ -13,6 +13,10 @@
 #include "TemperatureProperties.H"
 
 #include <AMReX.H>
+#include <AMReX_BoxArray.H>
+#include <AMReX_DistributionMapping.H>
+
+#include <functional>
 
 /**
  * \brief Get temperature at a point on the grid
@@ -81,7 +85,13 @@ struct GetTemperatureVector
     amrex::ParserExecutor<3> m_ux_std_parser, m_uy_std_parser, m_uz_std_parser;
 #if defined(WARPX_USE_OPENPMD) && !defined(WARPX_DIM_RZ) && \
     !defined(WARPX_DIM_RCYLINDER) && !defined(WARPX_DIM_RSPHERE)
+    /** View on the openPMD data, if m_type == TempFromFileVector */
     ExternalFieldVectorView m_from_file;
+    /** Readers of the three components of `u_std`. These are owned by the
+     * TemperatureProperties object that was passed to the constructor. */
+    ExternalFieldReader* m_u_std_x_reader = nullptr;
+    ExternalFieldReader* m_u_std_y_reader = nullptr;
+    ExternalFieldReader* m_u_std_z_reader = nullptr;
 #endif
     /**
      * \brief Construct the functor with information provided by temp
@@ -90,6 +100,29 @@ struct GetTemperatureVector
      * populate the functor
      */
     explicit GetTemperatureVector (TemperatureProperties const& temp) noexcept;
+
+    // This function needs to be called before initializing the momentum of the
+    // particles, when `u_std` is read from a file. When the readers are created
+    // in the constructor of TemperatureProperties, we do not know the particle
+    // containers' BoxArray and DistributionMapping yet.
+    void prepare (amrex::BoxArray const& grids,
+                  amrex::DistributionMapping const& dmap,
+                  amrex::IntVect const& ngrow,
+                  std::function<amrex::Real(amrex::Real)> const& get_zlab);
+
+    // This function needs to be called before we do continuous injection of
+    // particles to inform the readers to load the data we need.
+    void prepare (amrex::RealBox const& pbox, int moving_dir, int moving_sign,
+                  std::function<amrex::Real(amrex::Real)> const& get_zlab);
+
+    // For distributed data, this function prepares the functor for reading
+    // data in this Box. Here `li` is the local index for the Box in a
+    // particle container.
+    void prepare (int li);
+
+    [[nodiscard]] bool needPreparation () const;
+
+    [[nodiscard]] bool distributed () const;
 
     /**
      * \brief Functor call. Returns the value of temperature at the location (x,y,z)

--- a/Source/Initialization/GetTemperature.cpp
+++ b/Source/Initialization/GetTemperature.cpp
@@ -25,8 +25,9 @@ GetTemperatureVector::GetTemperatureVector (TemperatureProperties const& temp) n
     : m_type{temp.m_type}
 #if defined(WARPX_USE_OPENPMD) && !defined(WARPX_DIM_RZ) && \
     !defined(WARPX_DIM_RCYLINDER) && !defined(WARPX_DIM_RSPHERE)
-    , m_from_file{temp.m_u_std_x_reader.get(), temp.m_u_std_y_reader.get(),
-                  temp.m_u_std_z_reader.get()}
+    , m_u_std_x_reader{temp.m_u_std_x_reader.get()}
+    , m_u_std_y_reader{temp.m_u_std_y_reader.get()}
+    , m_u_std_z_reader{temp.m_u_std_z_reader.get()}
 #endif
 {
     if (m_type == TempConstantVector) {
@@ -39,4 +40,74 @@ GetTemperatureVector::GetTemperatureVector (TemperatureProperties const& temp) n
         m_uy_std_parser = temp.m_ptr_uy_std_parser->compile<3>();
         m_uz_std_parser = temp.m_ptr_uz_std_parser->compile<3>();
     }
+}
+
+void GetTemperatureVector::prepare (amrex::BoxArray const& grids,
+                                    amrex::DistributionMapping const& dmap,
+                                    amrex::IntVect const& ngrow,
+                                    std::function<amrex::Real(amrex::Real)> const& get_zlab)
+{
+#if defined(WARPX_USE_OPENPMD) && !defined(WARPX_DIM_RZ) && \
+    !defined(WARPX_DIM_RCYLINDER) && !defined(WARPX_DIM_RSPHERE)
+    if (needPreparation()) {
+        m_u_std_x_reader->prepare(grids, dmap, ngrow, get_zlab);
+        m_u_std_y_reader->prepare(grids, dmap, ngrow, get_zlab);
+        m_u_std_z_reader->prepare(grids, dmap, ngrow, get_zlab);
+        m_from_file = ExternalFieldVectorView(m_u_std_x_reader, m_u_std_y_reader,
+                                              m_u_std_z_reader);
+    }
+#else
+    amrex::ignore_unused(grids, dmap, ngrow, get_zlab);
+#endif
+}
+
+void GetTemperatureVector::prepare (amrex::RealBox const& pbox, int moving_dir, int moving_sign,
+                                    std::function<amrex::Real(amrex::Real)> const& get_zlab)
+{
+#if defined(WARPX_USE_OPENPMD) && !defined(WARPX_DIM_RZ) && \
+    !defined(WARPX_DIM_RCYLINDER) && !defined(WARPX_DIM_RSPHERE)
+    if (needPreparation()) {
+        m_u_std_x_reader->prepare(pbox, moving_dir, moving_sign, get_zlab);
+        m_u_std_y_reader->prepare(pbox, moving_dir, moving_sign, get_zlab);
+        m_u_std_z_reader->prepare(pbox, moving_dir, moving_sign, get_zlab);
+        m_from_file = ExternalFieldVectorView(m_u_std_x_reader, m_u_std_y_reader,
+                                              m_u_std_z_reader);
+    }
+#else
+    amrex::ignore_unused(pbox, moving_dir, moving_sign, get_zlab);
+#endif
+}
+
+void GetTemperatureVector::prepare (int li)
+{
+#if defined(WARPX_USE_OPENPMD) && !defined(WARPX_DIM_RZ) && \
+    !defined(WARPX_DIM_RCYLINDER) && !defined(WARPX_DIM_RSPHERE)
+    if (needPreparation()) {
+        m_from_file = ExternalFieldVectorView(m_u_std_x_reader, m_u_std_y_reader,
+                                              m_u_std_z_reader, li);
+    }
+#else
+    amrex::ignore_unused(li);
+#endif
+}
+
+bool GetTemperatureVector::needPreparation () const
+{
+#if defined(WARPX_USE_OPENPMD) && !defined(WARPX_DIM_RZ) && \
+    !defined(WARPX_DIM_RCYLINDER) && !defined(WARPX_DIM_RSPHERE)
+    return m_type == TempFromFileVector;
+#else
+    return false;
+#endif
+}
+
+bool GetTemperatureVector::distributed () const
+{
+#if defined(WARPX_USE_OPENPMD) && !defined(WARPX_DIM_RZ) && \
+    !defined(WARPX_DIM_RCYLINDER) && !defined(WARPX_DIM_RSPHERE)
+    if (needPreparation()) {
+        return m_u_std_x_reader->distributed();
+    }
+#endif
+    return false;
 }

--- a/Source/Initialization/GetVelocity.H
+++ b/Source/Initialization/GetVelocity.H
@@ -12,8 +12,12 @@
 #include "VelocityProperties.H"
 
 #include <AMReX.H>
+#include <AMReX_BoxArray.H>
 #include <AMReX_Dim3.H>
+#include <AMReX_DistributionMapping.H>
 #include <AMReX_REAL.H>
+
+#include <functional>
 
 /** Get the bulk drift momentum vector at a point on the grid
  *
@@ -34,7 +38,13 @@ struct GetVelocityVector
 
 #if defined(WARPX_USE_OPENPMD) && !defined(WARPX_DIM_RZ) && \
     !defined(WARPX_DIM_RCYLINDER) && !defined(WARPX_DIM_RSPHERE)
+    /** View on the openPMD data, if m_type == VelFromFileVector */
     ExternalFieldVectorView m_from_file;
+    /** Readers of the three components of `u_mean`. These are owned by the
+     * VelocityProperties object that was passed to the constructor. */
+    ExternalFieldReader* m_u_mean_x_reader = nullptr;
+    ExternalFieldReader* m_u_mean_y_reader = nullptr;
+    ExternalFieldReader* m_u_mean_z_reader = nullptr;
 #endif
 
     /**
@@ -44,6 +54,29 @@ struct GetVelocityVector
      * populate the functor
      */
     explicit GetVelocityVector (VelocityProperties const& vel) noexcept;
+
+    // This function needs to be called before initializing the momentum of the
+    // particles, when `u_mean` is read from a file. When the readers are
+    // created in the constructor of VelocityProperties, we do not know the
+    // particle containers' BoxArray and DistributionMapping yet.
+    void prepare (amrex::BoxArray const& grids,
+                  amrex::DistributionMapping const& dmap,
+                  amrex::IntVect const& ngrow,
+                  std::function<amrex::Real(amrex::Real)> const& get_zlab);
+
+    // This function needs to be called before we do continuous injection of
+    // particles to inform the readers to load the data we need.
+    void prepare (amrex::RealBox const& pbox, int moving_dir, int moving_sign,
+                  std::function<amrex::Real(amrex::Real)> const& get_zlab);
+
+    // For distributed data, this function prepares the functor for reading
+    // data in this Box. Here `li` is the local index for the Box in a
+    // particle container.
+    void prepare (int li);
+
+    [[nodiscard]] bool needPreparation () const;
+
+    [[nodiscard]] bool distributed () const;
 
     /**
      * \brief Functor call. Returns the value of velocity at the location (x,y,z)

--- a/Source/Initialization/GetVelocity.cpp
+++ b/Source/Initialization/GetVelocity.cpp
@@ -11,8 +11,9 @@ GetVelocityVector::GetVelocityVector (VelocityProperties const& vel) noexcept
     : m_type{vel.m_type}
 #if defined(WARPX_USE_OPENPMD) && !defined(WARPX_DIM_RZ) && \
     !defined(WARPX_DIM_RCYLINDER) && !defined(WARPX_DIM_RSPHERE)
-    , m_from_file{vel.m_u_mean_x_reader.get(), vel.m_u_mean_y_reader.get(),
-                  vel.m_u_mean_z_reader.get()}
+    , m_u_mean_x_reader{vel.m_u_mean_x_reader.get()}
+    , m_u_mean_y_reader{vel.m_u_mean_y_reader.get()}
+    , m_u_mean_z_reader{vel.m_u_mean_z_reader.get()}
 #endif
 {
     if (m_type == VelConstantVector) {
@@ -25,4 +26,74 @@ GetVelocityVector::GetVelocityVector (VelocityProperties const& vel) noexcept
         m_uy_mean_parser = vel.m_ptr_uy_mean_parser->compile<3>();
         m_uz_mean_parser = vel.m_ptr_uz_mean_parser->compile<3>();
     }
+}
+
+void GetVelocityVector::prepare (amrex::BoxArray const& grids,
+                                 amrex::DistributionMapping const& dmap,
+                                 amrex::IntVect const& ngrow,
+                                 std::function<amrex::Real(amrex::Real)> const& get_zlab)
+{
+#if defined(WARPX_USE_OPENPMD) && !defined(WARPX_DIM_RZ) && \
+    !defined(WARPX_DIM_RCYLINDER) && !defined(WARPX_DIM_RSPHERE)
+    if (needPreparation()) {
+        m_u_mean_x_reader->prepare(grids, dmap, ngrow, get_zlab);
+        m_u_mean_y_reader->prepare(grids, dmap, ngrow, get_zlab);
+        m_u_mean_z_reader->prepare(grids, dmap, ngrow, get_zlab);
+        m_from_file = ExternalFieldVectorView(m_u_mean_x_reader, m_u_mean_y_reader,
+                                              m_u_mean_z_reader);
+    }
+#else
+    amrex::ignore_unused(grids, dmap, ngrow, get_zlab);
+#endif
+}
+
+void GetVelocityVector::prepare (amrex::RealBox const& pbox, int moving_dir, int moving_sign,
+                                 std::function<amrex::Real(amrex::Real)> const& get_zlab)
+{
+#if defined(WARPX_USE_OPENPMD) && !defined(WARPX_DIM_RZ) && \
+    !defined(WARPX_DIM_RCYLINDER) && !defined(WARPX_DIM_RSPHERE)
+    if (needPreparation()) {
+        m_u_mean_x_reader->prepare(pbox, moving_dir, moving_sign, get_zlab);
+        m_u_mean_y_reader->prepare(pbox, moving_dir, moving_sign, get_zlab);
+        m_u_mean_z_reader->prepare(pbox, moving_dir, moving_sign, get_zlab);
+        m_from_file = ExternalFieldVectorView(m_u_mean_x_reader, m_u_mean_y_reader,
+                                              m_u_mean_z_reader);
+    }
+#else
+    amrex::ignore_unused(pbox, moving_dir, moving_sign, get_zlab);
+#endif
+}
+
+void GetVelocityVector::prepare (int li)
+{
+#if defined(WARPX_USE_OPENPMD) && !defined(WARPX_DIM_RZ) && \
+    !defined(WARPX_DIM_RCYLINDER) && !defined(WARPX_DIM_RSPHERE)
+    if (needPreparation()) {
+        m_from_file = ExternalFieldVectorView(m_u_mean_x_reader, m_u_mean_y_reader,
+                                              m_u_mean_z_reader, li);
+    }
+#else
+    amrex::ignore_unused(li);
+#endif
+}
+
+bool GetVelocityVector::needPreparation () const
+{
+#if defined(WARPX_USE_OPENPMD) && !defined(WARPX_DIM_RZ) && \
+    !defined(WARPX_DIM_RCYLINDER) && !defined(WARPX_DIM_RSPHERE)
+    return m_type == VelFromFileVector;
+#else
+    return false;
+#endif
+}
+
+bool GetVelocityVector::distributed () const
+{
+#if defined(WARPX_USE_OPENPMD) && !defined(WARPX_DIM_RZ) && \
+    !defined(WARPX_DIM_RCYLINDER) && !defined(WARPX_DIM_RSPHERE)
+    if (needPreparation()) {
+        return m_u_mean_x_reader->distributed();
+    }
+#endif
+    return false;
 }

--- a/Source/Initialization/InjectorMomentum.H
+++ b/Source/Initialization/InjectorMomentum.H
@@ -17,16 +17,22 @@
 #include "Utils/WarpXConst.H"
 
 #include <AMReX.H>
+#include <AMReX_BoxArray.H>
 #include <AMReX_Config.H>
+#include <AMReX_DataAllocator.H>
 #include <AMReX_Dim3.H>
+#include <AMReX_DistributionMapping.H>
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_REAL.H>
 #include <AMReX_Parser.H>
 #include <AMReX_Random.H>
+#include <AMReX_Vector.H>
 
 #include <AMReX_BaseFwd.H>
 
 #include <cmath>
+#include <functional>
+#include <memory>
 #include <string>
 
 // struct whose getMomentum returns constant momentum.
@@ -238,6 +244,48 @@ struct InjectorMomentumMaxwellian
         return amrex::XDim3 {u_mean.x, u_mean.y, u_mean.z};
     }
 
+    void prepare (amrex::BoxArray const& grids,
+                  amrex::DistributionMapping const& dmap,
+                  amrex::IntVect const& ngrow,
+                  std::function<amrex::Real(amrex::Real)> const& get_zlab)
+    {
+        // `get_zlab` evaluates getBulkMomentum on the host, i.e. the bulk drift
+        // that is being prepared here. It can therefore not be used for the bulk
+        // drift itself; and it cannot be used for the thermal spread either when
+        // the bulk drift is read distributedly, since the host then only holds
+        // one chunk of it.
+        std::function<amrex::Real(amrex::Real)> const no_zlab;
+        velocity.prepare(grids, dmap, ngrow, no_zlab);
+        temperature.prepare(grids, dmap, ngrow,
+                            velocity.distributed() ? no_zlab : get_zlab);
+    }
+
+    void prepare (amrex::RealBox const& pbox, int moving_dir, int moving_sign,
+                  std::function<amrex::Real(amrex::Real)> const& get_zlab)
+    {
+        // See the comment about `get_zlab` in the function above.
+        std::function<amrex::Real(amrex::Real)> const no_zlab;
+        velocity.prepare(pbox, moving_dir, moving_sign, no_zlab);
+        temperature.prepare(pbox, moving_dir, moving_sign,
+                            velocity.distributed() ? no_zlab : get_zlab);
+    }
+
+    void prepare (int li)
+    {
+        velocity.prepare(li);
+        temperature.prepare(li);
+    }
+
+    [[nodiscard]] bool needPreparation () const
+    {
+        return velocity.needPreparation() || temperature.needPreparation();
+    }
+
+    [[nodiscard]] bool distributed () const
+    {
+        return velocity.distributed() || temperature.distributed();
+    }
+
 private:
     GetVelocityVector velocity;
     GetTemperatureVector temperature;
@@ -372,6 +420,33 @@ struct InjectorMomentumJuttner
         return velocity(x,y,z);
     }
 
+    void prepare (amrex::BoxArray const& grids,
+                  amrex::DistributionMapping const& dmap,
+                  amrex::IntVect const& ngrow,
+                  std::function<amrex::Real(amrex::Real)> const& /*get_zlab*/)
+    {
+        // `get_zlab` calls getBulkMomentum, i.e. the bulk drift that is being
+        // prepared here, so it must not be used for the bulk drift itself.
+        velocity.prepare(grids, dmap, ngrow, std::function<amrex::Real(amrex::Real)>{});
+    }
+
+    void prepare (amrex::RealBox const& pbox, int moving_dir, int moving_sign,
+                  std::function<amrex::Real(amrex::Real)> const& /*get_zlab*/)
+    {
+        // See the comment about `get_zlab` in the function above.
+        velocity.prepare(pbox, moving_dir, moving_sign,
+                         std::function<amrex::Real(amrex::Real)>{});
+    }
+
+    void prepare (int li)
+    {
+        velocity.prepare(li);
+    }
+
+    [[nodiscard]] bool needPreparation () const { return velocity.needPreparation(); }
+
+    [[nodiscard]] bool distributed () const { return velocity.distributed(); }
+
 private:
     GetVelocityVector velocity;
     GetTemperature temperature;
@@ -399,6 +474,33 @@ struct InjectorMomentumParser
     {
         return m_velocity(x,y,z);
     }
+
+    void prepare (amrex::BoxArray const& grids,
+                  amrex::DistributionMapping const& dmap,
+                  amrex::IntVect const& ngrow,
+                  std::function<amrex::Real(amrex::Real)> const& /*get_zlab*/)
+    {
+        // `get_zlab` calls getBulkMomentum, i.e. the momentum that is being
+        // prepared here, so it must not be used for the momentum itself.
+        m_velocity.prepare(grids, dmap, ngrow, std::function<amrex::Real(amrex::Real)>{});
+    }
+
+    void prepare (amrex::RealBox const& pbox, int moving_dir, int moving_sign,
+                  std::function<amrex::Real(amrex::Real)> const& /*get_zlab*/)
+    {
+        // See the comment about `get_zlab` in the function above.
+        m_velocity.prepare(pbox, moving_dir, moving_sign,
+                           std::function<amrex::Real(amrex::Real)>{});
+    }
+
+    void prepare (int li)
+    {
+        m_velocity.prepare(li);
+    }
+
+    [[nodiscard]] bool needPreparation () const { return m_velocity.needPreparation(); }
+
+    [[nodiscard]] bool distributed () const { return m_velocity.distributed(); }
 
     GetVelocityVector m_velocity;
 };
@@ -478,6 +580,20 @@ struct InjectorMomentum
     ~InjectorMomentum() = default;
 
     void clear ();
+
+    void prepare (amrex::BoxArray const& grids,
+                  amrex::DistributionMapping const& dmap,
+                  amrex::IntVect const& ngrow,
+                  std::function<amrex::Real(amrex::Real)> const& get_zlab);
+
+    void prepare (amrex::RealBox const& pbox, int moving_dir, int moving_sign,
+                  std::function<amrex::Real(amrex::Real)> const& get_zlab);
+
+    void prepare (int li, InjectorMomentum** inj_mom);
+
+    [[nodiscard]] bool needPreparation () const;
+
+    [[nodiscard]] bool distributed () const;
 
     // call getMomentum from the object stored in the union
     // (the union is called Object, and the instance is called object).
@@ -575,6 +691,10 @@ struct InjectorMomentum
 
 private:
 
+    // Prepare the object stored in the union for reading the data of the Box
+    // whose local index is `li`.
+    void prepareObject (int li);
+
     // An instance of union Object constructs and stores any one of
     // the objects declared (constant or gaussian or parser).
     union Object {
@@ -615,6 +735,10 @@ private:
         InjectorMomentumParser parser;
     };
     Object object;
+#if defined(AMREX_USE_OMP) && !defined(AMREX_USE_GPU)
+    std::unique_ptr<void,amrex::DataDeleter> inj_mom_data;
+    amrex::Vector<InjectorMomentum*> inj_mom_omp;
+#endif
 };
 
 // In order for InjectorMomentum to be trivially copyable, its destructor

--- a/Source/Initialization/InjectorMomentum.cpp
+++ b/Source/Initialization/InjectorMomentum.cpp
@@ -7,6 +7,8 @@
  */
 #include "InjectorMomentum.H"
 
+#include <AMReX_OpenMP.H>
+
 using namespace amrex;
 
 void InjectorMomentum::clear () // NOLINT(readability-make-member-function-const)
@@ -23,5 +25,166 @@ void InjectorMomentum::clear () // NOLINT(readability-make-member-function-const
     {
         break;
     }
+    }
+
+#if defined(AMREX_USE_OMP) && !defined(AMREX_USE_GPU)
+    inj_mom_omp.clear();
+    inj_mom_data.reset();
+#endif
+}
+
+void InjectorMomentum::prepare (amrex::BoxArray const& grids,
+                                amrex::DistributionMapping const& dmap,
+                                amrex::IntVect const& ngrow,
+                                std::function<amrex::Real(amrex::Real)> const& get_zlab)
+{
+    switch (type)
+    {
+    case Type::maxwellian:
+    {
+        object.maxwellian.prepare(grids,dmap,ngrow,get_zlab);
+        break;
+    }
+    case Type::juttner:
+    {
+        object.juttner.prepare(grids,dmap,ngrow,get_zlab);
+        break;
+    }
+    case Type::parser:
+    {
+        object.parser.prepare(grids,dmap,ngrow,get_zlab);
+        break;
+    }
+    default:
+        break;
+    }
+
+#if defined(AMREX_USE_OMP) && !defined(AMREX_USE_GPU)
+    if (this->distributed()) {
+        auto const nthreads = amrex::OpenMP::get_max_threads();
+        inj_mom_data = std::unique_ptr<void,amrex::DataDeleter>
+            (amrex::The_Cpu_Arena()->alloc(sizeof(InjectorMomentum)*nthreads),
+             amrex::DataDeleter{amrex::The_Cpu_Arena()});
+        auto* p = reinterpret_cast<InjectorMomentum*>(inj_mom_data.get());
+        inj_mom_omp.clear();
+        for (int tid = 0; tid < nthreads; ++tid) {
+            inj_mom_omp.push_back(p++);
+        }
+        for (auto* q : inj_mom_omp) {
+            std::memcpy((void*)q, (void const*)this, sizeof(InjectorMomentum));
+        }
+    }
+#endif
+}
+
+void InjectorMomentum::prepare (amrex::RealBox const& pbox, int moving_dir, int moving_sign,
+                                std::function<amrex::Real(amrex::Real)> const& get_zlab)
+{
+    switch (type)
+    {
+    case Type::maxwellian:
+    {
+        object.maxwellian.prepare(pbox, moving_dir, moving_sign, get_zlab);
+        break;
+    }
+    case Type::juttner:
+    {
+        object.juttner.prepare(pbox, moving_dir, moving_sign, get_zlab);
+        break;
+    }
+    case Type::parser:
+    {
+        object.parser.prepare(pbox, moving_dir, moving_sign, get_zlab);
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+void InjectorMomentum::prepareObject (int li)
+{
+    switch (type)
+    {
+    case Type::maxwellian:
+    {
+        object.maxwellian.prepare(li);
+        break;
+    }
+    case Type::juttner:
+    {
+        object.juttner.prepare(li);
+        break;
+    }
+    case Type::parser:
+    {
+        object.parser.prepare(li);
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+void InjectorMomentum::prepare (int li, InjectorMomentum** inj_mom)
+{
+    if (this->needPreparation()) {
+#if defined(AMREX_USE_OMP) && !defined(AMREX_USE_GPU)
+        if (inj_mom_data) {
+            auto* my_inj_mom = inj_mom_omp[amrex::OpenMP::get_thread_num()];
+            my_inj_mom->prepareObject(li);
+            *inj_mom = my_inj_mom;
+        } else
+#endif
+        {
+            prepareObject(li);
+#ifdef AMREX_USE_GPU
+            amrex::Gpu::htod_memcpy_async(*inj_mom, this, sizeof(InjectorMomentum));
+#else
+            *inj_mom = this;
+#endif
+        }
+    }
+}
+
+bool InjectorMomentum::needPreparation () const
+{
+    switch (type)
+    {
+    case Type::maxwellian:
+    {
+        return object.maxwellian.needPreparation();
+    }
+    case Type::juttner:
+    {
+        return object.juttner.needPreparation();
+    }
+    case Type::parser:
+    {
+        return object.parser.needPreparation();
+    }
+    default:
+        return false;
+    }
+}
+
+bool InjectorMomentum::distributed () const
+{
+    switch (type)
+    {
+    case Type::maxwellian:
+    {
+        return object.maxwellian.distributed();
+    }
+    case Type::juttner:
+    {
+        return object.juttner.distributed();
+    }
+    case Type::parser:
+    {
+        return object.parser.distributed();
+    }
+    default:
+        return false;
     }
 }

--- a/Source/Initialization/PlasmaInjector.H
+++ b/Source/Initialization/PlasmaInjector.H
@@ -153,6 +153,7 @@ public:
     [[nodiscard]] InjectorFlux*  getInjectorFlux () const;
     [[nodiscard]] InjectorMomentum* getInjectorMomentumDevice () const;
     [[nodiscard]] InjectorMomentum* getInjectorMomentumHost () const;
+    [[nodiscard]] InjectorMomentum* getInjectorMomentum (int li) const;
 
     void prepare (amrex::BoxArray const& grids,
                   amrex::DistributionMapping const& dmap,
@@ -198,6 +199,7 @@ protected:
 
     std::unique_ptr<InjectorMomentum,InjectorMomentumDeleter> h_inj_mom;
     InjectorMomentum* d_inj_mom = nullptr;
+    bool inj_mom_distributed = false;
 
     // Keep a pointer to TemperatureProperties to ensure the lifetime of the
     // contained Parser

--- a/Source/Initialization/PlasmaInjector.cpp
+++ b/Source/Initialization/PlasmaInjector.cpp
@@ -706,11 +706,30 @@ PlasmaInjector::getInjectorMomentumHost () const
     return h_inj_mom.get();
 }
 
+InjectorMomentum*
+PlasmaInjector::getInjectorMomentum (int li) const
+{
+    auto* inj_mom = d_inj_mom;
+    if (inj_mom_distributed) {
+        h_inj_mom->prepare(li, &inj_mom);
+    }
+    return inj_mom;
+}
+
 void PlasmaInjector::prepare (amrex::BoxArray const& grids,
                               amrex::DistributionMapping const& dmap,
                               amrex::IntVect const& ngrow,
                               std::function<amrex::Real(amrex::Real)> const& get_zlab)
 {
+    // Only distributed data need to be prepared here: data that are not
+    // distributed have already been read in full, in SpeciesUtils::parseMomentum.
+    // The momentum injector is prepared before the density injector, because
+    // `get_zlab` uses the bulk momentum.
+    if (h_inj_mom && h_inj_mom->distributed()) {
+        h_inj_mom->prepare(grids, dmap, ngrow, get_zlab);
+        inj_mom_distributed = true;
+    }
+
     if (h_inj_rho) {
         h_inj_rho->prepare(grids, dmap, ngrow, get_zlab);
         inj_rho_distributed = h_inj_rho->distributed();
@@ -727,6 +746,11 @@ void PlasmaInjector::prepare (amrex::BoxArray const& grids,
 void PlasmaInjector::prepare (amrex::RealBox const& pbox, int moving_dir, int moving_sign,
                               std::function<amrex::Real(amrex::Real)> const& get_zlab)
 {
+    // Continuous injection only happens with a moving window, in which case the
+    // momentum data are never distributed (see SpeciesUtils::parseMomentum), so
+    // there is nothing to prepare for the momentum injector here.
+    inj_mom_distributed = false;
+
     if (h_inj_rho) {
         h_inj_rho->prepare(pbox, moving_dir, moving_sign, get_zlab);
 #ifdef AMREX_USE_GPU

--- a/Source/Initialization/TemperatureProperties.H
+++ b/Source/Initialization/TemperatureProperties.H
@@ -44,9 +44,11 @@ struct TemperatureProperties
      * \param[in] pp: Reference to the parameter parser object for the species being initialized
      * \param[in] source_name: Optional group name of the input parameters
      * \param[in] geom: Domain geometry (for openPMD external fields when used)
+     * \param[in] allow_distributed: Whether the injection style supports reading the openPMD
+     * data distributedly. This is the default value of `read_u_std_distributed`.
      */
     TemperatureProperties (const amrex::ParmParse& pp, std::string const& source_name,
-                           amrex::Geometry const& geom);
+                           amrex::Geometry const& geom, bool allow_distributed);
 
     /* Type of temperature initialization */
     TemperatureInitType m_type;

--- a/Source/Initialization/TemperatureProperties.cpp
+++ b/Source/Initialization/TemperatureProperties.cpp
@@ -12,8 +12,6 @@
 #include "Utils/TextMsg.H"
 #include "WarpX.H"
 
-#include <AMReX_BoxArray.H>
-#include <AMReX_DistributionMapping.H>
 #include <AMReX_IntVect.H>
 
 #include <sstream>
@@ -24,9 +22,9 @@
  *  for `maxwellian` distribution, and `theta` for `maxwell_juttner`.
  */
 TemperatureProperties::TemperatureProperties (const amrex::ParmParse& pp, std::string const& source_name,
-                                              amrex::Geometry const& geom)
+                                              amrex::Geometry const& geom, bool allow_distributed)
 {
-    amrex::ignore_unused(geom);
+    amrex::ignore_unused(geom, allow_distributed);
 
     std::string mom_dist_s;
     utils::parser::query(pp, source_name, "momentum_distribution_type", mom_dist_s);
@@ -97,22 +95,24 @@ TemperatureProperties::TemperatureProperties (const amrex::ParmParse& pp, std::s
                     "supported in boosted-frame simulations yet.");
             }
             utils::parser::get(pp, source_name, "read_u_std_from_path", m_read_u_std_path);
+            bool distributed = allow_distributed;
+            pp.query("read_u_std_distributed", distributed);
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(allow_distributed || !distributed,
+                "read_u_std_distributed = 1 is only supported for the injection styles "
+                "that inject particles cell by cell (NRandomPerCell and NUniformPerCell), "
+                "and without moving window. In the other cases, the openPMD data must be "
+                "read in full on every MPI process: set read_u_std_distributed = 0.");
             amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const problo =
                 geom.ProbLoArray();
             amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx =
                 geom.CellSizeArray();
             amrex::Box const dombox = amrex::convert(geom.Domain(), amrex::IntVect(1));
             m_u_std_x_reader = std::make_unique<ExternalFieldReader>(
-                m_read_u_std_path, "u_std", "x", problo, dx, dombox, false);
+                m_read_u_std_path, "u_std", "x", problo, dx, dombox, distributed);
             m_u_std_y_reader = std::make_unique<ExternalFieldReader>(
-                m_read_u_std_path, "u_std", "y", problo, dx, dombox, false);
+                m_read_u_std_path, "u_std", "y", problo, dx, dombox, distributed);
             m_u_std_z_reader = std::make_unique<ExternalFieldReader>(
-                m_read_u_std_path, "u_std", "z", problo, dx, dombox, false);
-            amrex::BoxArray const grids;
-            amrex::DistributionMapping const dmap;
-            m_u_std_x_reader->prepare(grids, dmap, amrex::IntVect(0));
-            m_u_std_y_reader->prepare(grids, dmap, amrex::IntVect(0));
-            m_u_std_z_reader->prepare(grids, dmap, amrex::IntVect(0));
+                m_read_u_std_path, "u_std", "z", problo, dx, dombox, distributed);
             m_type = TempFromFileVector;
 #else
             WARPX_ABORT_WITH_MESSAGE(

--- a/Source/Initialization/VelocityProperties.H
+++ b/Source/Initialization/VelocityProperties.H
@@ -41,9 +41,11 @@ struct VelocityProperties
      * \param[in] pp: Reference to the parameter parser object for the species being initialized
      * \param[in] source_name: Optional group name of the input parameters
      * \param[in] geom: Simulation geometry (for aligning openPMD external fields)
+     * \param[in] allow_distributed: Whether the injection style supports reading the openPMD
+     * data distributedly. This is the default value of `read_u_mean_distributed`.
      */
     VelocityProperties (const amrex::ParmParse& pp, std::string const& source_name,
-                        amrex::Geometry const& geom);
+                        amrex::Geometry const& geom, bool allow_distributed);
 
     /* Type of velocity initialization */
     VelocityInitType m_type;

--- a/Source/Initialization/VelocityProperties.cpp
+++ b/Source/Initialization/VelocityProperties.cpp
@@ -13,8 +13,6 @@
 #include "Utils/TextMsg.H"
 #include "WarpX.H"
 
-#include <AMReX_BoxArray.H>
-#include <AMReX_DistributionMapping.H>
 #include <AMReX_IntVect.H>
 
 #include <cmath>
@@ -30,9 +28,9 @@ namespace {
      */
     void ParseVelocityVector (const amrex::ParmParse& pp, std::string const& source_name,
                               std::string const& dist_type_param, VelocityProperties& vel,
-                              amrex::Geometry const& geom)
+                              amrex::Geometry const& geom, bool allow_distributed)
     {
-        amrex::ignore_unused(geom);
+        amrex::ignore_unused(geom, allow_distributed);
 
         std::string u_mean_dist_s = "constant";
         utils::parser::query(pp, source_name, dist_type_param.c_str(), u_mean_dist_s);
@@ -66,22 +64,24 @@ namespace {
             }
             utils::parser::get(pp, source_name, "read_u_mean_from_path",
                                vel.m_read_u_mean_path);
+            bool distributed = allow_distributed;
+            pp.query("read_u_mean_distributed", distributed);
+            WARPX_ALWAYS_ASSERT_WITH_MESSAGE(allow_distributed || !distributed,
+                "read_u_mean_distributed = 1 is only supported for the injection styles "
+                "that inject particles cell by cell (NRandomPerCell and NUniformPerCell), "
+                "and without moving window. In the other cases, the openPMD data must be "
+                "read in full on every MPI process: set read_u_mean_distributed = 0.");
             amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const problo =
                 geom.ProbLoArray();
             amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> const dx =
                 geom.CellSizeArray();
             amrex::Box const dombox = amrex::convert(geom.Domain(), amrex::IntVect(1));
             vel.m_u_mean_x_reader = std::make_unique<ExternalFieldReader>(
-                vel.m_read_u_mean_path, "u_mean", "x", problo, dx, dombox, false);
+                vel.m_read_u_mean_path, "u_mean", "x", problo, dx, dombox, distributed);
             vel.m_u_mean_y_reader = std::make_unique<ExternalFieldReader>(
-                vel.m_read_u_mean_path, "u_mean", "y", problo, dx, dombox, false);
+                vel.m_read_u_mean_path, "u_mean", "y", problo, dx, dombox, distributed);
             vel.m_u_mean_z_reader = std::make_unique<ExternalFieldReader>(
-                vel.m_read_u_mean_path, "u_mean", "z", problo, dx, dombox, false);
-            amrex::BoxArray const grids;
-            amrex::DistributionMapping const dmap;
-            vel.m_u_mean_x_reader->prepare(grids, dmap, amrex::IntVect(0));
-            vel.m_u_mean_y_reader->prepare(grids, dmap, amrex::IntVect(0));
-            vel.m_u_mean_z_reader->prepare(grids, dmap, amrex::IntVect(0));
+                vel.m_read_u_mean_path, "u_mean", "z", problo, dx, dombox, distributed);
             vel.m_type = VelFromFileVector;
 #else
             WARPX_ABORT_WITH_MESSAGE(
@@ -106,15 +106,16 @@ namespace {
 * `parse_momentum_function`.
 */
 VelocityProperties::VelocityProperties (const amrex::ParmParse& pp, std::string const& source_name,
-                                        amrex::Geometry const& geom)
+                                        amrex::Geometry const& geom, bool allow_distributed)
 {
     std::string mom_dist_s;
     utils::parser::query(pp, source_name, "momentum_distribution_type", mom_dist_s);
     if (mom_dist_s == "maxwell_juttner") {
         ParseVelocityVector(pp, source_name, "maxwell_juttner_u_mean_distribution_type", *this,
-                            geom);
+                            geom, allow_distributed);
     } else if (mom_dist_s == "maxwellian") {
-        ParseVelocityVector(pp, source_name, "maxwellian_u_mean_distribution_type", *this, geom);
+        ParseVelocityVector(pp, source_name, "maxwellian_u_mean_distribution_type", *this, geom,
+                            allow_distributed);
     }
     else if (mom_dist_s == "parse_momentum_function") {
         std::string str_ux_mean_function, str_uy_mean_function, str_uz_mean_function;

--- a/Source/Particles/ParticleCreation/AddParticles.cpp
+++ b/Source/Particles/ParticleCreation/AddParticles.cpp
@@ -81,6 +81,7 @@
 #include <array>
 #include <cmath>
 #include <cstdlib>
+#include <functional>
 #include <limits>
 #include <map>
 #include <random>
@@ -775,7 +776,6 @@ PhysicalParticleContainer::AddPlasma (PlasmaInjector& plasma_injector, int lev, 
     const bool refine_injection = findRefinedInjectionBox(fine_injection_box, rrfac);
 
     InjectorPosition* inj_pos = plasma_injector.getInjectorPosition();
-    InjectorMomentum* inj_mom = plasma_injector.getInjectorMomentumDevice();
     InjectorMomentum* h_inj_mom = plasma_injector.getInjectorMomentumHost();
     const amrex::Real gamma_boost = WarpX::gamma_boost;
     const amrex::Real beta_boost = WarpX::beta_boost;
@@ -794,11 +794,18 @@ PhysicalParticleContainer::AddPlasma (PlasmaInjector& plasma_injector, int lev, 
                                                      m_user_int_attrib_parser,
                                                      m_user_real_attrib_parser);
 
-    auto get_zlab = [=] (amrex::Real z) -> amrex::Real
-    {
-        return applyBallisticCorrection(amrex::XDim3{0._rt, 0._rt, z}, h_inj_mom,
-                                        gamma_boost, beta_boost, t);
-    };
+    // `get_zlab` is the identity when there is no boost and no ballistic drift.
+    // In that case, leave it empty: this avoids evaluating the bulk momentum
+    // before the momentum injector has been prepared (which is needed when the
+    // bulk momentum is read from a file).
+    std::function<amrex::Real(amrex::Real)> get_zlab;
+    if (gamma_boost != 1._rt || t != 0._rt) {
+        get_zlab = [=] (amrex::Real z) -> amrex::Real
+        {
+            return applyBallisticCorrection(amrex::XDim3{0._rt, 0._rt, z}, h_inj_mom,
+                                            gamma_boost, beta_boost, t);
+        };
+    }
 
     if (initial_injection) {
         // Initial particle injection
@@ -842,6 +849,7 @@ PhysicalParticleContainer::AddPlasma (PlasmaInjector& plasma_injector, int lev, 
         }
 
         auto* inj_rho = plasma_injector.getInjectorDensity(mfi.LocalIndex());
+        auto* inj_mom = plasma_injector.getInjectorMomentum(mfi.LocalIndex());
 
         const int grid_id = mfi.index();
         const int tile_id = mfi.LocalTileIndex();

--- a/Source/Utils/SpeciesUtils.cpp
+++ b/Source/Utils/SpeciesUtils.cpp
@@ -8,6 +8,11 @@
 #include <ablastr/warn_manager/WarnManager.H>
 #include "Utils/TextMsg.H"
 #include "Utils/Parser/ParserUtils.H"
+#include "WarpX.H"
+
+#include <AMReX_BoxArray.H>
+#include <AMReX_DistributionMapping.H>
+#include <AMReX_IntVect.H>
 
 namespace SpeciesUtils {
 
@@ -130,6 +135,19 @@ namespace SpeciesUtils {
 
         const amrex::ParmParse pp_species(species_name);
 
+        // Reading the openPMD data distributedly requires the BoxArray and the
+        // DistributionMapping of the destination container, which are only
+        // available for the injection styles that inject cell by cell (and for
+        // the fluid container, whose style is "none"). It is also incompatible
+        // with the moving window, because the bulk momentum is then evaluated
+        // on the host, outside of the injection loop (see
+        // UpdateInjectionPosition in WarpXMovingWindow.cpp). In the other
+        // cases, the openPMD data are read in full on every MPI process.
+        const bool allow_distributed = ((style == "nrandompercell") ||
+                                        (style == "nuniformpercell") ||
+                                        (style == "none")) &&
+                                       !WarpX::do_moving_window;
+
         // parse momentum information
         std::string mom_dist_s;
         utils::parser::get(pp_species, source_name, "momentum_distribution_type", mom_dist_s);
@@ -204,15 +222,19 @@ namespace SpeciesUtils {
             h_inj_mom.reset(new InjectorMomentum((InjectorMomentumUniform*)nullptr,
                                                 ux_min, uy_min, uz_min, ux_max, uy_max, uz_max));
         } else if (mom_dist_s == "maxwellian") {
-            h_mom_temp = std::make_unique<TemperatureProperties>(pp_species, source_name, geom);
+            h_mom_temp = std::make_unique<TemperatureProperties>(pp_species, source_name, geom,
+                                                                allow_distributed);
             const GetTemperatureVector getTempVec(*h_mom_temp);
-            h_mom_vel = std::make_unique<VelocityProperties>(pp_species, source_name, geom);
+            h_mom_vel = std::make_unique<VelocityProperties>(pp_species, source_name, geom,
+                                                            allow_distributed);
             const GetVelocityVector getVelVec(*h_mom_vel);
             h_inj_mom.reset(new InjectorMomentum((InjectorMomentumMaxwellian*)nullptr, getTempVec, getVelVec));
         } else if (mom_dist_s == "maxwell_juttner"){
-            h_mom_temp = std::make_unique<TemperatureProperties>(pp_species, source_name, geom);
+            h_mom_temp = std::make_unique<TemperatureProperties>(pp_species, source_name, geom,
+                                                                allow_distributed);
             const GetTemperature getTemp(*h_mom_temp);
-            h_mom_vel = std::make_unique<VelocityProperties>(pp_species, source_name, geom);
+            h_mom_vel = std::make_unique<VelocityProperties>(pp_species, source_name, geom,
+                                                            allow_distributed);
             const GetVelocityVector getVelVec(*h_mom_vel);
             // Construct InjectorMomentum with InjectorMomentumJuttner.
             h_inj_mom.reset(new InjectorMomentum((InjectorMomentumJuttner*)nullptr, getTemp, getVelVec));
@@ -220,12 +242,24 @@ namespace SpeciesUtils {
             // The momentum is defined by the parser functions ux_mean_function,
             // uy_mean_function, uz_mean_function, stored in VelocityProperties and
             // evaluated through GetVelocityVector (the parsers are owned by h_mom_vel).
-            h_mom_vel = std::make_unique<VelocityProperties>(pp_species, source_name, geom);
+            h_mom_vel = std::make_unique<VelocityProperties>(pp_species, source_name, geom,
+                                                            allow_distributed);
             const GetVelocityVector getVelVec(*h_mom_vel);
             // Construct InjectorMomentum with InjectorMomentumParser.
             h_inj_mom.reset(new InjectorMomentum((InjectorMomentumParser*)nullptr, getVelVec));
         } else {
             StringParseAbortMessage("Momentum distribution type", mom_dist_s);
+        }
+
+        // openPMD data that are not distributed among MPI processes are read in
+        // full right away, because this does not require the BoxArray and the
+        // DistributionMapping of the destination container. (Distributed data
+        // are read later, in PlasmaInjector::prepare and
+        // WarpXFluidContainer::InitData.) This is a no-op if the momentum is
+        // not read from a file.
+        if (h_inj_mom && ! h_inj_mom->distributed()) {
+            h_inj_mom->prepare(amrex::BoxArray{}, amrex::DistributionMapping{},
+                               amrex::IntVect(0), nullptr);
         }
     }
 


### PR DESCRIPTION
Mirrors the distributed reading of the density profile (`read_density_distributed`), for the `u_mean` and `u_std` momentum profiles added in #6999:

* `<species>.read_u_mean_distributed` / `<species>.read_u_std_distributed` select whether each MPI rank reads only the chunk of the openPMD data it needs, or the whole data set.
* `GetVelocityVector` / `GetTemperatureVector` gain the `prepare` / `distributed` interface of `InjectorDensityFromFile`, forwarded through `InjectorMomentum` (the analogue of `InjectorDensity`) and `PlasmaInjector::getInjectorMomentum(li)` (the analogue of `getInjectorDensity(li)`).
* Distributed reading needs the BoxArray and DistributionMapping of the destination container, so it is only available for the cell-by-cell injection styles and the fluid container, and without moving window. It is the default there, and off (with an explicit abort if requested) elsewhere, where the data are read in full when the injector is created.