### PR TITLE
`setup.py`: Find Free-Threaded Python (`Python_FIND_ABI`)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,8 +136,9 @@ class CMakeBuild(build_ext):
             # Windows: has no RPath concept, all `.dll`s must be in %PATH%
             #          or same dir as calling executable
         ]
-        # Free-threaded (PEP 703) gil_disabled is OFF by default
-        #   https://cmake.org/cmake/help/latest/module/FindPython.html#variable:Python_FIND_ABI
+        # CMake's Python_FIND_ABI defaults the gil_disabled flag to OFF,
+        # so free-threaded interpreters are not matched. Requires CMake 3.30+"
+        # See https://cmake.org/cmake/help/latest/module/FindPython.html#variable:Python_FIND_ABI
         if sysconfig.get_config_var("Py_GIL_DISABLED"):
             cmake_args.append("-DPython_FIND_ABI=OFF;OFF;OFF;ON")
         if emscripten:

--- a/setup.py
+++ b/setup.py
@@ -136,6 +136,10 @@ class CMakeBuild(build_ext):
             # Windows: has no RPath concept, all `.dll`s must be in %PATH%
             #          or same dir as calling executable
         ]
+        # Free-threaded (PEP 703) gil_disabled is OFF by default
+        #   https://cmake.org/cmake/help/latest/module/FindPython.html#variable:Python_FIND_ABI
+        if sysconfig.get_config_var("Py_GIL_DISABLED"):
+            cmake_args.append("-DPython_FIND_ABI=OFF;OFF;OFF;ON")
         if emscripten:
             # Pyodide cross-compile: point at the target (WASM) Python headers
             cmake_args.append(


### PR DESCRIPTION
Disabled by default, but our cibuildwheels includes builds for it now
https://github.com/BLAST-ImpactX/impactx-wheels/pull/27
https://cmake.org/cmake/help/latest/module/FindPython.html#variable:Python_FIND_ABI

🤖 Generated with [Claude Code](https://claude.com/claude-code)