### PR TITLE
HybridPIC: preserve state across repeated Evolve calls

### DIFF
--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -214,11 +214,16 @@ WarpX::Evolve (int numsteps)
         }
 
         // If needed, deposit the initial ion charge and current densities that
-        // will be used to update the E-field in Ohm's law.
-        if (step == step_begin &&
+        // will be used to update the E-field in Ohm's law.  Evolve() can be
+        // called repeatedly by a Python co-simulation.  This initialization is
+        // once per WarpX instance, not once per Evolve() call: repeating it can
+        // re-add split external fields and, with the QDSMC electron equation,
+        // replace the evolved electron temperature by its initial closure.
+        if (!m_hybrid_pic_evolve_initialized &&
             electromagnetic_solver_id == ElectromagneticSolverAlgo::HybridPIC
         ) {
             HybridPICInitializeRhoJandB();
+            m_hybrid_pic_evolve_initialized = true;
         }
 
         // multi-physics: field ionization

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -219,11 +219,11 @@ WarpX::Evolve (int numsteps)
         // once per WarpX instance, not once per Evolve() call: repeating it can
         // re-add split external fields and, with the QDSMC electron equation,
         // replace the evolved electron temperature by its initial closure.
-        if (!m_hybrid_pic_evolve_initialized &&
-            electromagnetic_solver_id == ElectromagneticSolverAlgo::HybridPIC
+        if (electromagnetic_solver_id == ElectromagneticSolverAlgo::HybridPIC &&
+            !m_hybrid_pic_model->m_evolve_initialized
         ) {
             HybridPICInitializeRhoJandB();
-            m_hybrid_pic_evolve_initialized = true;
+            m_hybrid_pic_model->m_evolve_initialized = true;
         }
 
         // multi-physics: field ionization

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H
@@ -366,6 +366,11 @@ public:
     /** Check if rkf45 should be used */
     [[nodiscard]] bool DoRKF45(int step) const { return m_rkf45_intervals.contains(step); }
 
+    /** True after HybridPICInitializeRhoJandB() completes for this model.
+     *  Preserve the initialized state across repeated Evolve() calls, while
+     *  allowing the first deposition on a newly constructed restart instance. */
+    bool m_evolve_initialized = false;
+
     // Declare variables to hold hybrid-PIC model parameters
     /** Number of substeps to take when evolving B (also used as initial substep
      *  count guess when RKF45 adaptive stepping is active). May increase under

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1431,6 +1431,12 @@ private:
 
     bool m_is_synchronized = true;
 
+    /** True after the one-time Hybrid-PIC deposition/field initialization at
+     *  the beginning of the first Evolve() call.  Python co-simulations call
+     *  Evolve() repeatedly on the same instance, so step_begin cannot be used
+     *  as the initialization sentinel. */
+    bool m_hybrid_pic_evolve_initialized = false;
+
     // Synchronization of nodal points
     static constexpr bool sync_nodal_points = true;
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1431,12 +1431,6 @@ private:
 
     bool m_is_synchronized = true;
 
-    /** True after the one-time Hybrid-PIC deposition/field initialization at
-     *  the beginning of the first Evolve() call.  Python co-simulations call
-     *  Evolve() repeatedly on the same instance, so step_begin cannot be used
-     *  as the initialization sentinel. */
-    bool m_hybrid_pic_evolve_initialized = false;
-
     // Synchronization of nodal points
     static constexpr bool sync_nodal_points = true;
 


### PR DESCRIPTION
## Summary

Initialize Hybrid-PIC charge/current history and split fields only once per WarpX instance, rather than once per call to `WarpX::Evolve()`.

Python co-simulations commonly advance one persistent WarpX instance through many short `Evolve(numsteps)` calls. Since `step_begin` is reset from `istep[0]` on every call, the old `step == step_begin` condition reran `HybridPICInitializeRhoJandB()` at every exchange. That can re-add split external fields and replaces an evolved hybrid-electron state with the initial algebraic closure.

The new runtime sentinel remains false for a newly constructed restart instance, so the required first post-restart deposition still runs exactly once.

## Validation

- Built the Python-enabled 2-D MPI+OpenMP+PETSc configuration.
- `test_hybrid_electron_thermodynamics` passes.
- A two-call hybrid run (`Evolve(10)` followed by `Evolve(10)`) previously reset the represented electron energy from 21.1799 J to the cold-start state at the second call. With this change it advances continuously to 21.8114 J on step 11.
- In a 2 ns coupled reproduction, the hybrid-electron/Joule/radiation ledger residual improves from 94.899 J to `7.1e-12` J.
