### PR TITLE
ABLASTR: Warn Manager State is Per AMReX Cycle

### DIFF
--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -329,6 +329,9 @@ void
 WarpX::Finalize()
 {
     WarpX::ResetInstance();
+
+    // Clear all of the warning messages
+    ablastr::warn_manager::WMClear();
 }
 
 WarpX::WarpX ()

--- a/Source/ablastr/utils/msg_logger/MsgLogger.H
+++ b/Source/ablastr/utils/msg_logger/MsgLogger.H
@@ -224,6 +224,11 @@ namespace ablastr::utils::msg_logger
         [[nodiscard]] std::vector<MsgWithCounterAndRanks>
         collective_gather_msgs_with_counter_and_ranks() const;
 
+        /**
+         * \brief Clear all messages
+         */
+        void clear() { m_messages.clear(); }
+
         private:
 
         /**

--- a/Source/ablastr/warn_manager/WarnManager.H
+++ b/Source/ablastr/warn_manager/WarnManager.H
@@ -74,6 +74,15 @@ namespace ablastr::warn_manager
         */
         ~WarnManager() = default;
 
+        /**
+        * \brief Returns the WarnManager instance of the current AMReX
+        * initialize/finalize cycle, creating it on first use.
+        *
+        * The instance is destroyed by the next amrex::Finalize, so the
+        * returned reference must not be stored beyond it.
+        *
+        * @return the instance of the WarnManager class
+        */
         static WarnManager& GetInstance();
 
         /**
@@ -211,6 +220,7 @@ namespace ablastr::warn_manager
 
     /**
     * \brief Helper function to abbreviate the call to get a WarnManager instance
+    * (the returned reference must not be stored beyond the next amrex::Finalize)
     *
     * @return the instance of the WarnManager class
     */

--- a/Source/ablastr/warn_manager/WarnManager.H
+++ b/Source/ablastr/warn_manager/WarnManager.H
@@ -154,6 +154,11 @@ namespace ablastr::warn_manager
         */
         void debug_read_warnings_from_input(const amrex::ParmParse& params);
 
+        /**
+         * \brief Clear all warning messages
+         */
+        void Clear();
+
         static const int warn_line_size = 80 /*! Maximum line length to be used in formatting warning list*/;
         static const int warn_tab_size = 5 /*! Tabulation size to be used in formatting warning list*/;
 
@@ -238,6 +243,11 @@ namespace ablastr::warn_manager
         const std::string& topic,
         const std::string& text,
         const WarnPriority& priority = WarnPriority::medium);
+
+    /**
+     * \brief Clear all warning messages
+     */
+    void WMClear();
 }
 
 #endif //ABLASTR_WARN_MANAGER_H_

--- a/Source/ablastr/warn_manager/WarnManager.H
+++ b/Source/ablastr/warn_manager/WarnManager.H
@@ -75,14 +75,8 @@ namespace ablastr::warn_manager
         ~WarnManager() = default;
 
         /**
-        * \brief Returns the WarnManager instance of the current AMReX
-        * initialize/finalize cycle, creating it on first use.
-        *
-        * The instance is destroyed by the next amrex::Finalize, so the
-        * returned reference must not be stored beyond it.
-        *
-        * @return the instance of the WarnManager class
-        */
+         * \brief Return the static WarnManager singleton
+         */
         static WarnManager& GetInstance();
 
         /**
@@ -225,7 +219,6 @@ namespace ablastr::warn_manager
 
     /**
     * \brief Helper function to abbreviate the call to get a WarnManager instance
-    * (the returned reference must not be stored beyond the next amrex::Finalize)
     *
     * @return the instance of the WarnManager class
     */

--- a/Source/ablastr/warn_manager/WarnManager.cpp
+++ b/Source/ablastr/warn_manager/WarnManager.cpp
@@ -17,6 +17,8 @@
 #include <AMReX_ParmParse.H>
 
 #include <algorithm>
+#include <memory>
+#include <mutex>
 #include <sstream>
 #include <vector>
 
