### PR TITLE
Submit results of GPU CI tests to CDash

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -41,19 +41,24 @@ jobs:
     matrix:
       # 1D Cartesian, Cylindrical, Spherical
       1d:
+        CDASH_BUILD_NAME: CPU-1D
         WARPX_CMAKE_FLAGS: -DWarpX_DIMS='1;RCYLINDER;RSPHERE' -DWarpX_FFT=ON -DWarpX_PYTHON=ON -DWarpX_PETSC=ON
       # Cartesian 2D
       cartesian_2d:
+        CDASH_BUILD_NAME: CPU-2D
         WARPX_CMAKE_FLAGS: -DWarpX_DIMS=2 -DWarpX_FFT=ON -DWarpX_PYTHON=ON -DWarpX_PETSC=ON
       # Cartesian 3D
       cartesian_3d:
+        CDASH_BUILD_NAME: CPU-3D
         WARPX_CMAKE_FLAGS: -DWarpX_DIMS=3 -DWarpX_FFT=ON -DWarpX_PYTHON=ON
       # Cylindrical RZ
       cylindrical_rz:
+        CDASH_BUILD_NAME: CPU-RZ
         WARPX_CMAKE_FLAGS: -DWarpX_DIMS=RZ -DWarpX_FFT=ON -DWarpX_PYTHON=ON -DWarpX_PETSC=ON
         WARPX_RZ_FFT: 'TRUE'
       # single precision
       #single_precision:
+      #  CDASH_BUILD_NAME: CPU-All-SP
       #  WARPX_CMAKE_FLAGS: -DWarpX_DIMS='1;2;3;RZ' -DWarpX_FFT=ON -DWarpX_PYTHON=ON -DWarpX_PRECISION=SINGLE
       #  WARPX_RZ_FFT: 'TRUE'
 
@@ -178,11 +183,11 @@ jobs:
       # configure
       export AMReX_CMAKE_FLAGS="-DAMReX_ASSERTIONS=ON -DAMReX_TESTING=ON"
       export WARPX_TEST_FLAGS="-DWarpX_TEST_CLEANUP=ON -DWarpX_TEST_FPETRAP=ON -DWarpX_BACKTRACE_INFO=ON"
-      cmake -S . -B build          \
-        -DBUILDNAME=CI-Development \
-        -DSITE=Azure-CPU           \
-        ${AMReX_CMAKE_FLAGS}       \
-        ${WARPX_CMAKE_FLAGS}       \
+      cmake -S . -B build                    \
+        -DBUILDNAME="${CDASH_BUILD_NAME}"    \
+        -DSITE=Azure                         \
+        ${AMReX_CMAKE_FLAGS}                 \
+        ${WARPX_CMAKE_FLAGS}                 \
         ${WARPX_TEST_FLAGS}
       # build
       cmake --build build -j 2

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -202,7 +202,9 @@ jobs:
       export OMPI_MCA_rmaps_base_oversubscribe=1
       export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe
       # determine if the build was triggered by a push to the development branch
-      if [[ "$(Build.SourceBranch)" == "refs/heads/development" ]]; then
+      # FIXME: Remove the ci_gpu_cdash exception after CDash debugging is complete.
+      if [[ "$(Build.SourceBranch)" == "refs/heads/development" ||
+            "${SYSTEM_PULLREQUEST_SOURCEBRANCH:-}" == "refs/heads/ci_gpu_cdash" ]]; then
         # run tests (exclude pytest.AMReX when running Python tests)
         # and submit results to CDash as Experimental
         ctest --test-dir build --output-on-failure -E AMReX \

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -206,18 +206,14 @@ jobs:
       # allow oversubscription for Open MPI 4 and 5
       export OMPI_MCA_rmaps_base_oversubscribe=1
       export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe
