### PR TITLE
Docs: clarify LinearSolver/LinearFunction operator interface

### DIFF
--- a/Source/NonlinearSolvers/AMReXGMRES_Wrapper.H
+++ b/Source/NonlinearSolvers/AMReXGMRES_Wrapper.H
@@ -24,8 +24,7 @@
  *    The Ops class represents the linear operator A of the linear system
  *    A x = b solved by solve(). It must implement the interface defined in
  *    LinearFunction.H; in particular, an apply( Ax_vec, x_vec ) function
- *    that computes the action A*x of the operator on a vector x. See
- *    JacobianFunctionMF.H for an example.
+ *    that computes the action A(x) of the operator on a vector x.
  *
  *    The Vec class must have basic math operators, such as Copy, +=, -=,
  *    increment(), linComb(), scale(), etc.. See WarpXSolverVec.H for an example.
@@ -59,7 +58,7 @@ public:
 
     /**
      * \brief Solve the linear system A x = b for x, where A is the linear
-     *        operator whose action A*x on a vector x is computed by
+     *        operator whose action A(x) on a vector x is computed by
      *        Ops::apply(), and where the right-hand side b is a given
      *        vector that does not depend on x.
      *

--- a/Source/NonlinearSolvers/AMReXGMRES_Wrapper.H
+++ b/Source/NonlinearSolvers/AMReXGMRES_Wrapper.H
@@ -63,7 +63,7 @@ public:
      *        vector that does not depend on x.
      *
      * \param a_sol     unknowns, i.e., x in A x = b.
-     * \param a_rhs     RHS, i.e., b in A x = b (independent of x).
+     * \param a_rhs     RHS, i.e., b in A x = b.
      * \param a_tol_rel relative tolerance.
      * \param a_tol_abs absolute tolerance.
      * \param a_its     optional argument specifying the maximum number of iterations.

--- a/Source/NonlinearSolvers/AMReXGMRES_Wrapper.H
+++ b/Source/NonlinearSolvers/AMReXGMRES_Wrapper.H
@@ -21,9 +21,11 @@
  *    solver for more details. This class is templated on a vector class Vec,
  *    and an operator class Ops.
  *
- *    The Ops class must have the following function:
- *    ComputeRHS( R_vec, U_vec, time, nl_iter, from_jacobian ),
- *    where U_vec and R_vec are of type Vec.
+ *    The Ops class represents the linear operator A of the linear system
+ *    A x = b solved by solve(). It must implement the interface defined in
+ *    LinearFunction.H; in particular, an apply( Ax_vec, x_vec ) function
+ *    that computes the action A*x of the operator on a vector x. See
+ *    JacobianFunctionMF.H for an example.
  *
  *    The Vec class must have basic math operators, such as Copy, +=, -=,
  *    increment(), linComb(), scale(), etc.. See WarpXSolverVec.H for an example.
@@ -56,10 +58,13 @@ public:
     }
 
     /**
-     * \brief Solve the linear system
+     * \brief Solve the linear system A x = b for x, where A is the linear
+     *        operator whose action A*x on a vector x is computed by
+     *        Ops::apply(), and where the right-hand side b is a given
+     *        vector that does not depend on x.
      *
      * \param a_sol     unknowns, i.e., x in A x = b.
-     * \param a_rhs     RHS, i.e., b in A x = b.
+     * \param a_rhs     RHS, i.e., b in A x = b (independent of x).
      * \param a_tol_rel relative tolerance.
      * \param a_tol_abs absolute tolerance.
      * \param a_its     optional argument specifying the maximum number of iterations.

--- a/Source/NonlinearSolvers/AMReXGMRES_Wrapper.H
+++ b/Source/NonlinearSolvers/AMReXGMRES_Wrapper.H
@@ -19,9 +19,9 @@
  *    This class is a wrapper for AMReX's GMRES algorithm that inherits from
  *    WarpX's LinearSolver base class. See the documentation of AMReX's GMRES
  *    solver for more details. This class is templated on a vector class Vec,
- *    and an operator class Ops.
+ *    and a linear operator class LinOp.
  *
- *    The Ops class represents the linear operator A of the linear system
+ *    The LinOp class represents the linear operator A of the linear system
  *    A x = b solved by solve(). It must implement the interface defined in
  *    LinearFunction.H; in particular, an apply( Ax_vec, x_vec ) function
  *    that computes the action A(x) of the operator on a vector x.
@@ -29,12 +29,12 @@
  *    The Vec class must have basic math operators, such as Copy, +=, -=,
  *    increment(), linComb(), scale(), etc.. See WarpXSolverVec.H for an example.
  */
