### PR TITLE
Perlmutter CUDA 13.2 & Consistent Purge of JIT Caches

### DIFF
--- a/Tools/machines/adastra-cines/install_dependencies.sh
+++ b/Tools/machines/adastra-cines/install_dependencies.sh
@@ -30,6 +30,10 @@ python3 -m pip uninstall -qq -y pywarpx
 python3 -m pip uninstall -qq -y warpx
 python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 
+# clean out caches, e.g., depending on old system modules
+python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+
 
 # General extra dependencies ##################################################
 #
@@ -111,7 +115,6 @@ rm -rf ${SRC_DIR}/adios2-ad-build
 #
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade virtualenv
-python3 -m pip cache purge
 rm -rf ${SW_DIR}/venvs/warpx-adastra
 python3 -m venv ${SW_DIR}/venvs/warpx-adastra
 source ${SW_DIR}/venvs/warpx-adastra/bin/activate

--- a/Tools/machines/aurora-alcf/install_dependencies.sh
+++ b/Tools/machines/aurora-alcf/install_dependencies.sh
@@ -27,6 +27,10 @@ python3 -m pip uninstall -qq -y pywarpx
 python3 -m pip uninstall -qq -y warpx
 python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 
+# clean out caches, e.g., depending on old system modules
+python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+
 # General extra dependencies ##################################################
 #
 
@@ -64,7 +68,6 @@ rm -rf $HOME/src/lapackpp-aurora-gpu-build
 #
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade virtualenv
-python3 -m pip cache purge
 rm -rf ${SW_DIR}/venvs/warpx-aurora
 python3 -m venv ${SW_DIR}/venvs/warpx-aurora
 source ${SW_DIR}/venvs/warpx-aurora/bin/activate

--- a/Tools/machines/crusher-olcf/install_dependencies.sh
+++ b/Tools/machines/crusher-olcf/install_dependencies.sh
@@ -40,6 +40,10 @@ python3 -m pip uninstall -qq -y pywarpx
 python3 -m pip uninstall -qq -y warpx
 python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 
+# clean out caches, e.g., depending on old system modules
+python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+
 
 # General extra dependencies ##################################################
 #
@@ -79,7 +83,6 @@ rm -rf $HOME/src/lapackpp-crusher-gpu-build
 #
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade virtualenv
-python3 -m pip cache purge
 rm -rf ${SW_DIR}/venvs/warpx-crusher
 python3 -m venv ${SW_DIR}/venvs/warpx-crusher
 source ${SW_DIR}/venvs/warpx-crusher/bin/activate

--- a/Tools/machines/dane-llnl/install_dependencies.sh
+++ b/Tools/machines/dane-llnl/install_dependencies.sh
@@ -27,6 +27,10 @@ python3 -m pip uninstall -qq -y pywarpx
 python3 -m pip uninstall -qq -y warpx
 python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 
+# clean out caches, e.g., depending on old system modules
+python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+
 # Setup the directories where the packages will be installed
 if [ -z "${WARPX_SW_DIR+x}" ]; then
     WARPX_SW_DIR="/usr/workspace/${USER}/dane"
@@ -100,7 +104,6 @@ rm -rf ${WARPX_SW_DIR}/venvs/warpx-dane
 python3 -m venv ${WARPX_SW_DIR}/venvs/warpx-dane
 source ${WARPX_SW_DIR}/venvs/warpx-dane/bin/activate
 python3 -m pip install --upgrade pip
-#python3 -m pip cache purge
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel

--- a/Tools/machines/frontier-olcf/install_dependencies.sh
+++ b/Tools/machines/frontier-olcf/install_dependencies.sh
@@ -40,6 +40,10 @@ python3 -m pip uninstall -qq -y pywarpx
 python3 -m pip uninstall -qq -y warpx
 python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 
+# clean out caches, e.g., depending on old system modules
+python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+
 
 # General extra dependencies ##################################################
 #
@@ -78,7 +82,6 @@ rm -rf $HOME/src/lapackpp-frontier-gpu-build
 #
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade virtualenv
-python3 -m pip cache purge
 rm -rf ${SW_DIR}/venvs/warpx-frontier
 python3 -m venv ${SW_DIR}/venvs/warpx-frontier
 source ${SW_DIR}/venvs/warpx-frontier/bin/activate