-      # determine if the build was triggered by a push to the development branch
-      # FIXME: Remove the ci_gpu_cdash exception after CDash debugging is complete.
-      if [[ "$(Build.SourceBranch)" == "refs/heads/development" ||
-            "${SYSTEM_PULLREQUEST_SOURCEBRANCH:-}" == "refs/heads/ci_gpu_cdash" ]]; then
-        # run tests (exclude pytest.AMReX when running Python tests)
-        # and submit results to CDash as Experimental
-        ctest --test-dir build --output-on-failure -E AMReX \
-          -D ExperimentalTest -D ExperimentalSubmit
-      else
-        # run tests (exclude pytest.AMReX when running Python tests)
-        ctest --test-dir build --output-on-failure -E AMReX
-      fi
+      # TODO: Submit to CDash only from development after CDash debugging is complete:
+      # if [[ "$(Build.SourceBranch)" == "refs/heads/development" ]]; then
+      #   ctest ... -D ExperimentalTest -D ExperimentalSubmit
+      # fi
+      # run tests (exclude pytest.AMReX when running Python tests)
+      # and submit results to CDash as Experimental
+      ctest --test-dir build --output-on-failure -E AMReX \
+        -D ExperimentalTest -D ExperimentalSubmit
     displayName: 'Test'
 
   - bash: |

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -178,9 +178,11 @@ jobs:
       # configure
       export AMReX_CMAKE_FLAGS="-DAMReX_ASSERTIONS=ON -DAMReX_TESTING=ON"
       export WARPX_TEST_FLAGS="-DWarpX_TEST_CLEANUP=ON -DWarpX_TEST_FPETRAP=ON -DWarpX_BACKTRACE_INFO=ON"
-      cmake -S . -B build    \
-        ${AMReX_CMAKE_FLAGS} \
-        ${WARPX_CMAKE_FLAGS} \
+      cmake -S . -B build          \
+        -DBUILDNAME=CI-Development \
+        -DSITE=Azure-CPU           \
+        ${AMReX_CMAKE_FLAGS}       \
+        ${WARPX_CMAKE_FLAGS}       \
         ${WARPX_TEST_FLAGS}
       # build
       cmake --build build -j 2

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -206,14 +206,16 @@ jobs:
       # allow oversubscription for Open MPI 4 and 5
       export OMPI_MCA_rmaps_base_oversubscribe=1
       export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe
-      # TODO: Submit to CDash only from development after CDash debugging is complete:
-      # if [[ "$(Build.SourceBranch)" == "refs/heads/development" ]]; then
-      #   ctest ... -D ExperimentalTest -D ExperimentalSubmit
-      # fi
-      # run tests (exclude pytest.AMReX when running Python tests)
-      # and submit results to CDash as Experimental
-      ctest --test-dir build --output-on-failure -E AMReX \
-        -D ExperimentalTest -D ExperimentalSubmit
+      # determine if the build was triggered by a push to the development branch
+      if [[ "$(Build.SourceBranch)" == "refs/heads/development" ]]; then
+        # run tests (exclude pytest.AMReX when running Python tests)
+        # and submit results to CDash as Experimental
+        ctest --test-dir build --output-on-failure -E AMReX \
+          -D ExperimentalTest -D ExperimentalSubmit
+      else
+        # run tests (exclude pytest.AMReX when running Python tests)
+        ctest --test-dir build --output-on-failure -E AMReX
+      fi
     displayName: 'Test'
 
   - bash: |

--- a/.gitlab/ci.yaml
+++ b/.gitlab/ci.yaml
@@ -28,6 +28,8 @@ Nvidia-H100-single-precision:
     - |
       cmake -S . -B build                                  \
           -DCMAKE_VERBOSE_MAKEFILE=ON                      \
+          -DBUILDNAME="${CI_JOB_NAME}"                     \
+          -DSITE=GitLab-GPU                                \
           -DWarpX_COMPUTE=CUDA                             \
           -DWarpX_EB=ON                                    \
           -DWarpX_PYTHON=OFF                               \
@@ -67,6 +69,8 @@ AMD-MI300:
           -DCMAKE_C_COMPILER=$(which clang)            \
           -DCMAKE_CXX_COMPILER=$(which clang++)        \
           -DCMAKE_VERBOSE_MAKEFILE=ON                  \
