### PR TITLE
Linear Breit-Wheeler: use amrex::Math::powi and _prt literals

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/LinearBreitWheeler/LinearBreitWheelerCrossSection.H
+++ b/Source/Particles/Collision/BinaryCollision/LinearBreitWheeler/LinearBreitWheelerCrossSection.H
@@ -10,6 +10,7 @@
 
 #include "Utils/WarpXConst.H"
 
+#include <AMReX_Math.H>
 #include <AMReX_REAL.H>
 
 #include <cmath>
@@ -35,18 +36,15 @@ amrex::ParticleReal LinearBreitWheelerCrossSection (const amrex::ParticleReal& E
 
     if (E_star < me*c2) {return 0._prt;}
 
-    constexpr auto one_half_pr = amrex::ParticleReal(1./2.);
     constexpr amrex::ParticleReal pi = MathConst::pi;
     constexpr amrex::ParticleReal re2 = PhysConst::r_e * PhysConst::r_e;
-    auto constexpr pow2 = [](auto const x) { return x*x; };
-    auto constexpr pow4 = [](auto const x) { return x*x*x*x; };
 
-    const amrex::ParticleReal s = pow2(E_star/(me * c2));
+    const amrex::ParticleReal s = amrex::Math::powi<2>(E_star/(me * c2));
     const amrex::ParticleReal beta = std::sqrt(1._prt-1._prt/s);
 
-    const amrex::ParticleReal term1 = (3._prt-pow4(beta))*std::log((1._prt+beta)/(1._prt-beta));
-    const amrex::ParticleReal term2 = 2._prt*beta*(pow2(beta)-2._prt);
-    const amrex::ParticleReal cross_section = one_half_pr*pi*re2*(1._prt-pow2(beta))*(term1+term2);
+    const amrex::ParticleReal term1 = (3._prt-amrex::Math::powi<4>(beta))*std::log((1._prt+beta)/(1._prt-beta));
+    const amrex::ParticleReal term2 = 2._prt*beta*(amrex::Math::powi<2>(beta)-2._prt);
+    const amrex::ParticleReal cross_section = 0.5_prt*pi*re2*(1._prt-amrex::Math::powi<2>(beta))*(term1+term2);
 
     return cross_section;
 }

--- a/Source/Particles/Collision/BinaryCollision/LinearBreitWheeler/LinearBreitWheelerUtil.H
+++ b/Source/Particles/Collision/BinaryCollision/LinearBreitWheeler/LinearBreitWheelerUtil.H
@@ -62,8 +62,6 @@ namespace {
         constexpr auto c2 = PhysConst::c2_v<amrex::ParticleReal>;
         constexpr auto inv_c2 = PhysConst::inv_c2_v<amrex::ParticleReal>;
         constexpr amrex::ParticleReal me = PhysConst::m_e;
-        constexpr auto one_half_pr = amrex::ParticleReal(1./2.);
-        constexpr auto one_pr = amrex::ParticleReal(1.);
 
         // Compute momenta
         const amrex::ParticleReal p1x_in = u1x_in * me;
@@ -80,7 +78,7 @@ namespace {
 
         // Energy squared of each of the two colliding photons in the center of momentum frame,
         // calculated using the Lorentz invariance of the total four-momentum norm
-        const amrex::ParticleReal E_star_sq = one_half_pr*c2*p1_in*p2_in*(one_pr - cos_ang);
+        const amrex::ParticleReal E_star_sq = 0.5_prt*c2*p1_in*p2_in*(1._prt - cos_ang);
 
         // Square of the norm of the momentum of the products in the center of mass frame
         // Formula obtained by inverting E^2 = p^2*c^2 + m^2*c^4 in the COM frame for each particle:


### PR DESCRIPTION
## Summary

Small refactor of the linear Breit-Wheeler cross-section and utility headers split from #6141, to keep that PR as focused as possible.

Replaces the local `pow2`/`pow4` lambdas with `amrex::Math::powi<N>`, and the auxiliary `one_half_pr`/`one_pr` constants with the `0.5_prt`/`1._prt` literals.

There should be no change in behavior and no benchmark updates.