### PR TITLE
Generalize default test analysis scripts (regression, restart)

### DIFF
--- a/Examples/Physics_applications/uniform_plasma/CMakeLists.txt
+++ b/Examples/Physics_applications/uniform_plasma/CMakeLists.txt
@@ -26,7 +26,7 @@ add_warpx_test(
     3  # dims
     2  # nprocs
     inputs_test_3d_uniform_plasma_restart  # inputs
-    "analysis_default_restart.py diags/diag1000010"  # analysis
+    "analysis_default_restart.py --path diags/diag1000010"  # analysis
     "analysis_default_regression.py --path diags/diag1000010 --rtol 1e-12"  # checksum
     test_3d_uniform_plasma  # dependency
 )

--- a/Examples/Tests/load_external_field/CMakeLists.txt
+++ b/Examples/Tests/load_external_field/CMakeLists.txt
@@ -36,7 +36,7 @@ add_warpx_test(
     RZ  # dims
     1  # nprocs
     inputs_test_rz_load_external_field_grid_restart  # inputs
-    "analysis_default_restart.py diags/diag1000300"  # analysis
+    "analysis_default_restart.py --path diags/diag1000300"  # analysis
     "analysis_default_regression.py --path diags/diag1000300"  # checksum
     test_rz_load_external_field_grid  # dependency
 )
@@ -56,7 +56,7 @@ add_warpx_test(
     RZ  # dims
     1  # nprocs
     inputs_test_rz_load_external_field_particles_restart  # inputs
-    "analysis_default_restart.py diags/diag1000300"  # analysis
+    "analysis_default_restart.py --path diags/diag1000300"  # analysis
     "analysis_default_regression.py --path diags/diag1000300"  # checksum
     test_rz_load_external_field_particles  # dependency
 )
@@ -89,7 +89,7 @@ add_warpx_test(
     3                                                  # dims
     1                                                  # nprocs
     inputs_test_3d_load_external_field_particle_time_restart  # inputs
-    "analysis_default_restart.py diags/diag1000300"    # analysis
+    "analysis_default_restart.py --path diags/diag1000300"    # analysis
     "analysis_default_regression.py --path diags/diag1000300"  # checksum
     test_3d_load_external_field_particle_time          # dependency
 )

--- a/Examples/Tests/ohm_solver_restart/CMakeLists.txt
+++ b/Examples/Tests/ohm_solver_restart/CMakeLists.txt
@@ -16,7 +16,7 @@ add_warpx_test(
     2  # dims
     2  # nprocs
     "inputs_test_2d_ohm_solver_checkpoint_picmi.py amr.restart='../test_2d_ohm_solver_checkpoint_picmi/diags/chk000005'"  # inputs
-    "analysis_default_restart.py diags/diag1000010"  # analysis
+    "analysis_default_restart.py --path diags/diag1000010"  # analysis
     "analysis_default_regression.py --path diags/diag1000010"  # checksum
     test_2d_ohm_solver_checkpoint_picmi  # dependency
 )

--- a/Examples/Tests/pml/CMakeLists.txt
+++ b/Examples/Tests/pml/CMakeLists.txt
@@ -41,7 +41,7 @@ if(WarpX_FFT)
         2  # dims
         2  # nprocs
         inputs_test_2d_pml_x_psatd_restart  # inputs
-        "analysis_default_restart.py diags/diag1000300"  # analysis
+        "analysis_default_restart.py --path diags/diag1000300"  # analysis
         "analysis_default_regression.py --path diags/diag1000300"  # checksum
         test_2d_pml_x_psatd  # dependency
     )
@@ -62,7 +62,7 @@ add_warpx_test(
     2  # dims
     2  # nprocs
     inputs_test_2d_pml_x_yee_restart  # inputs
-    "analysis_default_restart.py diags/diag1000300"  # analysis
+    "analysis_default_restart.py --path diags/diag1000300"  # analysis
     "analysis_default_regression.py --path diags/diag1000300"  # checksum
     test_2d_pml_x_yee  # dependency
 )

--- a/Examples/Tests/restart/CMakeLists.txt
+++ b/Examples/Tests/restart/CMakeLists.txt
@@ -26,7 +26,7 @@ add_warpx_test(
     2  # dims
     1  # nprocs
     "inputs_test_2d_runtime_components_picmi.py amr.restart='../test_2d_runtime_components_picmi/diags/chk000005'"  # inputs
-    "analysis_default_restart.py diags/diag1000010"  # analysis
+    "analysis_default_restart.py --path diags/diag1000010"  # analysis
     "analysis_default_regression.py --path diags/diag1000010"  # checksum
     test_2d_runtime_components_picmi  # dependency
 )
@@ -46,7 +46,7 @@ add_warpx_test(
     3  # dims
     2  # nprocs
     inputs_test_3d_acceleration_restart  # inputs
-    "analysis_default_restart.py diags/diag1000010"  # analysis
+    "analysis_default_restart.py --path diags/diag1000010"  # analysis
     "analysis_default_regression.py --path diags/diag1000010"  # checksum
     test_3d_acceleration  # dependency
 )
@@ -69,7 +69,7 @@ if(WarpX_FFT)
         3  # dims
         2  # nprocs
         inputs_test_3d_acceleration_psatd_restart  # inputs