-template <typename Vec, typename Ops>
-class AMReXGMRES : public LinearSolver<Vec,Ops>
+template <typename Vec, typename LinOp>
+class AMReXGMRES : public LinearSolver<Vec,LinOp>
 {
 public:
 
-    using RT = typename Ops::RT; // double or float
+    using RT = typename LinOp::RT; // double or float
 
     AMReXGMRES () = default;
 
@@ -46,20 +46,20 @@ public:
     AMReXGMRES(AMReXGMRES&&) noexcept = delete;
     AMReXGMRES& operator=(AMReXGMRES&&) noexcept = delete;
 
-    //! Defines with a reference to Ops. It's the user's responsibility to
-    //! keep the Ops object alive for GMRES to be functional. This function
+    //! Defines with a reference to LinOp. It's the user's responsibility to
+    //! keep the LinOp object alive for GMRES to be functional. This function
     //! must be called before solve() can be called.
     AMREX_FORCE_INLINE
-    void define (Ops& linop) override
+    void define (LinOp& linop) override
     {
-        m_solver = std::make_unique<amrex::GMRES<Vec,Ops>>();
+        m_solver = std::make_unique<amrex::GMRES<Vec,LinOp>>();
         m_solver->define(linop);
     }
 
     /**
      * \brief Solve the linear system A x = b for x, where A is the linear
      *        operator whose action A(x) on a vector x is computed by
-     *        Ops::apply(), and where the right-hand side b is a given
+     *        LinOp::apply(), and where the right-hand side b is a given
      *        vector that does not depend on x.
      *
      * \param a_sol     unknowns, i.e., x in A x = b.
@@ -103,7 +103,7 @@ public:
     RT getResidualNorm () const override { return m_solver->getResidualNorm(); }
 
 private:
-    std::unique_ptr<amrex::GMRES<Vec,Ops>> m_solver = nullptr;
+    std::unique_ptr<amrex::GMRES<Vec,LinOp>> m_solver = nullptr;
 };
 
 #endif

--- a/Source/NonlinearSolvers/LinearFunction.H
+++ b/Source/NonlinearSolvers/LinearFunction.H
@@ -37,25 +37,23 @@ class LinearFunction
         /**
          * \brief Apply the linear operator A represented by this
          *        LinearFunction object on a given vector of type T,
-         *        i.e., compute its action a_Ax = A * a_x.
+         *        i.e., compute its action a_Ax = A(a_x).
          *
-         * \param a_Ax result of applying the operator, i.e., A * a_x.
+         * \param a_Ax result of applying the operator, i.e., A(a_x).
          * \param a_x  vector the operator is applied to.
          */
         virtual void apply ( T& a_Ax, const T& a_x ) = 0;
 
         /**
-         * \brief Apply the preconditioner on a given vector of type T,
-         *        i.e., solve P * a_U = a_X for a_U, where P is an
-         *        approximation of the linear operator A represented by
-         *        this LinearFunction object (so a_U is an approximation
-         *        of the solution of A * a_U = a_X). If there is no
-         *        preconditioner, P = I and a_U is a copy of a_X.
+         * \brief Apply right-preconditioning, i.e., solve P(a_lhs) = a_rhs,
+         *        where P is an approximation to the linear operator A
+         *        represented by this LinearFunction object. If there is no
+         *        preconditioner, P = I and this function does a_lhs = a_rhs.
          *
-         * \param a_U result of applying the preconditioner, i.e., P^{-1} * a_X.
-         * \param a_X vector the preconditioner is applied to.
+         * \param a_lhs result of applying the preconditioner, i.e., P^{-1}(a_rhs).
+         * \param a_rhs vector the preconditioner is applied to.
          */
-        virtual void precond ( T& a_U, const T& a_X ) = 0;
+        virtual void precond ( T& a_lhs, const T& a_rhs ) = 0;
 
         //! update preconditioner
         virtual void updatePreCondMat ( const T&  a_X ) = 0;

--- a/Source/NonlinearSolvers/LinearFunction.H
+++ b/Source/NonlinearSolvers/LinearFunction.H
@@ -45,15 +45,17 @@ class LinearFunction
         virtual void apply ( T& a_Ax, const T& a_x ) = 0;
 
         /**
-         * \brief Apply right-preconditioning, i.e., solve P(a_lhs) = a_rhs,
-         *        where P is an approximation to the linear operator A
-         *        represented by this LinearFunction object. If there is no
-         *        preconditioner, P = I and this function does a_lhs = a_rhs.
+         * \brief Apply the preconditioner on a given vector of type T,
+         *        i.e., solve P(a_U) = a_X for a_U, where P is an
+         *        approximation of the linear operator A represented by
+         *        this LinearFunction object (so a_U is an approximation
+         *        of the solution of A(a_U) = a_X). If there is no
+         *        preconditioner, P = I and a_U is a copy of a_X.
          *
-         * \param a_lhs result of applying the preconditioner, i.e., P^{-1}(a_rhs).
-         * \param a_rhs vector the preconditioner is applied to.
+         * \param a_U result of applying the preconditioner, i.e., P^{-1}(a_X).
+         * \param a_X vector the preconditioner is applied to.
          */
-        virtual void precond ( T& a_lhs, const T& a_rhs ) = 0;
+        virtual void precond ( T& a_U, const T& a_X ) = 0;
 
         //! update preconditioner
         virtual void updatePreCondMat ( const T&  a_X ) = 0;

--- a/Source/NonlinearSolvers/LinearFunction.H
+++ b/Source/NonlinearSolvers/LinearFunction.H
@@ -34,8 +34,15 @@ class LinearFunction
         LinearFunction(LinearFunction&&) noexcept = default;
         LinearFunction& operator=(LinearFunction&&) noexcept = default;
 
-        //! apply the linear function on a given vector of type T
-        virtual void apply ( T& a_dF, const T& a_dU ) = 0;
+        /**
+         * \brief Apply the linear operator A represented by this
+         *        LinearFunction object on a given vector of type T,
+         *        i.e., compute its action a_Ax = A * a_x.
+         *
+         * \param a_Ax result of applying the operator, i.e., A * a_x.
+         * \param a_x  vector the operator is applied to.
+         */
+        virtual void apply ( T& a_Ax, const T& a_x ) = 0;
 
         //! apply the preconditioner on a given vector of type T
         virtual void precond ( T& a_U, const T& a_X ) = 0;

--- a/Source/NonlinearSolvers/LinearFunction.H
+++ b/Source/NonlinearSolvers/LinearFunction.H
@@ -44,7 +44,17 @@ class LinearFunction
          */
         virtual void apply ( T& a_Ax, const T& a_x ) = 0;
 
-        //! apply the preconditioner on a given vector of type T
+        /**
+         * \brief Apply the preconditioner on a given vector of type T,
+         *        i.e., solve P * a_U = a_X for a_U, where P is an
+         *        approximation of the linear operator A represented by
+         *        this LinearFunction object (so a_U is an approximation
+         *        of the solution of A * a_U = a_X). If there is no
+         *        preconditioner, P = I and a_U is a copy of a_X.
+         *
+         * \param a_U result of applying the preconditioner, i.e., P^{-1} * a_X.
+         * \param a_X vector the preconditioner is applied to.
+         */
         virtual void precond ( T& a_U, const T& a_X ) = 0;
 
         //! update preconditioner

--- a/Source/NonlinearSolvers/LinearSolver.H
+++ b/Source/NonlinearSolvers/LinearSolver.H
@@ -45,7 +45,7 @@ public:
      *        vector that does not depend on x.
      *
      * \param a_sol     unknowns, i.e., x in A x = b.
-     * \param a_rhs     RHS, i.e., b in A x = b (independent of x).
+     * \param a_rhs     RHS, i.e., b in A x = b.
      * \param a_tol_rel relative tolerance.
      * \param a_tol_abs absolute tolerance.
      * \param a_its     optional argument specifying the maximum number of iterations.

--- a/Source/NonlinearSolvers/LinearSolver.H
+++ b/Source/NonlinearSolvers/LinearSolver.H
@@ -9,9 +9,8 @@
  *    The Ops class represents the linear operator A of the linear system
  *    A x = b solved by solve(). It must implement the interface defined in
  *    LinearFunction.H; in particular, an apply( Ax_vec, x_vec ) function
- *    that computes the action A*x of the operator on a vector x, as well as
+ *    that computes the action A(x) of the operator on a vector x, as well as
  *    precond(), makeVecLHS(), makeVecRHS(), and basic vector operations.
- *    See JacobianFunctionMF.H for an example.
  *
  *    The Vec class must have basic math operators, such as Copy, +=, -=,
  *    increment(), linComb(), scale(), etc.. See WarpXSolverVec.H for an example.
@@ -41,7 +40,7 @@ public:
 
     /**
      * \brief Solve the linear system A x = b for x, where A is the linear
-     *        operator whose action A*x on a vector x is computed by
+     *        operator whose action A(x) on a vector x is computed by
      *        Ops::apply(), and where the right-hand side b is a given
      *        vector that does not depend on x.
      *

--- a/Source/NonlinearSolvers/LinearSolver.H
+++ b/Source/NonlinearSolvers/LinearSolver.H
@@ -10,8 +10,7 @@
  *    The LinOp class represents the linear operator A of the linear system
  *    A x = b solved by solve(). It must implement the interface defined in
  *    LinearFunction.H; in particular, an apply( Ax_vec, x_vec ) function
- *    that computes the action A(x) of the operator on a vector x, as well as
- *    precond(), makeVecLHS(), makeVecRHS(), and basic vector operations.
+ *    that computes the action A(x) of the operator on a vector x
  *
  *    The Vec class must have basic math operators, such as Copy, +=, -=,
  *    increment(), linComb(), scale(), etc.. See WarpXSolverVec.H for an example.

--- a/Source/NonlinearSolvers/LinearSolver.H
+++ b/Source/NonlinearSolvers/LinearSolver.H
@@ -4,9 +4,10 @@
 /**
  * \brief Top-level class for the linear solver
  *
- *    This class is templated on a vector class Vec, and an operator class Ops.
+ *    This class is templated on a vector class Vec, and a linear operator
+ *    class LinOp.
  *
- *    The Ops class represents the linear operator A of the linear system
+ *    The LinOp class represents the linear operator A of the linear system
  *    A x = b solved by solve(). It must implement the interface defined in
  *    LinearFunction.H; in particular, an apply( Ax_vec, x_vec ) function
  *    that computes the action A(x) of the operator on a vector x, as well as
@@ -16,12 +17,12 @@
  *    increment(), linComb(), scale(), etc.. See WarpXSolverVec.H for an example.
  */
 
-template <typename Vec, typename Ops>
+template <typename Vec, typename LinOp>
 class LinearSolver
 {
 public:
 
-    using RT = typename Ops::RT; // double or float
+    using RT = typename LinOp::RT; // double or float
 
     LinearSolver () = default;
 
@@ -33,15 +34,15 @@ public:
     LinearSolver(LinearSolver&&) noexcept = delete;
     LinearSolver& operator=(LinearSolver&&) noexcept = delete;
 
-    //! Defines with a reference to Ops. It's the user's responsibility to
-    //! keep the Ops object alive for linear solver to be functional. This function
+    //! Defines with a reference to LinOp. It's the user's responsibility to
+    //! keep the LinOp object alive for linear solver to be functional. This function
     //! must be called before solve() can be called.
-    virtual void define (Ops& linop) = 0;
+    virtual void define (LinOp& linop) = 0;
 
     /**
      * \brief Solve the linear system A x = b for x, where A is the linear
      *        operator whose action A(x) on a vector x is computed by
-     *        Ops::apply(), and where the right-hand side b is a given
+     *        LinOp::apply(), and where the right-hand side b is a given
      *        vector that does not depend on x.
      *
      * \param a_sol     unknowns, i.e., x in A x = b.

--- a/Source/NonlinearSolvers/LinearSolver.H
+++ b/Source/NonlinearSolvers/LinearSolver.H
@@ -6,9 +6,12 @@
  *
  *    This class is templated on a vector class Vec, and an operator class Ops.
  *
- *    The Ops class must have the following function:
- *    ComputeRHS( R_vec, U_vec, time, nl_iter, from_jacobian ),
- *    where U_vec and R_vec are of type Vec.
+ *    The Ops class represents the linear operator A of the linear system
+ *    A x = b solved by solve(). It must implement the interface defined in
+ *    LinearFunction.H; in particular, an apply( Ax_vec, x_vec ) function
+ *    that computes the action A*x of the operator on a vector x, as well as
+ *    precond(), makeVecLHS(), makeVecRHS(), and basic vector operations.
+ *    See JacobianFunctionMF.H for an example.
  *
  *    The Vec class must have basic math operators, such as Copy, +=, -=,
  *    increment(), linComb(), scale(), etc.. See WarpXSolverVec.H for an example.
@@ -37,10 +40,13 @@ public:
     virtual void define (Ops& linop) = 0;
 
     /**
-     * \brief Solve the linear system
+     * \brief Solve the linear system A x = b for x, where A is the linear
+     *        operator whose action A*x on a vector x is computed by
+     *        Ops::apply(), and where the right-hand side b is a given
+     *        vector that does not depend on x.
      *
      * \param a_sol     unknowns, i.e., x in A x = b.
-     * \param a_rhs     RHS, i.e., b in A x = b.
+     * \param a_rhs     RHS, i.e., b in A x = b (independent of x).
      * \param a_tol_rel relative tolerance.
      * \param a_tol_abs absolute tolerance.
      * \param a_its     optional argument specifying the maximum number of iterations.

--- a/Source/NonlinearSolvers/PETScKSP_Wrapper.H
+++ b/Source/NonlinearSolvers/PETScKSP_Wrapper.H
@@ -69,7 +69,7 @@ public:
      *        vector that does not depend on x.
      *
      * \param a_sol     unknowns, i.e., x in A x = b.
-     * \param a_rhs     RHS, i.e., b in A x = b (independent of x).
+     * \param a_rhs     RHS, i.e., b in A x = b.
      * \param a_tol_rel relative tolerance.
      * \param a_tol_abs absolute tolerance.
      * \param a_its     optional argument specifying the maximum number of iterations.

--- a/Source/NonlinearSolvers/PETScKSP_Wrapper.H
+++ b/Source/NonlinearSolvers/PETScKSP_Wrapper.H
@@ -22,9 +22,9 @@
  *    This class is a wrapper for PETSc's KSP linear solver that inheritis from
  *    WarpX's LinearSolver base class. See the documentation of PETSc's KSP
  *    solver for more details. This class is templated on a vector class Vec,
- *    and an operator class Ops.
+ *    and a linear operator class LinOp.
  *
- *    The Ops class represents the linear operator A of the linear system
+ *    The LinOp class represents the linear operator A of the linear system
  *    A x = b solved by solve(). It must implement the interface defined in
  *    LinearFunction.H; in particular, an apply( Ax_vec, x_vec ) function
  *    that computes the action A(x) of the operator on a vector x.
@@ -37,12 +37,12 @@
  *    and consequent conflicts between PETSc and WarpX variables.
  */
 
-template <typename Vec, typename Ops>
-class PETScKSP : public LinearSolver<Vec,Ops>
+template <typename Vec, typename LinOp>
+class PETScKSP : public LinearSolver<Vec,LinOp>
 {
 public:
 
-    using RT = typename Ops::RT; // double or float
+    using RT = typename LinOp::RT; // double or float
 
     PETScKSP () = default;
 
@@ -54,10 +54,10 @@ public:
     PETScKSP(PETScKSP&&) noexcept = delete;
     PETScKSP& operator=(PETScKSP&&) noexcept = delete;
 
-    //! Defines with a reference to Ops. It's the user's responsibility to
-    //! keep the Ops object alive for GMRES to be functional. This function
+    //! Defines with a reference to LinOp. It's the user's responsibility to
+    //! keep the LinOp object alive for GMRES to be functional. This function
     //! must be called before solve() can be called.
-    void define (Ops& a_linop) override
+    void define (LinOp& a_linop) override
     {
         m_solver = std::make_unique<warpx_petsc::KSP_impl>(a_linop);
     }
@@ -65,7 +65,7 @@ public:
     /**
      * \brief Solve the linear system A x = b for x, where A is the linear
      *        operator whose action A(x) on a vector x is computed by
-     *        Ops::apply(), and where the right-hand side b is a given
+     *        LinOp::apply(), and where the right-hand side b is a given
      *        vector that does not depend on x.
      *
      * \param a_sol     unknowns, i.e., x in A x = b.

--- a/Source/NonlinearSolvers/PETScKSP_Wrapper.H
+++ b/Source/NonlinearSolvers/PETScKSP_Wrapper.H
@@ -27,8 +27,7 @@
  *    The Ops class represents the linear operator A of the linear system
  *    A x = b solved by solve(). It must implement the interface defined in
  *    LinearFunction.H; in particular, an apply( Ax_vec, x_vec ) function
- *    that computes the action A*x of the operator on a vector x. See
- *    JacobianFunctionMF.H for an example.
+ *    that computes the action A(x) of the operator on a vector x.
  *
  *    The Vec class must have basic math operators, such as Copy, +=, -=,
  *    increment(), linComb(), scale(), etc.. See WarpXSolverVec.H for an example.
@@ -65,7 +64,7 @@ public:
 
     /**
      * \brief Solve the linear system A x = b for x, where A is the linear
-     *        operator whose action A*x on a vector x is computed by
+     *        operator whose action A(x) on a vector x is computed by
      *        Ops::apply(), and where the right-hand side b is a given
      *        vector that does not depend on x.
      *

--- a/Source/NonlinearSolvers/PETScKSP_Wrapper.H
+++ b/Source/NonlinearSolvers/PETScKSP_Wrapper.H
@@ -24,9 +24,11 @@
  *    solver for more details. This class is templated on a vector class Vec,
  *    and an operator class Ops.
  *
- *    The Ops class must have the following function:
- *    ComputeRHS( R_vec, U_vec, time, nl_iter, from_jacobian ),
- *    where U_vec and R_vec are of type Vec.
+ *    The Ops class represents the linear operator A of the linear system
+ *    A x = b solved by solve(). It must implement the interface defined in
+ *    LinearFunction.H; in particular, an apply( Ax_vec, x_vec ) function
+ *    that computes the action A*x of the operator on a vector x. See
+ *    JacobianFunctionMF.H for an example.
  *
  *    The Vec class must have basic math operators, such as Copy, +=, -=,
  *    increment(), linComb(), scale(), etc.. See WarpXSolverVec.H for an example.
@@ -62,13 +64,16 @@ public:
     }
 
     /**
-     * \brief Solve the linear system
+     * \brief Solve the linear system A x = b for x, where A is the linear
+     *        operator whose action A*x on a vector x is computed by
+     *        Ops::apply(), and where the right-hand side b is a given
+     *        vector that does not depend on x.
      *
      * \param a_sol     unknowns, i.e., x in A x = b.
-     * \param a_rhs     RHS, i.e., b in A x = b.
+     * \param a_rhs     RHS, i.e., b in A x = b (independent of x).
      * \param a_tol_rel relative tolerance.
      * \param a_tol_abs absolute tolerance.
-     * \patam a_its     optional argument specifying the maximum number of iterations.
+     * \param a_its     optional argument specifying the maximum number of iterations.
      */
     void solve (Vec& a_sol,
                 Vec const& a_rhs,


### PR DESCRIPTION
## Description

Documentation and naming clarifications for the linear solver classes in `Source/NonlinearSolvers/`. No functional changes.

The class-level comments of `LinearSolver` and its wrappers (`AMReXGMRES`, `PETScKSP`) stated that the `Ops` template parameter must provide a `ComputeRHS()` function. That requirement applies to the *nonlinear* solvers (Newton, Picard), whose `Ops` is the physics operator — but not to the linear solvers: their operator template parameter is the linear operator $A$ itself (e.g. `JacobianFunctionMF`), which must implement the `LinearFunction` interface.

Changes:
- **`LinearSolver.H`, `AMReXGMRES_Wrapper.H`, `PETScKSP_Wrapper.H`**:
  - Replace the erroneous `ComputeRHS` requirement with the actual contract (the `LinearFunction` interface, in particular `apply()` computing the action $A(x)$ of the operator), and clarify in the `solve()` documentation that the right-hand side $b$ is a given vector independent of $x$. Also fix a `\patam` typo.
  - Rename the template parameter `Ops` to `LinOp`, since `Ops` is used elsewhere (nonlinear solvers, `LinearFunction`, `JacobianFunctionMF`) for the physics operator providing `ComputeRHS()`, whereas here it refers to the linear operator $A$. The new name matches the `define(LinOp& linop)` argument and the AMReX linear-operator convention.
- **`LinearFunction.H`**:
  - Rename the parameters of the pure-virtual `apply()` from `a_dF`/`a_dU` to `a_Ax`/`a_x`, and document that it computes the action `a_Ax = A(a_x)`. The old names presumed the operator is a Jacobian acting on increments (as in `JacobianFunctionMF`, whose override keeps its meaningful `dF`/`dU` names), but the base class represents a generic linear operator.
  - Document that `precond(a_U, a_X)` solves `P(a_U) = a_X`, where $P$ approximates $A$ (so `a_U` approximates the solution of `A(a_U) = a_X`), with $P = I$ when there is no preconditioner. This matches the right-preconditioning contract expected by `amrex::GMRES`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)