--- a/Tools/machines/fugaku-riken/install_dependencies.sh
+++ b/Tools/machines/fugaku-riken/install_dependencies.sh
@@ -22,7 +22,7 @@ mkdir -p ${SRC_DIR}
 # clean out caches, e.g., depending on old system modules
 # no pip dependencies installed here
 #python3 -m pip cache purge || true
-rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+#rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
 
 # General extra dependencies ##################################################
 #

--- a/Tools/machines/fugaku-riken/install_dependencies.sh
+++ b/Tools/machines/fugaku-riken/install_dependencies.sh
@@ -19,6 +19,11 @@ rm -rf ${SW_DIR}
 mkdir -p ${SW_DIR}
 mkdir -p ${SRC_DIR}
 
+# clean out caches, e.g., depending on old system modules
+# no pip dependencies installed here
+#python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+
 # General extra dependencies ##################################################
 #
 

--- a/Tools/machines/greatlakes-umich/install_v100_dependencies.sh
+++ b/Tools/machines/greatlakes-umich/install_v100_dependencies.sh
@@ -30,6 +30,10 @@ python3 -m pip uninstall -qq -y pywarpx
 python3 -m pip uninstall -qq -y warpx
 python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 
+# clean out caches, e.g., depending on old system modules
+python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+
 
 # General extra dependencies ##################################################
 #
@@ -110,7 +114,6 @@ rm -rf ${build_dir}/lapackpp-v100-build
 #
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade virtualenv
-python3 -m pip cache purge
 rm -rf ${SW_DIR}/venvs/warpx-v100
 python3 -m venv ${SW_DIR}/venvs/warpx-v100
 source ${SW_DIR}/venvs/warpx-v100/bin/activate

--- a/Tools/machines/hpc3-uci/install_gpu_dependencies.sh
+++ b/Tools/machines/hpc3-uci/install_gpu_dependencies.sh
@@ -26,7 +26,7 @@ if [ -z ${proj-} ]; then echo "WARNING: The 'proj' variable is not yet set in yo
 #    echo "Is the \$proj environment variable of value \"$proj\" correctly set? "
 #    echo "Please edit line 2 of your hpc3_gpu_warpx.profile file to continue!"
 ##    exit
-fi
+#fi
 
 
 # Remove old dependencies #####################################################
@@ -39,6 +39,10 @@ mkdir -p ${SW_DIR}
 python3 -m pip uninstall -qq -y pywarpx
 python3 -m pip uninstall -qq -y warpx
 python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
+
+# clean out caches, e.g., depending on old system modules
+python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
 
 
 # General extra dependencies ##################################################
@@ -109,7 +113,6 @@ rm -rf $HOME/src/lapackpp-pm-gpu-build
 #
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade virtualenv
-python3 -m pip cache purge
 rm -rf ${SW_DIR}/venvs/warpx-gpu
 python3 -m venv ${SW_DIR}/venvs/warpx-gpu
 source ${SW_DIR}/venvs/warpx-gpu/bin/activate

--- a/Tools/machines/karolina-it4i/install_dependencies.sh
+++ b/Tools/machines/karolina-it4i/install_dependencies.sh
@@ -47,14 +47,18 @@ spack install
 
 # Python ##########################################################
 #
-python -m pip install --user --upgrade pandas
-python -m pip install --user --upgrade matplotlib
+# clean out caches, e.g., depending on old system modules
+python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+
+python3 -m pip install --user --upgrade pandas
+python3 -m pip install --user --upgrade matplotlib
 # optional
-#python -m pip install --user --upgrade yt
+#python3 -m pip install --user --upgrade yt
 
 # install or update WarpX dependencies
-python -m pip install --user --upgrade picmistandard==0.34.0
-python -m pip install --user --upgrade lasy
+python3 -m pip install --user --upgrade picmistandard==0.34.0
+python3 -m pip install --user --upgrade lasy
 
 # optional: for optimas (based on libEnsemble & ax->botorch->gpytorch->pytorch)