-        "analysis_default_restart.py diags/diag1000010"  # analysis
+        "analysis_default_restart.py --path diags/diag1000010"  # analysis
         "analysis_default_regression.py --path diags/diag1000010"  # checksum
         test_3d_acceleration_psatd  # dependency
     )
@@ -93,7 +93,7 @@ if(WarpX_FFT)
         3  # dims
         2  # nprocs
         inputs_test_3d_acceleration_psatd_time_avg_restart  # inputs
-        "analysis_default_restart.py diags/diag1000010"  # analysis
+        "analysis_default_restart.py --path diags/diag1000010"  # analysis
         "analysis_default_regression.py --path diags/diag1000010"  # checksum
         test_3d_acceleration_psatd_time_avg  # dependency
     )

--- a/Examples/Tests/restart_eb/CMakeLists.txt
+++ b/Examples/Tests/restart_eb/CMakeLists.txt
@@ -19,7 +19,7 @@ if(WarpX_EB)
         3  # dims
         1  # nprocs
         "inputs_test_3d_eb_picmi.py amr.restart='../test_3d_eb_picmi/diags/chk000030'"  # inputs
-        "analysis_default_restart.py diags/diag1000060"  # analysis
+        "analysis_default_restart.py --path diags/diag1000060"  # analysis
         "analysis_default_regression.py --path diags/diag1000060"  # checksum
         test_3d_eb_picmi  # dependency
     )

--- a/Examples/analysis_default_regression.py
+++ b/Examples/analysis_default_regression.py
@@ -38,6 +38,7 @@ if __name__ == "__main__":
         "--path",
         help="path to output file(s)",
         type=str,
+        required=True,
     )
 
     # add arguments: relative tolerance

--- a/Examples/analysis_default_regression.py
+++ b/Examples/analysis_default_regression.py
@@ -36,7 +36,7 @@ if __name__ == "__main__":
     # add arguments: output path
     parser.add_argument(
         "--path",
-        help="path to output file(s)",
+        help="path to output file",
         type=str,
         required=True,
     )

--- a/Examples/analysis_default_restart.py
+++ b/Examples/analysis_default_restart.py
@@ -54,8 +54,8 @@ def check_restart(filename, tolerance=1e-12):
     print(f"\ntolerance = {tolerance}")
     print()
     for field in ds_benchmark.field_list:
-        dr = ad_restart[field].squeeze().v
-        db = ad_benchmark[field].squeeze().v
+        dr = ad_restart["boxlib", field].squeeze().v
+        db = ad_benchmark["boxlib", field].squeeze().v
         error = np.amax(np.abs(dr - db))
         if np.amax(np.abs(db)) != 0.0:
             error /= np.amax(np.abs(db))
@@ -70,7 +70,7 @@ if __name__ == "__main__":
 
     # add arguments: output file path
     parser.add_argument(
-        "output_file",
+        "--path",
         help="path to output file(s)",
         type=str,
     )
@@ -89,4 +89,4 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # compare restart results against original results
-    check_restart(filename=args.output_file, tolerance=args.rtol)
+    check_restart(filename=args.path, tolerance=args.rtol)

--- a/Examples/analysis_default_restart.py
+++ b/Examples/analysis_default_restart.py
@@ -54,8 +54,8 @@ def check_restart(filename, tolerance=1e-12):
     print(f"\ntolerance = {tolerance}")
     print()
     for field in ds_benchmark.field_list:
-        dr = ad_restart["boxlib", field].squeeze().v
-        db = ad_benchmark["boxlib", field].squeeze().v
+        dr = ad_restart[field].squeeze().v
+        db = ad_benchmark[field].squeeze().v
         error = np.amax(np.abs(dr - db))
         if np.amax(np.abs(db)) != 0.0:
             error /= np.amax(np.abs(db))

--- a/Examples/analysis_default_restart.py
+++ b/Examples/analysis_default_restart.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
+import argparse
 import os
-import sys
 
 import numpy as np
 import yt
@@ -64,6 +64,29 @@ def check_restart(filename, tolerance=1e-12):
     print()
 
 
-# compare restart results against original results
-output_file = sys.argv[1]
-check_restart(output_file)
+if __name__ == "__main__":
+    # define parser
+    parser = argparse.ArgumentParser()
+
+    # add arguments: output file path
+    parser.add_argument(
+        "output_file",
+        help="path to output file(s)",
+        type=str,
+    )
+
+    # add arguments: relative tolerance
+    default_tolerance = 1e-12
+    parser.add_argument(
+        "--rtol",
+        help="relative tolerance between restart ad original",
+        type=float,
+        required=False,
+        default=default_tolerance,
+    )
+
+    # parse arguments
+    args = parser.parse_args()
+
+    # compare restart results against original results
+    check_restart(filename=args.output_file, tolerance=args.rtol)

--- a/Examples/analysis_default_restart.py
+++ b/Examples/analysis_default_restart.py
@@ -71,15 +71,16 @@ if __name__ == "__main__":
     # add arguments: output file path
     parser.add_argument(
         "--path",
-        help="path to output file(s)",
+        help="path to output file",
         type=str,
+        required=True,
     )
 
     # add arguments: relative tolerance
     default_tolerance = 1e-12
     parser.add_argument(
         "--rtol",
-        help="relative tolerance between restart ad original",
+        help="relative tolerance between restart and original",
         type=float,
         required=False,
         default=default_tolerance,


### PR DESCRIPTION
Does some clean up of analysis_default_restart.py. Added `rtol` input option. This option is needed in PR #6954.