### PR TITLE
Fix non-docs CI filter for root markdown/rst files

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -11,6 +11,8 @@ trigger:
     exclude:
     - 'Docs/**'
     - 'Tools/machines/**'
+    - '*.rst'
+    - '*.md'
     - '**/*.rst'
     - '**/*.md'
 pr:
@@ -20,6 +22,8 @@ pr:
     exclude:
     - 'Docs/**'
     - 'Tools/machines/**'
+    - '*.rst'
+    - '*.md'
     - '**/*.rst'
     - '**/*.md'
 


### PR DESCRIPTION
## Summary

#7200 and #7203 showed that the current non-docs filter in the Azure pipeline file does not match correctly markdown/rst files in the root directory, presumably because of the hard-coded `/` separator. 

This is similar to #7159, but takes care of a different corner case.