### PR TITLE
Curl-curl PC: enforce a fixed number of MLMG V-cycles

### DIFF
--- a/Source/NonlinearSolvers/CurlCurlMLMGPC.H
+++ b/Source/NonlinearSolvers/CurlCurlMLMGPC.H
@@ -117,7 +117,7 @@ class CurlCurlMLMGPC : public Preconditioner<T,Ops>
         bool m_use_gmres = false;
         bool m_use_gmres_pc = true;
 
-        int m_max_iter = 10;
+        int m_max_iter = 1;
         int m_max_coarsening_level = 30;
 
         bool m_beta_scalar = true;

--- a/Source/NonlinearSolvers/CurlCurlMLMGPC.H
+++ b/Source/NonlinearSolvers/CurlCurlMLMGPC.H
@@ -246,7 +246,6 @@ void CurlCurlMLMGPC<T,Ops>::Define ( const T& a_U,
 
     // Construct the MLMG solver
     m_solver = std::make_unique<MLMGT<MFArr>>(*m_curl_curl);
-    m_solver->setMaxIter(m_max_iter);
     m_solver->setFixedIter(m_max_iter);
     m_solver->setVerbose(static_cast<int>(m_verbose));
     m_solver->setBottomVerbose(static_cast<int>(m_bottom_verbose));
@@ -392,7 +391,9 @@ void CurlCurlMLMGPC<T,Ops>::Apply (T& a_x, const T& a_b)
         if (m_use_gmres) {
             m_gmres_solver->solve(solution, rhs, m_rtol, m_atol);
         } else {
-            m_solver->solve({&solution}, {&rhs}, m_rtol, m_atol);
+            // Zero tolerances: MLMG performs exactly m_max_iter V-cycles for any right-hand
+            // side, so that the preconditioner is a fixed linear operator, as required by GMRES.
+            m_solver->solve({&solution}, {&rhs}, RT(0.0), RT(0.0));
         }
     }
 }

--- a/Source/NonlinearSolvers/CurlCurlMLMGPC.H
+++ b/Source/NonlinearSolvers/CurlCurlMLMGPC.H
@@ -122,8 +122,10 @@ class CurlCurlMLMGPC : public Preconditioner<T,Ops>
 
         bool m_beta_scalar = true;
 
-        RT m_atol = 1.0e-16;
-        RT m_rtol = 1.0e-4;
+        // Zero by default, so that the solve performs a fixed number of iterations,
+        // and the preconditioner is thus a fixed linear operator, as required by GMRES.
+        RT m_atol = 0.0;
+        RT m_rtol = 0.0;
 
         Ops* m_ops = nullptr;
 
@@ -391,9 +393,10 @@ void CurlCurlMLMGPC<T,Ops>::Apply (T& a_x, const T& a_b)
         if (m_use_gmres) {
             m_gmres_solver->solve(solution, rhs, m_rtol, m_atol);
         } else {
-            // Zero tolerances: MLMG performs exactly m_max_iter V-cycles for any right-hand
-            // side, so that the preconditioner is a fixed linear operator, as required by GMRES.
-            m_solver->solve({&solution}, {&rhs}, RT(0.0), RT(0.0));
+            // m_rtol and m_atol are zero by default: this ensures that MLMG performs a fixed
+            // number of iterations (m_max_iter V-cycles), for any right-hand side, so that the
+            // preconditioner is a fixed linear operator, as required by GMRES.
+            m_solver->solve({&solution}, {&rhs}, m_rtol, m_atol);
         }
     }
 }


### PR DESCRIPTION
MLMG exits its iteration loop early once the residual drops below the requested tolerance, even when `setFixedIter()` is set. This can in theory make the preconditioner a different linear map depending on the right-hand side, which breaks the outer GMRES solver (it requires a fixed linear operator for the preconditioner). Pass zero tolerances instead, so that exactly `max_iter` V-cycles are always performed.

Also remove the redundant `setMaxIter()` call, which is superseded by `setFixedIter()`.