### PR TITLE
[WIP] Implement makeVecLHS/makeVecRHS in the LinearFunction base class

### DIFF
--- a/Source/NonlinearSolvers/JacobianFunctionMF.H
+++ b/Source/NonlinearSolvers/JacobianFunctionMF.H
@@ -69,9 +69,6 @@ class JacobianFunctionMF : public LinearFunction<T,Ops>
     }
 
 
-    T makeVecLHS () const override;
-    T makeVecRHS () const override;
-
     [[nodiscard]] inline
     bool isDefined() const { return m_is_defined;  }
 
@@ -130,6 +127,12 @@ class JacobianFunctionMF : public LinearFunction<T,Ops>
     [[nodiscard]] inline
     PreconditionerType pcType () const override { return m_pc_type; }
 
+    protected:
+
+    //! the LHS and RHS vectors have the same layout as the residual vector
+    [[nodiscard]] inline
+    const T& vecTemplate () const override { return m_R; }
+
     private:
 
     bool m_is_defined = false;
@@ -174,24 +177,6 @@ void JacobianFunctionMF<T,Ops>::define ( const T& a_U,
     }
 
     m_is_defined = true;
-}
-
-template <class T, class Ops>
-auto JacobianFunctionMF<T,Ops>::makeVecRHS () const -> T
-{
-    BL_PROFILE("JacobianFunctionMF::::makeVecRHS()");
-    T x;
-    x.Define(m_R);
-    return x;
-}
-
-template <class T, class Ops>
-auto JacobianFunctionMF<T,Ops>::makeVecLHS () const -> T
-{
-    BL_PROFILE("JacobianFunctionMF::::makeVecLHS()");
-    T x;
-    x.Define(m_R);
-    return x;
 }
 
 template <class T, class Ops>

--- a/Source/NonlinearSolvers/LinearFunction.H
+++ b/Source/NonlinearSolvers/LinearFunction.H
@@ -9,6 +9,8 @@
 
 #include "Preconditioner.H"
 
+#include <AMReX_BLProfiler.H>
+
 #include <string>
 
 /**
@@ -73,11 +75,21 @@ class LinearFunction
             a_Z.define(a_U);
         }
 
-        //! make LHS vector
-        [[nodiscard]] virtual T makeVecLHS () const = 0;
+        /**
+         * \brief Make a vector suitable to be used as the LHS x in A(x) = b.
+         *
+         * The default implementation returns a vector with the same layout as
+         * vecTemplate(). Override this only if the operator needs the LHS to
+         * have a different layout than the RHS (for instance, extra ghost
+         * cells for efficiency), which AMReX's GMRES allows for.
+         */
+        [[nodiscard]] virtual T makeVecLHS () const { return makeVec(); }
 
-        //! make RHS vector
-        [[nodiscard]] virtual T makeVecRHS () const = 0;
+        /**
+         * \brief Make a vector suitable to be used as the RHS b in A(x) = b.
+         *        See makeVecLHS() for the LHS/RHS distinction.
+         */
+        [[nodiscard]] virtual T makeVecRHS () const { return makeVec(); }
 
         //! vector copy operation
         inline void assign( T& a_Z, const T& a_U ) {
@@ -133,6 +145,23 @@ class LinearFunction
         [[nodiscard]] virtual PreconditionerType pcType () const = 0;
 
     protected:
+
+        /**
+         * \brief Return a defined vector whose layout (grids, distribution
+         *        map, number of components, ...) is that of the vectors this
+         *        linear operator acts on. It is used by makeVecLHS() and
+         *        makeVecRHS() to create new vectors.
+         */
+        [[nodiscard]] virtual const T& vecTemplate () const = 0;
+
+        //! make a new, defined vector with the same layout as vecTemplate()
+        [[nodiscard]] T makeVec () const
+        {
+            BL_PROFILE("LinearFunction::makeVec()");
+            T x;
+            x.Define(vecTemplate());
+            return x;
+        }
 
     private:
 


### PR DESCRIPTION
Both functions returned a vector with the same layout as the vector the linear operator was defined with, and this is the case for any operator acting on a `WarpXSolverVec`: its layout is fully determined by the field types it wraps, and it is always allocated without ghost cells.

Provide a default implementation in LinearFunction, based on a new vecTemplate() hook, and remove the duplicated implementations from JacobianFunctionMF. The two functions remain virtual, so that an operator that does need a different layout for the LHS (extra ghost cells, for instance, as AMReX's GMRES allows for) can still override them.