+          -DBUILDNAME="${CI_JOB_NAME}"                 \
+          -DSITE=GitLab-GPU                            \
           -DAMReX_AMD_ARCH=gfx942                      \
           -DWarpX_COMPUTE=HIP                          \
           -DWarpX_EB=ON                                \
@@ -102,6 +106,8 @@ Intel-PVC:
     - |
       cmake -S . -B build                       \
           -DBUILD_SHARED_LIBS=ON                \
+          -DBUILDNAME="${CI_JOB_NAME}"          \
+          -DSITE=GitLab-GPU                     \
           -DCMAKE_VERBOSE_MAKEFILE=ON           \
           -DCMAKE_C_COMPILER=$(which icx)       \
           -DCMAKE_CXX_COMPILER=$(which icpx)    \

--- a/.gitlab/ci.yaml
+++ b/.gitlab/ci.yaml
@@ -41,7 +41,15 @@ Nvidia-H100-single-precision:
     - export OMPI_ALLOW_RUN_AS_ROOT=1
     - export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     - export AMREX_DEFAULT_INIT="amrex.the_arena_init_size=0"
-    - ctest --test-dir build -R test_3d_laser_acceleration_btd.run --output-on-failure --no-tests=error
+    - |
+      if [[ "${CI_COMMIT_BRANCH}" == "development" ]]; then
+        # run tests and submit results to CDash as Experimental
+        ctest --test-dir build -R test_3d_laser_acceleration_btd.run \
+          --output-on-failure --no-tests=error -D ExperimentalTest -D ExperimentalSubmit
+      else
+        ctest --test-dir build -R test_3d_laser_acceleration_btd.run \
+          --output-on-failure --no-tests=error
+      fi
 
 AMD-MI300:
   extends: .install-dependencies
@@ -71,7 +79,15 @@ AMD-MI300:
     - export OMPI_ALLOW_RUN_AS_ROOT=1
     - export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     - export AMREX_DEFAULT_INIT="amrex.the_arena_init_size=0"
-    - ctest --test-dir build -R test_3d_laser_acceleration_btd.run --output-on-failure --no-tests=error
+    - |
+      if [[ "${CI_COMMIT_BRANCH}" == "development" ]]; then
+        # run tests and submit results to CDash as Experimental
+        ctest --test-dir build -R test_3d_laser_acceleration_btd.run \
+          --output-on-failure --no-tests=error -D ExperimentalTest -D ExperimentalSubmit
+      else
+        ctest --test-dir build -R test_3d_laser_acceleration_btd.run \
+          --output-on-failure --no-tests=error
+      fi
 
 Intel-PVC:
   # TODO: Re-enable the Intel PVC/SYCL runner. Runtime issues.
@@ -102,4 +118,12 @@ Intel-PVC:
           -DWarpX_PARTICLE_PRECISION=SINGLE
     - cmake --build build -j 16
     - export AMREX_DEFAULT_INIT="amrex.the_arena_init_size=0"
-    - ctest --test-dir build -R test_3d_laser_acceleration_btd.run --output-on-failure --no-tests=error
+    - |
+      if [[ "${CI_COMMIT_BRANCH}" == "development" ]]; then
+        # run tests and submit results to CDash as Experimental
+        ctest --test-dir build -R test_3d_laser_acceleration_btd.run \
+          --output-on-failure --no-tests=error -D ExperimentalTest -D ExperimentalSubmit
+      else
+        ctest --test-dir build -R test_3d_laser_acceleration_btd.run \
+          --output-on-failure --no-tests=error
+      fi

--- a/.gitlab/ci.yaml
+++ b/.gitlab/ci.yaml
@@ -28,8 +28,8 @@ Nvidia-H100-single-precision:
     - |
       cmake -S . -B build                                  \
           -DCMAKE_VERBOSE_MAKEFILE=ON                      \
-          -DBUILDNAME="${CI_JOB_NAME}"                     \
-          -DSITE=GitLab-GPU                                \
+          -DBUILDNAME=GPU-H100-CUDA-SP                     \
+          -DSITE=GitLab                                    \
           -DWarpX_COMPUTE=CUDA                             \
           -DWarpX_EB=ON                                    \
           -DWarpX_PYTHON=OFF                               \