-# python -m pip install --user --upgrade -r $WORK/src/warpx/Tools/optimas/requirements.txt
+# python3 -m pip install --user --upgrade -r $WORK/src/warpx/Tools/optimas/requirements.txt

--- a/Tools/machines/leonardo-cineca/install_gpu_dependencies.sh
+++ b/Tools/machines/leonardo-cineca/install_gpu_dependencies.sh
@@ -22,6 +22,10 @@ SW_DIR="$HOME/sw"
 rm -rf ${SW_DIR}
 mkdir -p ${SW_DIR}
 
+# clean out caches, e.g., depending on old system modules
+python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+
 
 # General extra dependencies ##################################################
 #
@@ -80,7 +84,6 @@ rm -rf ${SW_DIR}/venvs/warpx
 python3 -m venv ${SW_DIR}/venvs/warpx
 source ${SW_DIR}/venvs/warpx/bin/activate
 python3 -m ensurepip --upgrade
-python3 -m pip cache purge
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging

--- a/Tools/machines/lonestar6-tacc/install_a100_dependencies.sh
+++ b/Tools/machines/lonestar6-tacc/install_a100_dependencies.sh
@@ -29,6 +29,10 @@ python3 -m pip uninstall -qq -y pywarpx
 python3 -m pip uninstall -qq -y warpx
 python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 
+# clean out caches, e.g., depending on old system modules
+python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+
 
 # General extra dependencies ##################################################
 #
@@ -100,7 +104,6 @@ rm -rf ${build_dir}/lapackpp-a100-build
 #
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade virtualenv
-python3 -m pip cache purge
 rm -rf ${SW_DIR}/venvs/warpx-a100
 python3 -m venv ${SW_DIR}/venvs/warpx-a100
 source ${SW_DIR}/venvs/warpx-a100/bin/activate

--- a/Tools/machines/lumi-csc/install_dependencies.sh
+++ b/Tools/machines/lumi-csc/install_dependencies.sh
@@ -31,6 +31,10 @@ python3 -m pip uninstall -qq -y pywarpx
 python3 -m pip uninstall -qq -y warpx
 python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 
+# clean out caches, e.g., depending on old system modules
+python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+
 
 # General extra dependencies ##################################################
 #
@@ -146,7 +150,6 @@ rm -rf ${build_dir}/adios2-lu-build
 #
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade virtualenv
-python3 -m pip cache purge
 rm -rf ${SW_DIR}/venvs/warpx-lumi
 python3 -m venv ${SW_DIR}/venvs/warpx-lumi
 source ${SW_DIR}/venvs/warpx-lumi/bin/activate

--- a/Tools/machines/perlmutter-nersc/container/gpu/mpi/Containerfile
+++ b/Tools/machines/perlmutter-nersc/container/gpu/mpi/Containerfile
@@ -23,7 +23,7 @@
 #
 
 # Base System and Essential Tools Installation
-FROM nvidia/cuda:12.4.1-devel-ubuntu22.04 AS warpx-dev
+FROM nvidia/cuda:13.2.1-devel-ubuntu22.04 AS warpx-dev
 
 # WarpX version
 ARG warpx_version=25.11
@@ -213,8 +213,8 @@ RUN python3 -m venv /opt/venv && \
         --upgrade        \
         build            \
         cmake            \
-        "nvidia-cuda-runtime-cu12==12.4.*" \
-        cupy-cuda12x     \
+        "nvidia-cuda-runtime==13.2.*" \
+        cupy-cuda13x     \
         cython           \
         h5py             \
         lasy             \
@@ -236,7 +236,7 @@ RUN python3 -m venv /opt/venv && \
 #    uv pip install       \
 #        --no-cache-dir                                      \
 #        --upgrade                                           \
-#        --index-url https://download.pytorch.org/whl/cu126  \
+#        --index-url https://download.pytorch.org/whl/cu132  \
 #        torch
 #        optimas[all]
 
