### PR TITLE
ECT: use a named enumeration for the face info flags

### DIFF
--- a/Source/EmbeddedBoundary/EmbeddedBoundaryInit.H
+++ b/Source/EmbeddedBoundary/EmbeddedBoundaryInit.H
@@ -93,11 +93,12 @@ namespace warpx::embedded_boundary
 
    /**
     * \brief Initialize information for cell extensions.
-    *        The flags convention for m_flag_info_face is as follows
-    *          - 0 for unstable cells
-    *          - 1 for stable cells which have not been intruded
-    *          - 2 for stable cells which have been intruded
-    *        Here we cannot know if a cell is intruded or not so we initialize all stable cells with 1
+    *        The flags convention for m_flag_info_face is given by FaceInfo::Flag:
+    *          - FaceInfo::extended for unstable cells
+    *          - FaceInfo::available for stable cells which have not been intruded
+    *          - FaceInfo::intruded for stable cells which have been intruded
+    *        Here we cannot know if a cell is intruded or not, so we initialize all stable cells
+    *        with FaceInfo::available
     */
     void MarkExtensionCells(
         const std::array<amrex::Real,3>& cell_size,

--- a/Source/EmbeddedBoundary/EmbeddedBoundaryInit.cpp
+++ b/Source/EmbeddedBoundary/EmbeddedBoundaryInit.cpp
@@ -11,6 +11,7 @@
 
 #include "EmbeddedBoundaryInit.H"
 
+#include "EmbeddedBoundary/WarpXFaceInfoBox.H"
 #include "Fields.H"
 #include "Utils/TextMsg.H"
 
@@ -420,12 +421,10 @@ web::MarkExtensionCells (
 
                 // Does this face need to be extended?
                 // The difference between flag_info_face and flag_ext_face is that:
-                //     - for every face flag_info_face contains a:
-                //          * 0 if the face needs to be extended
-                //          * 1 if the face is large enough to lend area to other faces
-                //          * 2 if the face is actually intruded by other face
-                //       Here we only take care of the first two cases. The entries corresponding
-                //       to the intruded faces are going to be set in the function ComputeFaceExtensions
+                //     - for every face flag_info_face contains one of the FaceInfo::Flag values.
+                //       Here we only take care of FaceInfo::extended and FaceInfo::available. The
+                //       entries corresponding to the intruded faces are going to be set in the
+                //       function ComputeFaceExtensions
                 //     - for every face flag_ext_face contains a:
                 //          * 1 if the face needs to be extended
                 //          * 0 otherwise
@@ -434,12 +433,12 @@ web::MarkExtensionCells (
                 //       track of which cells could not be extended
                 flag_ext_face_data(i, j, k) = int(S(i, j, k) < S_stab && S(i, j, k) > 0);
                 if(flag_ext_face_data(i, j, k)){
-                    flag_info_face_data(i, j, k) = 0;
+                    flag_info_face_data(i, j, k) = FaceInfo::extended;
                 }
                 // Is this face available to lend area to other faces?
                 // The criterion is that the face has to be interior and not already unstable itself
                 if(int(S(i, j, k) > 0 && !flag_ext_face_data(i, j, k))) {
-                    flag_info_face_data(i, j, k) = 1;
+                    flag_info_face_data(i, j, k) = FaceInfo::available;
                 }
             });
         }

--- a/Source/EmbeddedBoundary/WarpXFaceExtensions.cpp
+++ b/Source/EmbeddedBoundary/WarpXFaceExtensions.cpp
@@ -197,7 +197,7 @@ namespace
                     // Modify the area according to the BCK algorithm
                     S(i, j, k) = ::ComputeSStab<idim>(i, j, k, lx, ly, lz, dx, dy, dz);
                     // Update the face info so that the solver doesn't think that this face is being extended
-                    flag_info_face_max_lev_idim(i, j, k) = -1;
+                    flag_info_face_max_lev_idim(i, j, k) = FaceInfo::bck_stabilized;
                 }
             });
         }
@@ -394,9 +394,10 @@ namespace
                     // has given away already some area, so we use Sz_red rather than Sz.
                     // If no face is available we don't do anything and we will need to use the
                     // multi-face extensions.