@@ -67,8 +67,8 @@ AMD-MI300:
           -DCMAKE_C_COMPILER=$(which clang)            \
           -DCMAKE_CXX_COMPILER=$(which clang++)        \
           -DCMAKE_VERBOSE_MAKEFILE=ON                  \
-          -DBUILDNAME="${CI_JOB_NAME}"                 \
-          -DSITE=GitLab-GPU                            \
+          -DBUILDNAME=GPU-MI300-HIP-SP                 \
+          -DSITE=GitLab                                \
           -DAMReX_AMD_ARCH=gfx942                      \
           -DWarpX_COMPUTE=HIP                          \
           -DWarpX_EB=ON                                \
@@ -102,8 +102,8 @@ Intel-PVC:
     - |
       cmake -S . -B build                       \
           -DBUILD_SHARED_LIBS=ON                \
-          -DBUILDNAME="${CI_JOB_NAME}"          \
-          -DSITE=GitLab-GPU                     \
+          -DBUILDNAME=GPU-PVC-SYCL-Mixed        \
+          -DSITE=GitLab                         \
           -DCMAKE_VERBOSE_MAKEFILE=ON           \
           -DCMAKE_C_COMPILER=$(which icx)       \
           -DCMAKE_CXX_COMPILER=$(which icpx)    \

--- a/.gitlab/ci.yaml
+++ b/.gitlab/ci.yaml
@@ -43,13 +43,15 @@ Nvidia-H100-single-precision:
     - export OMPI_ALLOW_RUN_AS_ROOT=1
     - export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     - export AMREX_DEFAULT_INIT="amrex.the_arena_init_size=0"
-    # TODO: Submit to CDash only from development after CDash debugging is complete:
-    # if [[ "${CI_COMMIT_BRANCH}" == "development" ]]; then
-    #   ctest ... -D ExperimentalTest -D ExperimentalSubmit
-    # fi
-    # run tests and submit results to CDash as Experimental
-    - ctest --test-dir build -R test_3d_laser_acceleration_btd.run
-        --output-on-failure --no-tests=error -D ExperimentalTest -D ExperimentalSubmit
+    - |
+      if [[ "${CI_COMMIT_BRANCH}" == "development" ]]; then
+        # run tests and submit results to CDash as Experimental
+        ctest --test-dir build -R test_3d_laser_acceleration_btd.run \
+          --output-on-failure --no-tests=error -D ExperimentalTest -D ExperimentalSubmit
+      else
+        ctest --test-dir build -R test_3d_laser_acceleration_btd.run \
+          --output-on-failure --no-tests=error
+      fi
 
 AMD-MI300:
   extends: .install-dependencies
@@ -81,13 +83,15 @@ AMD-MI300:
     - export OMPI_ALLOW_RUN_AS_ROOT=1
     - export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     - export AMREX_DEFAULT_INIT="amrex.the_arena_init_size=0"
-    # TODO: Submit to CDash only from development after CDash debugging is complete:
-    # if [[ "${CI_COMMIT_BRANCH}" == "development" ]]; then
-    #   ctest ... -D ExperimentalTest -D ExperimentalSubmit
-    # fi
-    # run tests and submit results to CDash as Experimental
-    - ctest --test-dir build -R test_3d_laser_acceleration_btd.run
-        --output-on-failure --no-tests=error -D ExperimentalTest -D ExperimentalSubmit
+    - |
+      if [[ "${CI_COMMIT_BRANCH}" == "development" ]]; then
+        # run tests and submit results to CDash as Experimental
+        ctest --test-dir build -R test_3d_laser_acceleration_btd.run \
+          --output-on-failure --no-tests=error -D ExperimentalTest -D ExperimentalSubmit
+      else
+        ctest --test-dir build -R test_3d_laser_acceleration_btd.run \
+          --output-on-failure --no-tests=error
+      fi
 
 Intel-PVC:
   # TODO: Re-enable the Intel PVC/SYCL runner. Runtime issues.