@@ -274,7 +274,7 @@ RUN git clone                       \
     rm -rf /opt/warpx/lib/*.a
 
 # Reduce to runtime
-FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04 AS warpx
+FROM nvidia/cuda:13.2.1-runtime-ubuntu22.04 AS warpx
 
 # Install essential system dependencies (runtime)
 RUN apt-get update            && \

--- a/Tools/machines/perlmutter-nersc/container/gpu/nompi/Containerfile
+++ b/Tools/machines/perlmutter-nersc/container/gpu/nompi/Containerfile
@@ -23,7 +23,7 @@
 #
 
 # Base System and Essential Tools Installation
-FROM nvidia/cuda:12.4.1-devel-ubuntu22.04 AS warpx-dev
+FROM nvidia/cuda:13.2.1-devel-ubuntu22.04 AS warpx-dev
 
 # WarpX version
 ARG warpx_version=25.11
@@ -183,8 +183,8 @@ RUN python3 -m venv /opt/venv && \
         --upgrade        \
         build            \
         cmake            \
-        "nvidia-cuda-runtime-cu12==12.4.*" \
-        cupy-cuda12x     \
+        "nvidia-cuda-runtime==13.2.*" \
+        cupy-cuda13x     \
         cython           \
         h5py             \
         lasy             \
@@ -207,7 +207,7 @@ RUN python3 -m venv /opt/venv && \
 #    uv pip install       \
 #        --no-cache-dir                                      \
 #        --upgrade                                           \
-#        --index-url https://download.pytorch.org/whl/cu126  \
+#        --index-url https://download.pytorch.org/whl/cu132  \
 #        torch
 #        optimas[all]
 
@@ -246,7 +246,7 @@ RUN git clone                       \
     rm -rf /opt/warpx/lib/*.a
 
 # Reduce to runtime
-FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04 AS warpx
+FROM nvidia/cuda:13.2.1-runtime-ubuntu22.04 AS warpx
 
 # Install essential system dependencies (runtime)
 RUN apt-get update            && \

--- a/Tools/machines/perlmutter-nersc/install_cpu_dependencies.sh
+++ b/Tools/machines/perlmutter-nersc/install_cpu_dependencies.sh
@@ -40,6 +40,10 @@ python3 -m pip uninstall -qq -y pywarpx
 python3 -m pip uninstall -qq -y warpx
 python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 
+# clean out caches, e.g., depending on old system modules
+python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+
 
 # General extra dependencies ##################################################
 #
@@ -131,7 +135,6 @@ rm -rf ${build_dir}/lapackpp-pm-cpu-build
 #
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade virtualenv
-python3 -m pip cache purge
 rm -rf ${SW_DIR}/venvs/warpx-cpu
 python3 -m venv ${SW_DIR}/venvs/warpx-cpu
 source ${SW_DIR}/venvs/warpx-cpu/bin/activate

--- a/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
+++ b/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
@@ -153,9 +153,9 @@ python3 -m pip install --upgrade matplotlib
 python3 -m pip install --upgrade yt
 # install or update WarpX dependencies
 python3 -m pip install --upgrade -r $HOME/src/warpx/requirements.txt
-python3 -m pip install --upgrade cupy-cuda12x  # CUDA 12 compatible wheel
+python3 -m pip install --upgrade cupy-cuda13x  # CUDA 13 compatible wheel
 # optimas (based on libEnsemble & ax->botorch->gpytorch->pytorch)
-python3 -m pip install --upgrade torch  # CUDA 12 compatible wheel
+python3 -m pip install --upgrade torch --index-url https://download.pytorch.org/whl/cu132  # CUDA 13.2 compatible wheel
 python3 -m pip install --upgrade optimas[all]
 python3 -m pip install --upgrade lasy
 

--- a/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
+++ b/Tools/machines/perlmutter-nersc/install_gpu_dependencies.sh
@@ -40,6 +40,10 @@ python3 -m pip uninstall -qq -y pywarpx
 python3 -m pip uninstall -qq -y warpx
 python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 
+# clean out caches, e.g., depending on old system modules
+python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+
 
 # General extra dependencies ##################################################
 #
@@ -131,7 +135,6 @@ rm -rf ${build_dir}/lapackpp-pm-gpu-build
 #
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade virtualenv
-python3 -m pip cache purge
 rm -rf ${SW_DIR}/venvs/warpx-gpu
 python3 -m venv ${SW_DIR}/venvs/warpx-gpu
 source ${SW_DIR}/venvs/warpx-gpu/bin/activate

--- a/Tools/machines/perlmutter-nersc/perlmutter_gpu_warpx.profile.example
+++ b/Tools/machines/perlmutter-nersc/perlmutter_gpu_warpx.profile.example
@@ -12,7 +12,7 @@ module load craype
 module load craype-x86-milan
 module load craype-accel-nvidia80
 module load cudatoolkit
-module load gcc-native/13.2  # default gcc-native/14 breaks pybind11 builds with NVCC 12.9.41
+module load gcc-native/13.2  # default gcc-native/14 breaks pybind11 builds with NVCC 13.2.78
 module load cmake/3.30.2
 
 # missing modules installed here

--- a/Tools/machines/pitzer-osc/install_cpu_dependencies.sh
+++ b/Tools/machines/pitzer-osc/install_cpu_dependencies.sh
@@ -29,6 +29,10 @@ python3 -m pip uninstall -qq -y pywarpx
 python3 -m pip uninstall -qq -y warpx
 python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 
+# clean out caches, e.g., depending on old system modules
+python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+
 # General extra dependencies ##################################################
 #
 SRC_DIR="${HOME}/src"
@@ -135,7 +139,6 @@ rm -rf ${SW_DIR}/venvs/${VENV_NAME}
 python3 -m venv ${SW_DIR}/venvs/${VENV_NAME}
 source ${SW_DIR}/venvs/${VENV_NAME}/bin/activate
 python3 -m pip install --upgrade pip
-python3 -m pip cache purge
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel

--- a/Tools/machines/pitzer-osc/install_v100_dependencies.sh
+++ b/Tools/machines/pitzer-osc/install_v100_dependencies.sh
@@ -29,6 +29,10 @@ python3 -m pip uninstall -qq -y pywarpx
 python3 -m pip uninstall -qq -y warpx
 python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 
+# clean out caches, e.g., depending on old system modules
+python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+
 # General extra dependencies ##################################################
 #
 SRC_DIR="${HOME}/src"
@@ -135,7 +139,6 @@ rm -rf ${SW_DIR}/venvs/${VENV_NAME}
 python3 -m venv ${SW_DIR}/venvs/${VENV_NAME}
 source ${SW_DIR}/venvs/${VENV_NAME}/bin/activate
 python3 -m pip install --upgrade pip
-python3 -m pip cache purge
 python3 -m pip install --upgrade build
 python3 -m pip install --upgrade packaging
 python3 -m pip install --upgrade wheel

--- a/Tools/machines/polaris-alcf/install_gpu_dependencies.sh
+++ b/Tools/machines/polaris-alcf/install_gpu_dependencies.sh
@@ -27,6 +27,10 @@ python3 -m pip uninstall -qq -y pywarpx
 python3 -m pip uninstall -qq -y warpx
 python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 
+# clean out caches, e.g., depending on old system modules
+python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+
 # General extra dependencies ##################################################
 #
 
@@ -94,7 +98,6 @@ rm -rf $HOME/src/lapackpp-pm-gpu-build
 #
 python3 -m pip install --upgrade pip
 python3 -m pip install --upgrade virtualenv
-python3 -m pip cache purge
 rm -rf ${SW_DIR}/venvs/warpx
 python3 -m venv ${SW_DIR}/venvs/warpx
 source ${SW_DIR}/venvs/warpx/bin/activate

--- a/Tools/machines/tuolumne-llnl/install_cpu_dependencies.sh
+++ b/Tools/machines/tuolumne-llnl/install_cpu_dependencies.sh
@@ -31,6 +31,11 @@ python3 -m pip uninstall -qq -y pywarpx
 python3 -m pip uninstall -qq -y warpx
 python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 
+# clean out caches, e.g., depending on old system modules
+# pip cache disabled system-wide
+#python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+
 
 # General extra dependencies ##################################################
 #
@@ -213,7 +218,6 @@ cd -
 export PIP_EXTRA_INDEX_URL="https://pypi.org/simple"
 
 python3 -m pip install --upgrade pip
-# python3 -m pip cache purge || true  # Cache disabled on system
 rm -rf ${SW_DIR}/venvs/warpx-tuolumne-cpu
 python3 -m venv ${SW_DIR}/venvs/warpx-tuolumne-cpu
 source ${SW_DIR}/venvs/warpx-tuolumne-cpu/bin/activate

--- a/Tools/machines/tuolumne-llnl/install_mi300a_dependencies.sh
+++ b/Tools/machines/tuolumne-llnl/install_mi300a_dependencies.sh
@@ -31,6 +31,11 @@ python3 -m pip uninstall -qq -y pywarpx
 python3 -m pip uninstall -qq -y warpx
 python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 
+# clean out caches, e.g., depending on old system modules
+# pip cache disabled system-wide
+#python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+
 
 # General extra dependencies ##################################################
 #
@@ -214,7 +219,6 @@ cd -
 export PIP_EXTRA_INDEX_URL="https://pypi.org/simple"
 
 python3 -m pip install --upgrade pip
-# python3 -m pip cache purge || true  # Cache disabled on system
 rm -rf ${SW_DIR}/venvs/warpx-tuolumne-mi300a
 python3 -m venv ${SW_DIR}/venvs/warpx-tuolumne-mi300a
 source ${SW_DIR}/venvs/warpx-tuolumne-mi300a/bin/activate

--- a/Tools/machines/tuolumne-llnl/install_mi300a_ml.sh
+++ b/Tools/machines/tuolumne-llnl/install_mi300a_ml.sh
@@ -27,6 +27,11 @@ SW_DIR="/p/lustre5/${USER}/tuolumne/warpx/mi300a"
 # remove common user mistakes in python, located in .local instead of a venv
 python3 -m pip uninstall -qqq -y torch 2>/dev/null || true
 
+# clean out caches, e.g., depending on old system modules
+# pip cache disabled system-wide
+#python3 -m pip cache purge || true
+rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
+
 
 # Python ML ###################################################################
 #


### PR DESCRIPTION
HPC install scripts: Ensure existing PIP and JIT Python caches do not survive system upgrades and pull in stale dependencies, e.g., on old CUDA toolkits.

Fix syntax error on HPC3 (UCI).
Write consistently `python3` on Karolina (IT4I).

<details>
## X-ref

- ImpactX: https://github.com/BLAST-ImpactX/impactx/pull/1624 (same change, all `docs/source/install/hpc/` scripts)

## Summary

Often, after HPC system upgrades, pip caches have wheels in them that still depend on old system libs, old system modules or old CUDA runtimes that are then incompatible when combined together in Python runs/imports.

This adds a cache purge to every `install*` script in `Tools/machines/`, early in the "Remove old dependencies" section, before any dependency is installed.

## Details

User-facing:
- every HPC `install*` script now runs `python3 -m pip cache purge` and additionally wipes the GPU kernel/JIT caches `~/.cupy/kernel_cache`, `~/.nv/ComputeCache`, `~/.cache/numba` and `~/.triton`, which `pip cache purge` does not cover but which go equally stale over a CUDA/ROCm runtime upgrade
- `hpc3-uci`: fixes a stray `fi` that was left behind when the `$proj` directory check was commented out; the script did not parse at all and aborted immediately for every user
- `karolina-it4i`: the script mixed `python` and `python3`; it now consistently uses `python3`

Internal:
- the purge moved up from the venv section into the "Remove old dependencies" section; the later, then redundant `pip cache purge` calls are removed, so each script purges exactly once
- `tuolumne-llnl`: the pip cache is disabled system-wide, the purge is left commented out there
- `fugaku-riken`: this script installs no pip dependencies, the purge is left commented out there
- the purge is guarded with `|| true` so that a disabled cache or a pip too old for the `cache` subcommand does not abort the script under `set -e`

## Testing

`bash -n` passes on all 20 scripts. It did not before this PR: `Tools/machines/hpc3-uci/install_gpu_dependencies.sh` failed with `syntax error near unexpected token 'fi'`.

</details>