### PR TITLE
Fix RSPHERE particle-boundary momentum basis

### DIFF
--- a/Examples/Tests/particle_boundary_interaction/CMakeLists.txt
+++ b/Examples/Tests/particle_boundary_interaction/CMakeLists.txt
@@ -30,3 +30,23 @@ if(WarpX_EB)
         OFF  # dependency
     )
 endif()
+
+add_warpx_test(
+    test_rsphere_particle_boundary_interaction_reflecting  # name
+    RSPHERE  # dims
+    1  # nprocs
+    inputs_test_rsphere_particle_boundary_interaction_reflecting  # inputs
+    "analysis_rsphere_radial_boundary.py diags/diag000001 reflecting"  # analysis
+    OFF  # checksum
+    OFF  # dependency
+)
+
+add_warpx_test(
+    test_rsphere_particle_boundary_interaction_thermal  # name
+    RSPHERE  # dims
+    1  # nprocs
+    inputs_test_rsphere_particle_boundary_interaction_thermal  # inputs
+    "analysis_rsphere_radial_boundary.py diags/diag000001 thermal"  # analysis
+    OFF  # checksum
+    OFF  # dependency
+)

--- a/Examples/Tests/particle_boundary_interaction/analysis_rsphere_radial_boundary.py
+++ b/Examples/Tests/particle_boundary_interaction/analysis_rsphere_radial_boundary.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 The WarpX Community
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+"""Check RSPHERE radial reflecting and thermal particle boundaries."""
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import yt
+from scipy.constants import c, m_e
+
+yt.funcs.mylog.setLevel(0)
+
+
+def particle_state(plotfile):
+    dataset = yt.load(str(plotfile))
+    data = dataset.all_data()
+    particle_id = np.asarray(data["test", "particle_id"], dtype=np.int64)
+    order = np.argsort(particle_id)
+    radius = np.asarray(data["test", "particle_position_x"])[order]
+    theta = np.asarray(data["test", "particle_theta"])[order]
+    phi = np.asarray(data["test", "particle_phi"])[order]
+    position = radius[:, None] * np.column_stack(
+        [
+            np.cos(theta) * np.cos(phi),
+            np.sin(theta) * np.cos(phi),
+            np.sin(phi),
+        ]
+    )
+    normalized_momentum = np.column_stack(
+        [
+            np.asarray(data["test", f"particle_momentum_{axis}"])[order]
+            / (m_e * c)
+            for axis in "xyz"
+        ]
+    )
+    return particle_id[order], position, normalized_momentum
+
+
+final_plotfile = Path(sys.argv[1])
+boundary_type = sys.argv[2]
+initial_plotfile = final_plotfile.with_name("diag000000")
+
+initial_id, initial_position, initial_u = particle_state(initial_plotfile)
+final_id, final_position, final_u = particle_state(final_plotfile)
+
+assert np.array_equal(final_id, initial_id), "the radial boundary changed particle IDs"
+assert initial_id.size >= 32, "the test needs angular coverage"
+
+initial_er = initial_position / np.linalg.norm(initial_position, axis=1)[:, None]
+final_er = final_position / np.linalg.norm(final_position, axis=1)[:, None]
+initial_ur = np.einsum("ij,ij->i", initial_u, initial_er)
+final_ur = np.einsum("ij,ij->i", final_u, final_er)
+
+np.testing.assert_allclose(initial_er, final_er, rtol=2.0e-14, atol=2.0e-14)
+np.testing.assert_allclose(initial_ur, 1.0, rtol=2.0e-14, atol=2.0e-14)
+
+if boundary_type == "reflecting":
+    np.testing.assert_allclose(final_u, -initial_u, rtol=2.0e-14, atol=2.0e-14)
+    np.testing.assert_allclose(final_ur, -1.0, rtol=2.0e-14, atol=2.0e-14)
+elif boundary_type == "thermal":
+    assert np.all(final_ur < 0.0), (
+        "thermal radial re-emission must point inward; "
+        f"{np.count_nonzero(final_ur >= 0.0)} of {final_ur.size} particles point outward"
+    )
+    assert np.all(np.linalg.norm(final_u, axis=1) > 0.0)
+else:
+    raise ValueError(f"unknown boundary type {boundary_type!r}")
+
+print(
+    f"PASS: RSPHERE {boundary_type} radial boundary; "
+    f"ur range [{final_ur.min():.6e}, {final_ur.max():.6e}]"
+)

--- a/Examples/Tests/particle_boundary_interaction/analysis_rsphere_radial_boundary.py
+++ b/Examples/Tests/particle_boundary_interaction/analysis_rsphere_radial_boundary.py
@@ -35,8 +35,7 @@ def particle_state(plotfile):
     )
     normalized_momentum = np.column_stack(
         [
-            np.asarray(data["test", f"particle_momentum_{axis}"])[order]
-            / (m_e * c)
+            np.asarray(data["test", f"particle_momentum_{axis}"])[order] / (m_e * c)
             for axis in "xyz"
         ]
     )