@@ -120,10 +124,12 @@ Intel-PVC:
           -DWarpX_PARTICLE_PRECISION=SINGLE
     - cmake --build build -j 16
     - export AMREX_DEFAULT_INIT="amrex.the_arena_init_size=0"
-    # TODO: Submit to CDash only from development after CDash debugging is complete:
-    # if [[ "${CI_COMMIT_BRANCH}" == "development" ]]; then
-    #   ctest ... -D ExperimentalTest -D ExperimentalSubmit
-    # fi
-    # run tests and submit results to CDash as Experimental
-    - ctest --test-dir build -R test_3d_laser_acceleration_btd.run
-        --output-on-failure --no-tests=error -D ExperimentalTest -D ExperimentalSubmit
+    - |
+      if [[ "${CI_COMMIT_BRANCH}" == "development" ]]; then
+        # run tests and submit results to CDash as Experimental
+        ctest --test-dir build -R test_3d_laser_acceleration_btd.run \
+          --output-on-failure --no-tests=error -D ExperimentalTest -D ExperimentalSubmit
+      else
+        ctest --test-dir build -R test_3d_laser_acceleration_btd.run \
+          --output-on-failure --no-tests=error
+      fi

--- a/.gitlab/ci.yaml
+++ b/.gitlab/ci.yaml
@@ -29,7 +29,7 @@ NVIDIA-H100:
       cmake -S . -B build                                  \
           -DCMAKE_VERBOSE_MAKEFILE=ON                      \
           -DBUILDNAME=GPU-H100-CUDA-SP                     \
-          -DSITE=GitLab                                    \
+          -DSITE=Frank_UO                                  \
           -DWarpX_COMPUTE=CUDA                             \
           -DWarpX_EB=ON                                    \
           -DWarpX_PYTHON=OFF                               \
@@ -70,7 +70,7 @@ AMD-MI300:
           -DCMAKE_CXX_COMPILER=$(which clang++)        \
           -DCMAKE_VERBOSE_MAKEFILE=ON                  \
           -DBUILDNAME=GPU-MI300-HIP-SP                 \
-          -DSITE=GitLab                                \
+          -DSITE=Frank_UO                              \
           -DAMReX_AMD_ARCH=gfx942                      \
           -DWarpX_COMPUTE=HIP                          \
           -DWarpX_EB=ON                                \
@@ -106,8 +106,8 @@ Intel-PVC:
     - |
       cmake -S . -B build                       \
           -DBUILD_SHARED_LIBS=ON                \
-          -DBUILDNAME=GPU-PVC-SYCL-Mixed        \
-          -DSITE=GitLab                         \
+          -DBUILDNAME=GPU-PVC-SYCL-MP           \
+          -DSITE=Frank_UO                       \
           -DCMAKE_VERBOSE_MAKEFILE=ON           \
           -DCMAKE_C_COMPILER=$(which icx)       \
           -DCMAKE_CXX_COMPILER=$(which icpx)    \

--- a/.gitlab/ci.yaml
+++ b/.gitlab/ci.yaml
@@ -44,7 +44,9 @@ Nvidia-H100-single-precision:
     - export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     - export AMREX_DEFAULT_INIT="amrex.the_arena_init_size=0"
     - |
-      if [[ "${CI_COMMIT_BRANCH}" == "development" ]]; then
+      # FIXME: Remove the ci_gpu_cdash exception after CDash debugging is complete.
+      if [[ "${CI_COMMIT_BRANCH}" == "development" ||
+            "${CI_COMMIT_BRANCH}" == "ci_gpu_cdash" ]]; then
         # run tests and submit results to CDash as Experimental
         ctest --test-dir build -R test_3d_laser_acceleration_btd.run \
           --output-on-failure --no-tests=error -D ExperimentalTest -D ExperimentalSubmit
@@ -84,7 +86,9 @@ AMD-MI300:
     - export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     - export AMREX_DEFAULT_INIT="amrex.the_arena_init_size=0"
     - |