+                    const int flag_neigh = GetNeigh(flag_info_face, i, j, k, i_n, j_n, idim);
                     if (GetNeigh(S_red, i, j, k, i_n, j_n, idim) > S_ext
-                        && (GetNeigh(flag_info_face, i, j, k, i_n, j_n, idim) == 1
-                        || GetNeigh(flag_info_face, i, j, k, i_n, j_n, idim) == 2)
+                        && (flag_neigh == FaceInfo::available
+                            || flag_neigh == FaceInfo::intruded)
                         && flag_ext_face(i, j, k) && ! stop) {
                         n_borrow += 1;
                         stop = true;
@@ -437,7 +438,8 @@ namespace
         for(int i_loc = 0; i_loc <= 2; i_loc++){
             for(int j_loc = 0; j_loc <= 2; j_loc++){
                 const int flag = GetNeigh(flag_info_face, i, j, k, i_loc - 1, j_loc - 1, idim);
-                local_avail(i_loc, j_loc) = flag == 1 || flag == 2;
+                local_avail(i_loc, j_loc) = flag == FaceInfo::available
+                                            || flag == FaceInfo::intruded;
             }
         }
 
@@ -674,9 +676,11 @@ WarpX::ComputeOneWayExtensions ()
                                 // has given away already some area, so we use Sz_red rather than Sz.
                                 // If no face is available we don't do anything and we will need to use the
                                 // multi-face extensions.
+                                const int flag_neigh =
+                                    ::GetNeigh(flag_info_face, i, j, k, i_n, j_n, idim);
                                 if (::GetNeigh(S_mod, i, j, k, i_n, j_n, idim) > S_ext
-                                    && (::GetNeigh(flag_info_face, i, j, k, i_n, j_n, idim) == 1
-                                         || GetNeigh(flag_info_face, i, j, k, i_n, j_n, idim) == 2)
+                                    && (flag_neigh == FaceInfo::available
+                                        || flag_neigh == FaceInfo::intruded)
                                     && flag_ext_face(i, j, k)) {
 
                                     ::SetNeigh(S_mod,
@@ -691,7 +695,9 @@ WarpX::ComputeOneWayExtensions ()
                                                                       borrowing_neigh_faces);
                                     borrowing_area[ps] = S_ext;
 
-                                    ::SetNeigh(flag_info_face, 2, i, j, k, i_n, j_n, idim);
+                                    ::SetNeigh(flag_info_face,
+                                               static_cast<int>(FaceInfo::intruded),
+                                               i, j, k, i_n, j_n, idim);
                                     // Add the area to the intruding face.
                                     S_mod(i, j, k) = S(i, j, k) + S_ext;
                                     flag_ext_face(i, j, k) = false;
@@ -805,7 +811,8 @@ WarpX::ComputeEightWaysExtensions ()
                     for(int i_loc = 0; i_loc <= 2; i_loc++){
                         for(int j_loc = 0; j_loc <= 2; j_loc++){
                             auto const flag = ::GetNeigh(flag_info_face, i, j, k, i_loc - 1, j_loc - 1, idim);
-                            local_avail(i_loc, j_loc) = flag == 1 || flag == 2;
+                            local_avail(i_loc, j_loc) = flag == FaceInfo::available
+                                                        || flag == FaceInfo::intruded;
                         }
                     }
 
@@ -856,7 +863,9 @@ WarpX::ComputeEightWaysExtensions ()
                                                                       borrowing_neigh_faces);
                                     borrowing_area[ps + count] = patch;
 
-                                    ::SetNeigh(flag_info_face, 2, i, j, k, i_n, j_n, idim);
+                                    ::SetNeigh(flag_info_face,
+                                               static_cast<int>(FaceInfo::intruded),
+                                               i, j, k, i_n, j_n, idim);
 
                                     S_mod(i, j, k) += patch;
                                     ::SetNeigh(S_mod,

--- a/Source/EmbeddedBoundary/WarpXFaceInfoBox.H
+++ b/Source/EmbeddedBoundary/WarpXFaceInfoBox.H
@@ -15,6 +15,32 @@
 
 #include <bitset>
 
+/**
+* \brief Categories of mesh faces used by the ECT solver, stored in the `flag_info_face`
+* iMultiFab (see WarpX::m_flag_info_face). They are initialized in WarpX::MarkExtensionCells
+* and then updated in WarpX::ComputeFaceExtensions.
+*
+* This is deliberately an unscoped enumeration with a fixed underlying type: the values are
+* read from and written to an `amrex::iMultiFab`, so they are compared against `int` and a
+* scoped enumeration would require a cast at every use site.
+*/
+namespace FaceInfo
+{
+    enum Flag : int {
+        //! The face is too small to be stable and could be extended neither with the one-way
+        //! nor with the eight-ways extension: it is stabilized with the BCK correction instead
+        bck_stabilized = -1,
+        //! The face is too small to be stable and is extended, i.e. it borrows area from its
+        //! neighbors. This is also the value used before the extensions are computed, to mark
+        //! the faces that need to be extended.
+        extended = 0,
+        //! The face is large enough to be stable and can lend area to its neighbors
+        available = 1,
+        //! The face is large enough to be stable and has lent area to at least one neighbor
+        intruded = 2
+    };
+}
+
 struct FaceInfoBox {
     enum Neighbours : uint8_t {n, s, e, w, nw, ne, sw, se};
 

--- a/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/EvolveB.cpp
@@ -286,7 +286,7 @@ void FiniteDifferenceSolver::EvolveBCartesianECT (
 
                 if (S(i, j, k) <= 0) { return; }
 
-                if (!(flag_info_cell_dim(i, j, k) == 0)) { return; }
+                if (!(flag_info_cell_dim(i, j, k) == FaceInfo::extended)) { return; }
 
                 Venl_dim(i, j, k) = Rho(i, j, k) * S(i, j, k);
                 amrex::Real rho_enl;
@@ -365,13 +365,13 @@ void FiniteDifferenceSolver::EvolveBCartesianECT (
             amrex::ParallelFor(tb, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
                 if (S(i, j, k) <= 0) { return; }
 
-                if (flag_info_cell_dim(i, j, k) == 0) {
+                if (flag_info_cell_dim(i, j, k) == FaceInfo::extended) {
                     return;
                 }
-                else if (flag_info_cell_dim(i, j, k) == 1) {
+                else if (flag_info_cell_dim(i, j, k) == FaceInfo::available) {
                     //Stable cell which hasn't been intruded
                     B(i, j, k) = B(i, j, k) - dt * Rho(i, j, k);
-                } else if (flag_info_cell_dim(i, j, k) == 2) {
+                } else if (flag_info_cell_dim(i, j, k) == FaceInfo::intruded) {
                     //Stable cell which has been intruded
                     Venl_dim(i, j, k) += Rho(i, j, k) * S_mod(i, j, k);
                     B(i, j, k) = B(i, j, k) - dt * Venl_dim(i, j, k) / S(i, j, k);

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1271,10 +1271,12 @@ private:
      */
     amrex::Vector<  std::unique_ptr<amrex::iMultiFab> > m_eb_reduce_particle_shape;
 
-    /** EB: for every mesh face flag_info_face contains a:
-     *          * 0 if the face needs to be extended
-     *          * 1 if the face is large enough to lend area to other faces
-     *          * 2 if the face is actually intruded by other face
+    /** EB: for every mesh face flag_info_face contains one of the FaceInfo::Flag values:
+     *          * FaceInfo::extended if the face needs to be extended
+     *          * FaceInfo::available if the face is large enough to lend area to other faces
+     *          * FaceInfo::intruded if the face is actually intruded by other face
+     *          * FaceInfo::bck_stabilized if the face could not be extended and was stabilized
+     *            with the BCK correction instead
      * It is initialized in WarpX::MarkExtensionCells
      * This is only used for the ECT solver.*/
     amrex::Vector<std::array< std::unique_ptr<amrex::iMultiFab>, 3 > > m_flag_info_face;


### PR DESCRIPTION
The `flag_info_face` iMultiFab used by the ECT solver stored bare integer codes (0, 1, 2 and -1) whose meaning had to be looked up in a comment at every use site.

Introduce `FaceInfo::Flag` in `WarpXFaceInfoBox.H`, with one enumerator per category (`extended`, `available`, `intruded`, `bck_stabilized`), and use it in the initialization, in the face extensions and in the ECT B push. The enumeration is unscoped and has a fixed `int` underlying type, because the values are read from and written to an `amrex::iMultiFab` and a scoped enumeration would require a cast at every comparison.

This is a pure readability change: the stored values are unchanged.