--- a/Examples/Tests/particle_boundary_interaction/inputs_base_rsphere_radial_boundary
+++ b/Examples/Tests/particle_boundary_interaction/inputs_base_rsphere_radial_boundary
@@ -1,0 +1,44 @@
+# Copyright 2026 The WarpX Community
+#
+# This file is part of WarpX.
+#
+# License: BSD-3-Clause-LBNL
+
+max_step = 1
+warpx.const_dt = 1.2e-9
+
+amr.n_cell = 1
+amr.max_level = 0
+amr.blocking_factor = 1
+amr.max_grid_size = 1
+
+geometry.dims = RSPHERE
+geometry.prob_lo = 0.75
+geometry.prob_hi = 1.0
+
+boundary.field_lo = none
+boundary.field_hi = none
+boundary.particle_lo = none
+
+algo.maxwell_solver = none
+algo.particle_shape = 1
+
+particles.species_names = test
+
+test.charge = 0.0
+test.mass = m_e
+test.injection_style = NUniformPerCell
+test.num_particles_per_cell_each_dim = 2 4 4
+test.profile = constant
+test.density = 1.0
+test.momentum_distribution_type = parse_momentum_function
+test.momentum_function_ux(x,y,z) = "u0*x/sqrt(x*x+y*y+z*z)"
+test.momentum_function_uy(x,y,z) = "u0*y/sqrt(x*x+y*y+z*z)"
+test.momentum_function_uz(x,y,z) = "u0*z/sqrt(x*x+y*y+z*z)"
+my_constants.u0 = 1.0
+
+diagnostics.diags_names = diag
+diag.intervals = 1
+diag.diag_type = Full
+diag.fields_to_plot = none
+diag.write_species = 1

--- a/Examples/Tests/particle_boundary_interaction/inputs_test_rsphere_particle_boundary_interaction_reflecting
+++ b/Examples/Tests/particle_boundary_interaction/inputs_test_rsphere_particle_boundary_interaction_reflecting
@@ -1,0 +1,3 @@
+FILE = inputs_base_rsphere_radial_boundary
+
+boundary.particle_hi = reflecting

--- a/Examples/Tests/particle_boundary_interaction/inputs_test_rsphere_particle_boundary_interaction_thermal
+++ b/Examples/Tests/particle_boundary_interaction/inputs_test_rsphere_particle_boundary_interaction_thermal
@@ -1,0 +1,4 @@
+FILE = inputs_base_rsphere_radial_boundary
+
+boundary.particle_hi = thermal
+boundary.test.u_th = 0.02

--- a/Source/Particles/ParticleBoundaries_K.H
+++ b/Source/Particles/ParticleBoundaries_K.H
@@ -128,9 +128,11 @@ namespace ApplyParticleBoundaries {
                        boundaries.xmin_bc, boundaries.xmax_bc,
                        boundaries.reflection_model_xlo(-ux), boundaries.reflection_model_xhi(ux),
                        engine);
+#ifndef WARPX_DIM_RSPHERE
         if (rethermalize_x) {
             thermalize_boundary_particle(ux, uy, uz, boundaries.m_uth, engine);
         }
+#endif
 #endif
 #ifdef WARPX_DIM_3D
         bool rethermalize_y = false; // stores if particle crosses y boundary and needs to be thermalized
@@ -177,20 +179,23 @@ namespace ApplyParticleBoundaries {
         if (change_sign_uz) { uz = -uz; }
 #elif defined(WARPX_DIM_RSPHERE)
         // "y" is theta
-        // "z" is phi
+        // "z" is phi, the elevation from the x-y plane
         const amrex::Real costheta = std::cos(y);
         const amrex::Real sintheta = std::sin(y);
         const amrex::Real cosphi = std::cos(z);
         const amrex::Real sinphi = std::sin(z);
-        amrex::Real ur = +ux*costheta*sinphi + uy*sintheta*sinphi + uz*cosphi;
+        amrex::Real ur = +ux*costheta*cosphi + uy*sintheta*cosphi + uz*sinphi;
         amrex::Real ut = -ux*sintheta + uy*costheta;
-        amrex::Real up = -ux*costheta*cosphi - uy*sintheta*cosphi + uz*sinphi;
+        amrex::Real up = -ux*costheta*sinphi - uy*sintheta*sinphi + uz*cosphi;
+        if (rethermalize_x) {
+            thermalize_boundary_particle(ur, ut, up, boundaries.m_uth, engine);
+        }
         if (change_sign_ux) { ur = -ur; }
         if (change_sign_uy) { ut = -ut; }
         if (change_sign_uz) { up = -up; }
-        ux = sinphi*costheta*ur - sintheta*ut - cosphi*costheta*up;
-        uy = sinphi*sintheta*ur + costheta*ut - cosphi*sintheta*up;
-        uz = cosphi*ur + sinphi*up;
+        ux = cosphi*costheta*ur - sintheta*ut - sinphi*costheta*up;
+        uy = cosphi*sintheta*ur + costheta*ut - sinphi*sintheta*up;
+        uz = sinphi*ur + cosphi*up;
 #else
         if (change_sign_ux) { ux = -ux; }
         if (change_sign_uy) { uy = -uy; }


### PR DESCRIPTION
## Summary

RSPHERE stores `phi` as elevation from the Cartesian x-y plane. The particle-boundary kernel instead used the spherical basis for a polar angle measured from +z. Consequently, reflecting a particle at a radial boundary changed the wrong Cartesian momentum components away from special angles.

This change:

- uses the documented elevation-angle basis for Cartesian/local momentum conversion;
- samples thermal re-emission in the local `(u_r, u_theta, u_phi)` frame, so the half-Maxwellian normal component is always directed into the domain;
- adds native RSPHERE reflecting and thermal regressions with 32 angularly distributed particles.

## Reproducer and validation

On the unmodified `development` branch:

- reflecting boundary: 96/96 Cartesian momentum-component checks fail;
- thermal boundary: 8/32 returned particles point outward.

With this commit:

- reflecting run and component-wise analysis pass;
- thermal run and inward-normal analysis pass;
- Release RSPHERE build, Ruff, Python compilation, repository input-name audit, and `git diff --check` pass.

This is independent of #7194, which corrects Cartesian-to-RSPHERE particle position initialization. These tests use native `NUniformPerCell` RSPHERE initialization and directly exercise the boundary kernel.