-      if [[ "${CI_COMMIT_BRANCH}" == "development" ]]; then
+      # FIXME: Remove the ci_gpu_cdash exception after CDash debugging is complete.
+      if [[ "${CI_COMMIT_BRANCH}" == "development" ||
+            "${CI_COMMIT_BRANCH}" == "ci_gpu_cdash" ]]; then
         # run tests and submit results to CDash as Experimental
         ctest --test-dir build -R test_3d_laser_acceleration_btd.run \
           --output-on-failure --no-tests=error -D ExperimentalTest -D ExperimentalSubmit
@@ -125,7 +129,9 @@ Intel-PVC:
     - cmake --build build -j 16
     - export AMREX_DEFAULT_INIT="amrex.the_arena_init_size=0"
     - |
-      if [[ "${CI_COMMIT_BRANCH}" == "development" ]]; then
+      # FIXME: Remove the ci_gpu_cdash exception after CDash debugging is complete.
+      if [[ "${CI_COMMIT_BRANCH}" == "development" ||
+            "${CI_COMMIT_BRANCH}" == "ci_gpu_cdash" ]]; then
         # run tests and submit results to CDash as Experimental
         ctest --test-dir build -R test_3d_laser_acceleration_btd.run \
           --output-on-failure --no-tests=error -D ExperimentalTest -D ExperimentalSubmit

--- a/.gitlab/ci.yaml
+++ b/.gitlab/ci.yaml
@@ -43,17 +43,13 @@ Nvidia-H100-single-precision:
     - export OMPI_ALLOW_RUN_AS_ROOT=1
     - export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     - export AMREX_DEFAULT_INIT="amrex.the_arena_init_size=0"
-    - |
-      # FIXME: Remove the ci_gpu_cdash exception after CDash debugging is complete.
-      if [[ "${CI_COMMIT_BRANCH}" == "development" ||
-            "${CI_COMMIT_BRANCH}" == "ci_gpu_cdash" ]]; then
-        # run tests and submit results to CDash as Experimental
-        ctest --test-dir build -R test_3d_laser_acceleration_btd.run \
-          --output-on-failure --no-tests=error -D ExperimentalTest -D ExperimentalSubmit
-      else
-        ctest --test-dir build -R test_3d_laser_acceleration_btd.run \
-          --output-on-failure --no-tests=error
-      fi
+    # TODO: Submit to CDash only from development after CDash debugging is complete:
+    # if [[ "${CI_COMMIT_BRANCH}" == "development" ]]; then
+    #   ctest ... -D ExperimentalTest -D ExperimentalSubmit
+    # fi
+    # run tests and submit results to CDash as Experimental
+    - ctest --test-dir build -R test_3d_laser_acceleration_btd.run
+        --output-on-failure --no-tests=error -D ExperimentalTest -D ExperimentalSubmit
 
 AMD-MI300:
   extends: .install-dependencies
@@ -85,17 +81,13 @@ AMD-MI300:
     - export OMPI_ALLOW_RUN_AS_ROOT=1
     - export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     - export AMREX_DEFAULT_INIT="amrex.the_arena_init_size=0"
-    - |
-      # FIXME: Remove the ci_gpu_cdash exception after CDash debugging is complete.
-      if [[ "${CI_COMMIT_BRANCH}" == "development" ||
-            "${CI_COMMIT_BRANCH}" == "ci_gpu_cdash" ]]; then
-        # run tests and submit results to CDash as Experimental
-        ctest --test-dir build -R test_3d_laser_acceleration_btd.run \
-          --output-on-failure --no-tests=error -D ExperimentalTest -D ExperimentalSubmit
-      else
-        ctest --test-dir build -R test_3d_laser_acceleration_btd.run \
-          --output-on-failure --no-tests=error
-      fi
+    # TODO: Submit to CDash only from development after CDash debugging is complete:
+    # if [[ "${CI_COMMIT_BRANCH}" == "development" ]]; then
+    #   ctest ... -D ExperimentalTest -D ExperimentalSubmit
+    # fi
+    # run tests and submit results to CDash as Experimental
+    - ctest --test-dir build -R test_3d_laser_acceleration_btd.run
+        --output-on-failure --no-tests=error -D ExperimentalTest -D ExperimentalSubmit
 
 Intel-PVC:
   # TODO: Re-enable the Intel PVC/SYCL runner. Runtime issues.
