### PR TITLE
Add end-of-line to benchmark JSON files

### DIFF
--- a/Tools/DevUtils/update_benchmarks_from_azure_output.py
+++ b/Tools/DevUtils/update_benchmarks_from_azure_output.py
@@ -83,6 +83,7 @@ def update_benchmarks_from_log_text(log_text):
                 print(json_file_string)
                 with open(json_filepath, "w") as json_f:
                     json.dump(json_file, json_f, sort_keys=True, indent=2)
+                    json_f.write("\n")  # Add trailing newline
                 updated.append(json_filename)
                 # reset to continue searching for more failing tests
                 failing_test = ""


### PR DESCRIPTION
This is a small fix to `update_benchmarks_from_azure_output.py` to explicitly add an end-of-line character to the last line of the JSON files written out. Whenever I use this script, it was always showing a change to the last line due to the lack of the end-of-line character there. Having the end-of-line character is much cleaner (and is the POSIX standard).