@@ -25,6 +27,14 @@ using namespace ablastr::warn_manager;
 
 namespace
 {
+    //! the WarnManager instance of the current AMReX initialize/finalize cycle
+    //! (with nested amrex::Initialize, the innermost amrex::Finalize already ends it)
+    std::unique_ptr<WarnManager> warn_manager_instance;
+
+    //! guards creation and teardown of warn_manager_instance - the pointer, not the
+    //! reference GetInstance returns; a namespace-scope pointer has no thread-safe init
+    std::mutex warn_manager_instance_mutex;
+
     WarnPriority MapPriorityToWarnPriority (
         const abl_msg_logger::Priority& priority)
     {
@@ -45,8 +55,32 @@ namespace
 }
 
 WarnManager& WarnManager::GetInstance() {
-    static auto warn_manager = WarnManager{};
-    return warn_manager;
+    const std::lock_guard<std::mutex> lock{warn_manager_instance_mutex};
+
+    if (!warn_manager_instance)
+    {
+        // The state of the warn manager (recorded warnings, the
+        // warn-immediately flag, the abort threshold and the MPI rank) belongs
+        // to one AMReX initialize/finalize cycle: a process that runs more than
+        // one simulation, e.g., a parameter scan in Python, starts each of them
+        // with a clean warning list and with the default warning settings.
+        // std::make_unique is not an option here, because the constructor is
+        // private.
+        warn_manager_instance = std::unique_ptr<WarnManager>{new WarnManager};
+
+        // Do not record a warning from a finalize hook: amrex::Finalize calls top()() before
+        // pop(), so a teardown pushed from there is dropped and leaks into the next cycle.
+        amrex::ExecOnFinalize([](){
+            // destroyed outside the lock: the non-recursive mutex deadlocks on a warning
+            std::unique_ptr<WarnManager> expiring;
+            {
+                const std::lock_guard<std::mutex> finalize_lock{warn_manager_instance_mutex};
+                expiring = std::move(warn_manager_instance);
+            }
+        });
+    }
+
+    return *warn_manager_instance;
 }
 
 WarnManager::WarnManager():

--- a/Source/ablastr/warn_manager/WarnManager.cpp
+++ b/Source/ablastr/warn_manager/WarnManager.cpp
@@ -17,8 +17,6 @@
 #include <AMReX_ParmParse.H>
 
 #include <algorithm>
-#include <memory>
-#include <mutex>
 #include <sstream>
 #include <vector>
 
@@ -27,14 +25,6 @@ using namespace ablastr::warn_manager;
 
 namespace
 {
-    //! the WarnManager instance of the current AMReX initialize/finalize cycle
-    //! (with nested amrex::Initialize, the innermost amrex::Finalize already ends it)
-    std::unique_ptr<WarnManager> warn_manager_instance;
-
-    //! guards creation and teardown of warn_manager_instance - the pointer, not the
-    //! reference GetInstance returns; a namespace-scope pointer has no thread-safe init
-    std::mutex warn_manager_instance_mutex;
-
     WarnPriority MapPriorityToWarnPriority (
         const abl_msg_logger::Priority& priority)
     {
@@ -55,32 +45,8 @@ namespace
 }
 
 WarnManager& WarnManager::GetInstance() {
-    const std::lock_guard<std::mutex> lock{warn_manager_instance_mutex};
-
-    if (!warn_manager_instance)
-    {
-        // The state of the warn manager (recorded warnings, the
-        // warn-immediately flag, the abort threshold and the MPI rank) belongs
-        // to one AMReX initialize/finalize cycle: a process that runs more than
-        // one simulation, e.g., a parameter scan in Python, starts each of them
-        // with a clean warning list and with the default warning settings.
-        // std::make_unique is not an option here, because the constructor is
-        // private.
-        warn_manager_instance = std::unique_ptr<WarnManager>{new WarnManager};
-
-        // Do not record a warning from a finalize hook: amrex::Finalize calls top()() before
-        // pop(), so a teardown pushed from there is dropped and leaks into the next cycle.
-        amrex::ExecOnFinalize([](){
-            // destroyed outside the lock: the non-recursive mutex deadlocks on a warning
-            std::unique_ptr<WarnManager> expiring;
-            {
-                const std::lock_guard<std::mutex> finalize_lock{warn_manager_instance_mutex};
-                expiring = std::move(warn_manager_instance);
-            }
-        });
-    }
-
-    return *warn_manager_instance;
+    static auto warn_manager = WarnManager{};
+    return warn_manager;
 }
 
 WarnManager::WarnManager():
@@ -346,6 +312,11 @@ WarnManager::MsgFormatter(
     return ss_out.str();
 }
 
+void WarnManager::Clear()
+{
+    m_p_logger->clear();
+}
+
 WarnManager& ablastr::warn_manager::GetWMInstance()
 {
     return WarnManager::GetInstance();
@@ -358,4 +329,9 @@ void ablastr::warn_manager::WMRecordWarning(
 {
     WarnManager::GetInstance().RecordWarning(
         topic, text, priority);
+}
+
+void ablastr::warn_manager::WMClear()
+{
+    WarnManager::GetInstance().Clear();
 }


### PR DESCRIPTION
## Summary

`WarnManager` is a process-lifetime singleton, so the warnings it recorded outlived `WarpX::Finalize()`. A process that runs more than one simulation (e.g., a parameter scan in Python, or the pytest unit tests) saw the second simulation report the warnings of the first one again.

* User-facing: a second simulation in the same process starts with a clean warning list. **No change for a regular simulation run**, which runs exactly one simulation.
* Internal: new `WarnManager::Clear()` and `ablastr::warn_manager::WMClear()`, backed by `msg_logger::Logger::clear()`, called at the end of `WarpX::Finalize()`. The singleton and its lifetime are unchanged.

<details>
<summary>Details and test coverage</summary>

### Details

An earlier version of this PR gave the singleton a per-AMReX-cycle lifetime instead: a `std::unique_ptr` created on first use, released from an `amrex::ExecOnFinalize` hook and guarded by a mutex. That reset more state, but it had to work around `amrex::Finalize()` draining its finalize stack with `top()()` before `pop()`, which silently drops a hook that is registered while the stack is draining. Clearing the message list from `WarpX::Finalize()` covers the case that actually bites and is much easier to reason about.

The warning settings are not part of the reset. `always_warn_immediately` is re-set on every `WarpX` construction, because `initialize_warning_manager()` always calls `SetAlwaysWarnImmediately()` with the parsed-or-default value. `abort_on_warning_threshold` is only assigned when `warpx.abort_on_warning_threshold` is present in the inputs, so a second simulation that omits it keeps the threshold of the first one.

### Test coverage

`Source/ablastr/warn_manager/WarnManager.cpp` and `Source/WarpX.cpp` compile clean with the project warning flags.

The behavior itself is not covered by a test on `development` yet. The natural home is the pytest harness of https://github.com/BLAST-WarpX/warpx/pull/7144, which runs several simulations in one process: a test there should assert that the second simulation's warning list starts empty, otherwise this can regress silently.

</details>