@@ -128,14 +120,10 @@ Intel-PVC:
           -DWarpX_PARTICLE_PRECISION=SINGLE
     - cmake --build build -j 16
     - export AMREX_DEFAULT_INIT="amrex.the_arena_init_size=0"
-    - |
-      # FIXME: Remove the ci_gpu_cdash exception after CDash debugging is complete.
-      if [[ "${CI_COMMIT_BRANCH}" == "development" ||
-            "${CI_COMMIT_BRANCH}" == "ci_gpu_cdash" ]]; then
-        # run tests and submit results to CDash as Experimental
-        ctest --test-dir build -R test_3d_laser_acceleration_btd.run \
-          --output-on-failure --no-tests=error -D ExperimentalTest -D ExperimentalSubmit
-      else
-        ctest --test-dir build -R test_3d_laser_acceleration_btd.run \
-          --output-on-failure --no-tests=error
-      fi
+    # TODO: Submit to CDash only from development after CDash debugging is complete:
+    # if [[ "${CI_COMMIT_BRANCH}" == "development" ]]; then
+    #   ctest ... -D ExperimentalTest -D ExperimentalSubmit
+    # fi
+    # run tests and submit results to CDash as Experimental
+    - ctest --test-dir build -R test_3d_laser_acceleration_btd.run
+        --output-on-failure --no-tests=error -D ExperimentalTest -D ExperimentalSubmit

--- a/.gitlab/ci.yaml
+++ b/.gitlab/ci.yaml
@@ -20,7 +20,7 @@
     - python3 -m venv venv
     - source venv/bin/activate
 
-Nvidia-H100-single-precision:
+NVIDIA-H100:
   extends: .install-dependencies
   tags: [nvidia-h100]
   image: nvcr.io/nvidia/cuda:12.8.0-devel-ubuntu24.04

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -12,9 +12,3 @@ set(CTEST_NIGHTLY_START_TIME 08:00:00 UTC)
 set(CTEST_SUBMIT_URL https://my.cdash.org/submit.php?project=WarpX)
 
 set(CTEST_DROP_SITE_CDASH TRUE)
-
-# Set site and build names
-# - CTest script variables: CTEST_SITE, CTEST_BUILD_NAME
-# - CTest module variables: SITE, BUILDNAME
-set(SITE "Azure-Pipelines")
-set(BUILDNAME "CI-Development")


### PR DESCRIPTION
## Summary

Add flags that enable reporting to CDash to the `ctest` commands in `.gitlab/ci.yaml`.

The implementation follows what we do in `.azure-pipelines.yml` for CPU CI tests:

https://github.com/BLAST-WarpX/warpx/blob/d48df61a1613d24909438579c9e669df8ff1ee57/.azure-pipelines.yml#L202-L211

Propose new labels in CDash (alternative labels in https://github.com/BLAST-WarpX/warpx/pull/7174#issuecomment-5362580631, please chime in):
- `GitLab` / `GPU-H100-CUDA-SP`
- `GitLab` / `GPU-MI300-HIP-SP`
- `GitLab` / `GPU-PVC-SYCL-Mixed` (currently disabled)
- `Azure` / `CPU-1D` (or `CPU-1D-CYL-SPH` - see https://github.com/BLAST-WarpX/warpx/pull/7174#discussion_r3825676448)
- `Azure` / `CPU-2D`
- `Azure` / `CPU-3D`
- `Azure` / `CPU-RZ`

<img width="1839" height="282" alt="Screenshot from 2026-08-20 14-43-11" src="https://github.com/user-attachments/assets/b10613bd-0c87-457b-b6de-81679ca58d75" />


## Notes

This will create conflicts with #7055. It is probably easier to merge #7174 first (this PR) and then rebase #7055.

## Follow up

- Exclude `pytest.AMReX` when running Python tests as in `.azure-pipelines.yml` for CPU CI tests.