### PR TITLE
add deposition callbacks to electrostatic solvers

### DIFF
--- a/Source/FieldSolver/ElectrostaticSolvers/EffectivePotentialES.cpp
+++ b/Source/FieldSolver/ElectrostaticSolvers/EffectivePotentialES.cpp
@@ -13,6 +13,7 @@
 #include "Fields.H"
 #include "Particles/MultiParticleContainer_fwd.H"
 #include "Utils/Parser/ParserUtils.H"
+#include "Python/callbacks.H"
 #include "WarpX.H"
 
 using namespace amrex;
@@ -58,10 +59,12 @@ void EffectivePotentialES::ComputeSpaceChargeField (
     // set the boundary potentials appropriately
     setPhiBC(phi_fp, warpx.gett_new(0));
 
+    ExecutePythonCallback("beforedeposition");
     // Calculate the mass enhancement factor - see  Appendix A of
     // Barnes, Journal of Comp. Phys., 424 (2021), 109852.
     // Also accumulate the total charge density.
     ComputeSigma(rho_fp);
+    ExecutePythonCallback("afterdeposition");
 
     // perform phi calculation
     computePhi(rho_fp, phi_fp, Efield_fp);

--- a/Source/FieldSolver/ElectrostaticSolvers/LabFrameExplicitES.cpp
+++ b/Source/FieldSolver/ElectrostaticSolvers/LabFrameExplicitES.cpp
@@ -38,11 +38,13 @@ void LabFrameExplicitES::ComputeSpaceChargeField (
     const MultiLevelScalarField phi_fp = fields.get_mr_levels(FieldType::phi_fp, max_level);
     const MultiLevelVectorField Efield_fp = fields.get_mr_levels_alldirs(FieldType::Efield_fp, max_level);
 
+    ExecutePythonCallback("beforedeposition");
     mpc.DepositCharge(rho_fp, 0.0_rt);
     if (mfl) {
         const int lev = 0;
         mfl->DepositCharge(fields, *rho_fp[lev], lev);
     }
+    ExecutePythonCallback("afterdeposition");
 
     // Apply filter, perform MPI exchange, interpolate across levels
     const Vector<std::unique_ptr<MultiFab> > rho_buf(num_levels);


### PR DESCRIPTION
## Summary

This PR adds `beforedeposition` and `afterdeposition` callback functionality to `LabFrameExplicitES` and `EffectivePotentialES` solver routes. 

## Importance

The main utility of this PR is the `afterdeposition` callback, where this will allow manipulation of `rho_fp` after deposition but before the `computePhi` call. This has applications for modeling surface charge, diffusion, or any modification of charge for use in the electrostatic solver.

the `beforedepostion` addition is mainly for consistency. The utility of this call is questionable for the `LabFrameExplicitES` because `beforeEsolve` is called right before. For `EffectivePotentialES`, the `beforedeposition` call happens between `setPhiBC` and `ComputeSigma`, so there may be some utility here. 

## To Do

We may want to add deposition callbacks to `RelativisticExplicitES`, but I'm not sure where. Let me know where to add this.

## Testing
This was tested with a personal model and confirmed to work. No specific tests were created for this PR as it's a simple change and the default testers will catch any problems

