### PR TITLE
Use `NoGpuSync` for MLMG in all solver call sites

### DIFF
--- a/Source/Initialization/DivCleaner/ProjectionDivCleaner.H
+++ b/Source/Initialization/DivCleaner/ProjectionDivCleaner.H
@@ -104,6 +104,7 @@ private:
         mlmg.setVerbose(m_verbose);
         mlmg.setBottomVerbose(m_bottom_verbose);
         mlmg.setConvergenceNormType(amrex::MLMGNormType::greater);
+        mlmg.setNoGpuSync(true);
         mlmg.solve({m_solution[lev].get()}, {m_source[lev].get()}, m_rtol, m_atol);
     }
 

--- a/Source/ablastr/fields/EffectivePotentialPoissonSolver.H
+++ b/Source/ablastr/fields/EffectivePotentialPoissonSolver.H
@@ -231,6 +231,7 @@ computeEffectivePotentialPhi (
         mlmg.setVerbose(verbosity);
         mlmg.setMaxIter(max_iters);
         mlmg.setConvergenceNormType(amrex::MLMGNormType::greater);
+        mlmg.setNoGpuSync(true);
 
         const int ng = int(grid_type == utils::enums::GridType::Collocated); // ghost cells
         if (ng) {

--- a/Source/ablastr/fields/VectorPoissonSolver.H
+++ b/Source/ablastr/fields/VectorPoissonSolver.H
@@ -212,6 +212,7 @@ computeVectorPotential   (  amrex::Vector<amrex::Array<amrex::MultiFab*, 3> > co
             mlmg[adim]->setVerbose(verbosity);
             mlmg[adim]->setMaxIter(max_iters);
             mlmg[adim]->setConvergenceNormType(always_use_bnorm ? amrex::MLMGNormType::bnorm : amrex::MLMGNormType::greater);
+            mlmg[adim]->setNoGpuSync(true);
 
             // Solve Poisson equation at lev
             mlmg[adim]->solve( {A[lev][adim]}, {curr[lev][adim]},


### PR DESCRIPTION
## What this does

Since MLMG issues a very large number of small kernels, setting `mlmg.setNoGpuSync(true)` and thus removing the per-kernel stream synchronization can be a substantial win at small problem sizes on GPU.

WarpX constructs an `amrex::MLMG` object in **five** places, but only one of them sets the flag. This PR sets it in the remaining four.

| # | Call site | Solver | Before |
|---|-----------|--------|--------|
| 1 | `Source/ablastr/fields/PoissonSolver.H` (`computePhi`) | electrostatic | ✅ set in #6491 |
| 2 | `Source/ablastr/fields/EffectivePotentialPoissonSolver.H` | effective-potential ES | ❌ → ✅ |
| 3 | `Source/ablastr/fields/VectorPoissonSolver.H` | magnetostatic (×3 components) | ❌ → ✅ |
| 4 | `Source/Initialization/DivCleaner/ProjectionDivCleaner.H` (`runMLMG`) | projection div cleaner | ❌ → ✅ |
| 5 | `Source/NonlinearSolvers/CurlCurlMLMGPC.H` | implicit-solver preconditioner | ❌ → ❌ (not safe yet, requires https://github.com/AMReX-Codes/amrex/pull/4895)|

This is a performance-only change: `setNoGpuSync` alters neither the discretization
nor the convergence criteria, and it is a no-op on CPU builds.

## Evidence that this should help (electrostatic PIC)

The flag was introduced for `computePhi` in [#6491](https://github.com/BLAST-WarpX/warpx/pull/6491), motivated by the profiling work in [#6487 "Performance of WarpX in serial problems"](https://github.com/BLAST-WarpX/warpx/issues/6487): see [#6487 (comment)](https://github.com/BLAST-WarpX/warpx/issues/6487#issuecomment-3746930529)