### PR TITLE
Dependencies: AMReX CUDA CMake 3.25+

### DIFF
--- a/.github/ISSUE_TEMPLATE/installation-issue.md
+++ b/.github/ISSUE_TEMPLATE/installation-issue.md
@@ -36,7 +36,7 @@ If you encountered the issue installing from source with CMake, please provide t
 2. project build: output of `cmake --build build` (include your specific build options, e.g., `-j 4`)
 
 If applicable, please add any additional information about your software environment:
-- [ ] CMake: e.g., 3.24.0
+- [ ] CMake: e.g., 3.25.0
 - [ ] C++ compiler: e.g., GNU 11.3 with NVCC 12.0.76
 - [ ] Python: e.g., CPython 3.12
 - [ ] MPI: e.g., OpenMPI 4.1.1

--- a/.github/workflows/cuda.yml
+++ b/.github/workflows/cuda.yml
@@ -88,7 +88,7 @@ jobs:
           -DWarpX_COMPUTE=CUDA         \
           -DWarpX_EB=ON                \
           -DWarpX_PYTHON=ON            \
-          -DAMReX_CUDA_ARCH=6.0        \
+          -DCMAKE_CUDA_ARCHITECTURES=60 \
           -DWarpX_OPENPMD=ON           \
           -DWarpX_openpmd_internal=OFF \
           -DWarpX_PRECISION=SINGLE     \
@@ -213,7 +213,7 @@ jobs:
           -DWarpX_COMPUTE=CUDA         \
           -DWarpX_EB=ON                \
           -DWarpX_PYTHON=OFF           \
-          -DAMReX_CUDA_ARCH=8.0        \
+          -DCMAKE_CUDA_ARCHITECTURES=80 \
           -DWarpX_OPENPMD=ON           \
           -DWarpX_FFT=ON               \
           -DAMReX_CUDA_ERROR_CROSS_EXECUTION_SPACE_CALL=ON \

--- a/.gitlab/ci.yaml
+++ b/.gitlab/ci.yaml
@@ -33,7 +33,7 @@ NVIDIA-H100:
           -DWarpX_COMPUTE=CUDA                             \
           -DWarpX_EB=ON                                    \
           -DWarpX_PYTHON=OFF                               \
-          -DAMReX_CUDA_ARCH=9.0                            \
+          -DCMAKE_CUDA_ARCHITECTURES=90                    \
           -DWarpX_OPENPMD=ON                               \
           -DWarpX_PRECISION=SINGLE                         \
           -DWarpX_FFT=ON                                   \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ string(JSON warpx_version GET "${dependencies_data}" version_warpx)
 
 # Preamble ####################################################################
 #
-cmake_minimum_required(VERSION 3.24.0)
+cmake_minimum_required(VERSION 3.25.0)
 project(WarpX VERSION ${warpx_version})
 
 include(${WarpX_SOURCE_DIR}/cmake/WarpXFunctions.cmake)
@@ -15,22 +15,6 @@ if(CMAKE_BINARY_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     message(FATAL_ERROR "Building in-source is not supported! "
             "Create a build directory and remove "
             "${CMAKE_SOURCE_DIR}/CMakeCache.txt ${CMAKE_SOURCE_DIR}/CMakeFiles/")
-endif()
-
-
-# CMake policies ##############################################################
-#
-# Setting a cmake_policy to OLD is deprecated by definition and will raise a
-# verbose warning
-if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
-    set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "" FORCE)
-endif()
-
-# AMReX 21.06+ supports CUDA_ARCHITECTURES with CMake 3.20+
-# CMake 3.18+: CMAKE_CUDA_ARCHITECTURES
-# https://cmake.org/cmake/help/latest/policy/CMP0104.html
-if(POLICY CMP0104)
-    cmake_policy(SET CMP0104 OLD)
 endif()
 
 

--- a/Docs/source/developers/gnumake.rst
+++ b/Docs/source/developers/gnumake.rst
@@ -64,6 +64,8 @@ options are:
     * ``USE_MPI=TRUE`` or ``FALSE``: Whether to compile with MPI support.
     * ``USE_OMP=TRUE`` or ``FALSE``: Whether to compile with OpenMP support.
     * ``USE_GPU=TRUE`` or ``FALSE``: Whether to compile for Nvidia GPUs (requires CUDA).
+      Set the target architecture with the ``AMREX_CUDA_ARCH`` environment variable, e.g. ``export AMREX_CUDA_ARCH=8.0`` for A100 (it defaults to ``7.0``).
+      This is the GNU Make spelling only: the CMake build uses ``CUDAARCHS``/``CMAKE_CUDA_ARCHITECTURES`` instead, and our HPC profiles set that one.
     * ``USE_OPENPMD=TRUE`` or ``FALSE``: Whether to support openPMD for I/O (requires openPMD-api).
     * ``MPI_THREAD_MULTIPLE=TRUE`` or ``FALSE``: Whether to initialize MPI with thread multiple support. Required to use asynchronous IO with more than :pp:param:`amrex.async_out_nfiles` (by default, 64) MPI tasks.
       Please see :ref:`data formats <dataanalysis-formats>` for more information.

--- a/Docs/source/install/cmake.rst
+++ b/Docs/source/install/cmake.rst
@@ -419,9 +419,9 @@ Select GPU Architectures
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 For Nvidia GPUs, WarpX uses the standard CMake interface to select the CUDA architectures to compile for.
-By default, AMReX selects ``native``, i.e., CMake detects the architecture of the GPU(s) visible on the machine that runs ``cmake`` and WarpX is built exactly for those.
+By default, we select ``native``, i.e., CMake detects the architecture of the GPU(s) visible on the machine that runs ``cmake`` and WarpX is built exactly for those.
 
-If no GPU is visible at configuration time - a typical situation on HPC login nodes, in containers and in CI - configuration stops with an error and you need to select the architecture explicitly, either as a CMake option:
+If no GPU is visible at configuration time (a typical situation on HPC login nodes, in containers and in CI) then configuration stops with an error and you need to select the architecture explicitly, either as a CMake option:
 
 .. code-block:: bash
 

--- a/Docs/source/install/cmake.rst
+++ b/Docs/source/install/cmake.rst
@@ -312,6 +312,8 @@ For example, this builds WarpX in all geometries, enables Python bindings and Nv
 
    cmake -S . -B build -DWarpX_DIMS="1;2;3;RZ;RCYLINDER;RSPHERE" -DWarpX_COMPUTE=CUDA
 
+On a machine without a visible GPU, e.g. an HPC login node, additionally select the GPU architecture to compile for (see :ref:`building-cmake-gpu-archs`).
+
 
 An executable WarpX binary with the current compile-time options encoded in its file name will be created in ``build/bin/``.
 Note that you need separate binaries to run 1D, 2D, 3D, RZ, RCYLINDER, RSPHERE geometry inputs scripts.
@@ -411,6 +413,37 @@ We also support adding `additional compiler flags via environment variables <htt
    Now call ``cmake -S . -B build`` (+ further options) again to re-initialize the build configuration.
 
 
+.. _building-cmake-gpu-archs:
+
+Select GPU Architectures
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+For Nvidia GPUs, WarpX uses the standard CMake interface to select the CUDA architectures to compile for.
+By default, AMReX selects ``native``, i.e., CMake detects the architecture of the GPU(s) visible on the machine that runs ``cmake`` and WarpX is built exactly for those.
+
+If no GPU is visible at configuration time - a typical situation on HPC login nodes, in containers and in CI - configuration stops with an error and you need to select the architecture explicitly, either as a CMake option:
+
+.. code-block:: bash
+
+   cmake -S . -B build -DWarpX_COMPUTE=CUDA -DCMAKE_CUDA_ARCHITECTURES=80
+
+or as an `environment variable <https://cmake.org/cmake/help/latest/envvar/CUDAARCHS.html>`__, which is what our :ref:`HPC profiles <install-hpc>` do:
+
+.. code-block:: bash
+
+   export CUDAARCHS=80
+
+Architectures are written as integers, e.g., ``80`` for A100 (compute capability 8.0) and ``90`` for H100.
+`Multiple architectures <https://cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html>`__ are separated by semicolons (``"80;90"``), and the special values ``native``, ``all`` and ``all-major`` are supported as well.
+
+.. note::
+
+   The older AMReX-specific spellings ``-DAMReX_CUDA_ARCH=8.0`` and ``export AMREX_CUDA_ARCH=8.0`` still work, but are deprecated and warn.
+   They are translated to the CMake variables above, including their historical value formats (``Auto``, ``Common``, ``Volta``, ``8.0``, ``7.0+PTX``, whitespace-separated lists).
+
+For AMD GPUs, select the architecture with ``-DAMReX_AMD_ARCH=gfx90a`` or ``export AMREX_AMD_ARCH=gfx90a``.
+
+
 CMake
 ^^^^^
 
@@ -418,6 +451,7 @@ CMake
 CMake Option                  Default & Values                             Description
 ============================= ============================================ ===========================================================
 ``CMAKE_BUILD_TYPE``          RelWithDebInfo/**Release**/Debug             `Type of build, symbols & optimizations <https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html>`__
+``CMAKE_CUDA_ARCHITECTURES``  **native**/all/all-major/``80``/...          `Nvidia GPU architectures to compile for <https://cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html>`__ (``WarpX_COMPUTE=CUDA``)
 ``CMAKE_INSTALL_PREFIX``      system-dependent path                        `Install path prefix <https://cmake.org/cmake/help/latest/variable/CMAKE_INSTALL_PREFIX.html>`__
 ``CMAKE_VERBOSE_MAKEFILE``    ON/**OFF**                                   `Print all compiler commands to the terminal during build <https://cmake.org/cmake/help/latest/variable/CMAKE_VERBOSE_MAKEFILE.html>`__
 ``WarpX_APP``                 **ON**/OFF                                   Build the WarpX executable application
@@ -427,7 +461,7 @@ CMake Option                  Default & Values                             Descr
 ``WarpX_DIMS``                **3**/2/1/RZ/RCYLINDER/RSPHERE               Simulation dimensionality. Use ``"1;2;3;RZ;RCYLINDER;RSPHERE"`` for all.
 ``WarpX_EB``                  **ON**/OFF                                   Embedded boundary support (not supported in RZ, RCYLINDER, and RSPHERE  yet)
 ``WarpX_PETSC``               ON/**OFF**                                   PETSc linear/nonlinear solvers via AMReX
-``WarpX_IPO``                 ON/**OFF**                                   Compile WarpX with interprocedural optimization (aka LTO)
+``WarpX_IPO``                 ON/**OFF**                                   Compile WarpX with interprocedural optimization (aka LTO); with ``WarpX_COMPUTE=CUDA`` this enables CUDA device LTO, which implies relocatable device code and needs explicit ``CMAKE_CUDA_ARCHITECTURES``
 ``WarpX_LIB``                 ON/**OFF**                                   Build WarpX as a library, e.g., for PICMI Python
 ``WarpX_MPI``                 **ON**/OFF                                   Multi-node support (message-passing)
 ``WarpX_MPI_THREAD_MULTIPLE`` **ON**/OFF                                   MPI thread-multiple support, i.e. for ``async_io``
@@ -515,6 +549,7 @@ Environment variables can be used to control the build step:
 Environment Variable          Default & Values                             Description
 ============================= ============================================ ================================================================
 ``WARPX_COMPUTE``             NOACC/**OMP**/CUDA/SYCL/HIP                  On-node, accelerated computing backend
+``CUDAARCHS``                 **native**/all/all-major/``80``/...          Nvidia GPU architectures to compile for (see :ref:`building-cmake-gpu-archs`)
 ``WARPX_DIMS``                ``"1;2;3;RZ;RCYLINDER;RSPHERE"``             Simulation dimensionalities (semicolon-separated list)
 ``WARPX_EB``                  **ON**/OFF                                   Embedded boundary support (not supported in RZ, RCYLINDER, and RSPHERE yet)
 ``WARPX_PETSC``               ON/**OFF**                                   PETSc linear/nonlinear solvers via AMReX

--- a/Docs/source/install/cmake.rst
+++ b/Docs/source/install/cmake.rst
@@ -461,7 +461,7 @@ CMake Option                  Default & Values                             Descr
 ``WarpX_DIMS``                **3**/2/1/RZ/RCYLINDER/RSPHERE               Simulation dimensionality. Use ``"1;2;3;RZ;RCYLINDER;RSPHERE"`` for all.
 ``WarpX_EB``                  **ON**/OFF                                   Embedded boundary support (not supported in RZ, RCYLINDER, and RSPHERE  yet)
 ``WarpX_PETSC``               ON/**OFF**                                   PETSc linear/nonlinear solvers via AMReX
-``WarpX_IPO``                 ON/**OFF**                                   Compile WarpX with interprocedural optimization (aka LTO); with ``WarpX_COMPUTE=CUDA`` this enables CUDA device LTO, which implies relocatable device code and needs explicit ``CMAKE_CUDA_ARCHITECTURES``
+``WarpX_IPO``                 ON/**OFF**                                   Compile WarpX with interprocedural optimization (aka LTO)
 ``WarpX_LIB``                 ON/**OFF**                                   Build WarpX as a library, e.g., for PICMI Python
 ``WarpX_MPI``                 **ON**/OFF                                   Multi-node support (message-passing)
 ``WarpX_MPI_THREAD_MULTIPLE`` **ON**/OFF                                   MPI thread-multiple support, i.e. for ``async_io``

--- a/Docs/source/install/dependencies.rst
+++ b/Docs/source/install/dependencies.rst
@@ -7,7 +7,7 @@ WarpX depends on the following popular third party software.
 Please see installation instructions below.
 
 - a mature `C++20 <https://en.wikipedia.org/wiki/C%2B%2B20>`__ compiler, e.g., GCC 12+, Clang 14, NVCC 12.4, MSVC 19.44 or newer
-- `CMake 3.24.0+ <https://cmake.org>`__
+- `CMake 3.25.0+ <https://cmake.org>`__
 - `Git 2.18+ <https://git-scm.com>`__
 - `AMReX <https://amrex-codes.github.io>`__: we automatically download and compile a copy of AMReX
 - `PICSAR <https://github.com/ECP-WarpX/picsar>`__: we automatically download and compile a copy of PICSAR

--- a/Tools/machines/greatlakes-umich/greatlakes_v100_warpx.profile.example
+++ b/Tools/machines/greatlakes-umich/greatlakes_v100_warpx.profile.example
@@ -48,7 +48,7 @@ alias getNode="salloc -N 1 --partition=gpu --ntasks-per-node=2 --cpus-per-task=2
 alias runNode="srun -N 1 --partition=gpu --ntasks-per-node=2 --cpus-per-task=20 --gpus-per-task=v100:1 -t 1:00:00 -A $proj"
 
 # optimize CUDA compilation for V100
-export AMREX_CUDA_ARCH=7.0
+export CUDAARCHS=70
 
 # optimize CPU microarchitecture for Intel Xeon Gold 6148
 export CXXFLAGS="-march=skylake-avx512"

--- a/Tools/machines/hpc3-uci/hpc3_gpu_warpx.profile.example
+++ b/Tools/machines/hpc3-uci/hpc3_gpu_warpx.profile.example
@@ -49,7 +49,7 @@ alias getNode="salloc -N 1 -t 0:30:00 --gres=gpu:V100:1 -p free-gpu"
 alias runNode="srun -N 1 -t 0:30:00 --gres=gpu:V100:1 -p free-gpu"
 
 # optimize CUDA compilation for V100
-export AMREX_CUDA_ARCH=7.0
+export CUDAARCHS=70
 
 # compiler environment hints
 export CXX=$(which g++)

--- a/Tools/machines/juwels-jsc/juwels_warpx.profile.example
+++ b/Tools/machines/juwels-jsc/juwels_warpx.profile.example
@@ -18,5 +18,5 @@ module load Python
 export GPUS_PER_SOCKET=2
 export GPUS_PER_NODE=4
 
-# optimize CUDA compilation for V100 (7.0) or for A100 (8.0)
-export AMREX_CUDA_ARCH=8.0
+# optimize CUDA compilation for V100 (70) or for A100 (80)
+export CUDAARCHS=80

--- a/Tools/machines/karolina-it4i/karolina_warpx.profile.example
+++ b/Tools/machines/karolina-it4i/karolina_warpx.profile.example
@@ -50,7 +50,7 @@ function getNode() {
 
 # Environment #####################################################
 # optimize CUDA compilation for A100
-export AMREX_CUDA_ARCH="8.0"
+export CUDAARCHS="80"
 export SCRATCH="/scratch/project/${proj,,}/${USER}"
 
 # optimize CPU microarchitecture for AMD EPYC 7763 (zen3)

--- a/Tools/machines/lawrencium-lbnl/lawrencium_warpx.profile.example
+++ b/Tools/machines/lawrencium-lbnl/lawrencium_warpx.profile.example
@@ -39,11 +39,11 @@ alias getNode="salloc -N 1 -t 1:00:00 --qos=es_debug --partition=es1 --constrain
 alias runNode="srun -N 1 -t 1:00:00 --qos=es_debug --partition=es1 --constraint=es1_v100 --gres=gpu:1 --cpus-per-task=4 -A $proj"
 
 # optimize CUDA compilation for 1080 Ti (deprecated)
-#export AMREX_CUDA_ARCH=6.1
+#export CUDAARCHS=61
 # optimize CUDA compilation for V100
-export AMREX_CUDA_ARCH=7.0
+export CUDAARCHS=70
 # optimize CUDA compilation for 2080 Ti
-#export AMREX_CUDA_ARCH=7.5
+#export CUDAARCHS=75
 
 # compiler environment hints
 export CXX=$(which g++)

--- a/Tools/machines/leonardo-cineca/leonardo_gpu_warpx.profile.example
+++ b/Tools/machines/leonardo-cineca/leonardo_gpu_warpx.profile.example
@@ -35,7 +35,7 @@ then
 fi
 
 # optimize CUDA compilation for A100
-export AMREX_CUDA_ARCH=8.0
+export CUDAARCHS=80
 
 # compiler environment hints
 export CXX=$(which g++)

--- a/Tools/machines/lonestar6-tacc/lonestar6_warpx_a100.profile.example
+++ b/Tools/machines/lonestar6-tacc/lonestar6_warpx_a100.profile.example
@@ -47,7 +47,7 @@ alias getNode="salloc -N 1 --ntasks-per-node=2 -t 1:00:00 -p gpu-100 --gpu-bind=
 alias runNode="srun -N 1 --ntasks-per-node=2 -t 0:30:00 -p gpu-100 --gpu-bind=single:1 -c 32 -G 2 -A $proj"
 
 # optimize CUDA compilation for A100
-export AMREX_CUDA_ARCH=8.0
+export CUDAARCHS=80
 
 # compiler environment hints
 export CC=$(which gcc)

--- a/Tools/machines/lxplus-cern/lxplus_warpx.profile.example
+++ b/Tools/machines/lxplus-cern/lxplus_warpx.profile.example
@@ -13,7 +13,7 @@ source /cvmfs/sft.cern.ch/lcg/views/LCG_108_cuda/x86_64-el9-gcc13-opt/setup.sh
 # source environment that ensures that the parallel HDF5 is picked before the serial one
 source /cvmfs/sft.cern.ch/lcg/releases/LCG_108_cuda/hdf5_mpi/1.14.6/x86_64-el9-gcc13-opt/hdf5_mpi-env.sh
 
-export AMREX_CUDA_ARCH="7.0;7.5"
+export CUDAARCHS="70;75"
 
 # compiler environment hints
 export CC=$(which gcc)

--- a/Tools/machines/ookami-sbu/ookami_warpx.profile.example
+++ b/Tools/machines/ookami-sbu/ookami_warpx.profile.example
@@ -2,7 +2,7 @@
 #export proj=<yourProject>
 
 # required dependencies
-module load cmake/3.19.0  # please check for a 3.24+ module and report back
+module load cmake/3.19.0  # too old: please check for a 3.25+ module and report back, or `python3 -m pip install -U cmake`
 module load gcc/10.3.0
 module load openmpi/gcc10/4.1.0
 

--- a/Tools/machines/perlmutter-nersc/container/gpu/mpi/Containerfile
+++ b/Tools/machines/perlmutter-nersc/container/gpu/mpi/Containerfile
@@ -34,8 +34,7 @@ ENV NJOBS=$NJOBS
 
 # Perlmutter GPU: A100
 # Perlmutter CPU: Zen v3
-ENV AMREX_CUDA_ARCH=8.0        \
-    CUDAARCHS=80               \
+ENV CUDAARCHS=80               \
     CXXFLAGS="-march=znver3"   \
     CFLAGS="-march=znver3"
 

--- a/Tools/machines/perlmutter-nersc/container/gpu/nompi/Containerfile
+++ b/Tools/machines/perlmutter-nersc/container/gpu/nompi/Containerfile
@@ -34,8 +34,7 @@ ENV NJOBS=$NJOBS
 
 # Perlmutter GPU: A100
 # Perlmutter CPU: Zen v3
-ENV AMREX_CUDA_ARCH=8.0        \
-    CUDAARCHS=80               \
+ENV CUDAARCHS=80               \
     CXXFLAGS="-march=znver3"   \
     CFLAGS="-march=znver3"
 

--- a/Tools/machines/perlmutter-nersc/perlmutter_gpu_warpx.profile.example
+++ b/Tools/machines/perlmutter-nersc/perlmutter_gpu_warpx.profile.example
@@ -58,7 +58,7 @@ alias runNode="srun -N 1 --ntasks-per-node=4 -t 0:30:00 -q interactive -C gpu --
 export CRAY_ACCEL_TARGET=nvidia80
 
 # optimize CUDA compilation for A100
-export AMREX_CUDA_ARCH=8.0
+export CUDAARCHS=80
 
 # optimize CPU microarchitecture for AMD EPYC 3rd Gen (Milan/Zen3)
 # note: the cc/CC/ftn wrappers below add those

--- a/Tools/machines/pitzer-osc/pitzer_v100_warpx.profile.example
+++ b/Tools/machines/pitzer-osc/pitzer_v100_warpx.profile.example
@@ -54,7 +54,7 @@ export PATH=${SW_DIR}/adios2-2.10.2/bin:${PATH}
 
 # avoid relocation truncation error which result from large executable size
 export CUDAFLAGS="--host-linker-script=use-lcs" # https://github.com/BLAST-WarpX/warpx/pull/3673
-export AMREX_CUDA_ARCH=7.0 # 7.0: V100, 8.0: V100, 9.0: H100 https://github.com/BLAST-WarpX/warpx/issues/3214
+export CUDAARCHS=70 # 70: V100, 80: A100, 90: H100 https://github.com/BLAST-WarpX/warpx/issues/3214
 
 # compiler environment hints
 export CC=$(which gcc)

--- a/Tools/machines/polaris-alcf/polaris_gpu_warpx.profile.example
+++ b/Tools/machines/polaris-alcf/polaris_gpu_warpx.profile.example
@@ -49,7 +49,7 @@ fi
 export CRAY_ACCEL_TARGET=nvidia80
 
 # optimize CUDA compilation for A100
-export AMREX_CUDA_ARCH=8.0
+export CUDAARCHS=80
 
 # optimize CPU microarchitecture for AMD EPYC 3rd Gen (Milan/Zen3)
 # note: the cc/CC/ftn wrappers below add those

--- a/Tools/machines/taurus-zih/taurus_warpx.profile.example
+++ b/Tools/machines/taurus-zih/taurus_warpx.profile.example
@@ -29,7 +29,7 @@ alias getNode="salloc --time=2:00:00 -N1 -n1 --cpus-per-task=6 --mem-per-cpu=204
 alias runNode="srun --time=2:00:00 -N1 -n1 --cpus-per-task=6 --mem-per-cpu=2048 --gres=gpu:1 --gpu-bind=single:1 -p alpha-interactive --pty bash"
 
 # optimize CUDA compilation for A100
-export AMREX_CUDA_ARCH=8.0
+export CUDAARCHS=80
 
 # compiler environment hints
 #export CC=$(which gcc)

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -149,9 +149,7 @@ macro(find_amrex)
         endif()
 
         # IPO/LTO
-        if(WarpX_IPO)
-            set(AMReX_IPO ON CACHE INTERNAL "")
-        endif()
+        set(AMReX_IPO "${WarpX_IPO}" CACHE INTERNAL "")
         if(WarpX_COMPUTE STREQUAL CUDA)
             if(WarpX_IPO)
                 set(AMReX_CUDA_LTO ON CACHE BOOL "" FORCE)

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -123,13 +123,15 @@ macro(find_amrex)
         # CUDA device LTO (AMReX_CUDA_LTO, set for WarpX_IPO below) only works
         # with relocatable device code: without RDC every translation unit is
         # already device linked on its own and AMReX errors out.
+        # FORCE: we derive these from WarpX options, so they must follow them
+        # when an existing build directory is re-configured.
         if(WarpX_ASCENT OR WarpX_SENSEI OR
            (WarpX_IPO AND WarpX_COMPUTE STREQUAL CUDA))
-            set(AMReX_GPU_RDC ON CACHE BOOL "")
+            set(AMReX_GPU_RDC ON CACHE BOOL "" FORCE)
         else()
             # we don't need RDC and disabling it simplifies the build
             # complexity and potentially improves code optimization
-            set(AMReX_GPU_RDC OFF CACHE BOOL "")
+            set(AMReX_GPU_RDC OFF CACHE BOOL "" FORCE)
         endif()
 
         # shared libs, i.e. for Python bindings, need relocatable code
@@ -151,8 +153,12 @@ macro(find_amrex)
         # IPO/LTO
         if(WarpX_IPO)
             set(AMReX_IPO ON CACHE INTERNAL "")
-            if(WarpX_COMPUTE STREQUAL CUDA)
-                set(AMReX_CUDA_LTO ON CACHE BOOL "")
+        endif()
+        if(WarpX_COMPUTE STREQUAL CUDA)
+            if(WarpX_IPO)
+                set(AMReX_CUDA_LTO ON CACHE BOOL "" FORCE)
+            else()
+                set(AMReX_CUDA_LTO OFF CACHE BOOL "" FORCE)
             endif()
         endif()
 

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -123,8 +123,6 @@ macro(find_amrex)
         # CUDA device LTO (AMReX_CUDA_LTO, set for WarpX_IPO below) only works
         # with relocatable device code: without RDC every translation unit is
         # already device linked on its own and AMReX errors out.
-        # FORCE: we derive these from WarpX options, so they must follow them
-        # when an existing build directory is re-configured.
         if(WarpX_ASCENT OR WarpX_SENSEI OR
            (WarpX_IPO AND WarpX_COMPUTE STREQUAL CUDA))
             set(AMReX_GPU_RDC ON CACHE BOOL "" FORCE)

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -120,7 +120,11 @@ macro(find_amrex)
         set(AMReX_LINEAR_SOLVERS_EM ON CACHE INTERNAL "")
         set(AMReX_LINEAR_SOLVERS_INCFLO ON CACHE INTERNAL "")
 
-        if(WarpX_ASCENT OR WarpX_SENSEI)
+        # CUDA device LTO (AMReX_CUDA_LTO, set for WarpX_IPO below) only works
+        # with relocatable device code: without RDC every translation unit is
+        # already device linked on its own and AMReX errors out.
+        if(WarpX_ASCENT OR WarpX_SENSEI OR
+           (WarpX_IPO AND WarpX_COMPUTE STREQUAL CUDA))
             set(AMReX_GPU_RDC ON CACHE BOOL "")
         else()
             # we don't need RDC and disabling it simplifies the build
@@ -170,13 +174,11 @@ macro(find_amrex)
             list(APPEND CMAKE_MODULE_PATH "${WarpX_amrex_src}/Tools/CMake")
             if(WarpX_COMPUTE STREQUAL CUDA)
                 enable_language(CUDA)
-                # AMReX 21.06+ supports CUDA_ARCHITECTURES
             endif()
             add_subdirectory(${WarpX_amrex_src} _deps/localamrex-build/)
         else()
             if(WarpX_COMPUTE STREQUAL CUDA)
                 enable_language(CUDA)
-                # AMReX 21.06+ supports CUDA_ARCHITECTURES
             endif()
             FetchContent_Declare(fetchedamrex
                 GIT_REPOSITORY ${WarpX_amrex_repo}

--- a/dependencies.json
+++ b/dependencies.json
@@ -5,7 +5,7 @@
     "version_picsar": "26.05",
     "version_pybind11_min": "v3.0.0",
     "version_picmi": "0.34.0",
-    "commit_amrex": "2cf4fbcde02a700e01c62bebb4a730aeeb66c661",
+    "commit_amrex": "19e6fba747b65a37d08f3fecef3ff2935318f26b",
     "commit_pyamrex": "dcf0d5c69a685af2096f684a512819b6c526f898",
     "commit_picsar": "26.05",
     "commit_pybind11": "v3.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    "cmake>=3.24.0",
+    "cmake>=3.25.0",
     "packaging>=23",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -69,14 +69,14 @@ class CMakeBuild(build_ext):
             out = subprocess.check_output(["cmake", "--version"])
         except OSError:
             raise RuntimeError(
-                "CMake 3.24.0+ must be installed to build the following "
+                "CMake 3.25.0+ must be installed to build the following "
                 + "extensions: "
                 + ", ".join(e.name for e in self.extensions)
             )
 
         cmake_version = parse(re.search(r"version\s*([\d.]+)", out.decode()).group(1))
-        if cmake_version < parse("3.24.0"):
-            raise RuntimeError("CMake >= 3.24.0 is required")
+        if cmake_version < parse("3.25.0"):
+            raise RuntimeError("CMake >= 3.25.0 is required")
 
         for ext in self.extensions:
             self.build_extension(ext)


### PR DESCRIPTION
## Summary

Weekly AMReX update, which pulls in [AMReX-Codes/amrex#4773](https://github.com/AMReX-Codes/amrex/pull/4773): CUDA architectures are now selected through the standard CMake interface and the CMake minimum rises to 3.25.
This moves our CI, HPC profiles and containers over to the new spelling and raises WarpX's own CMake minimum to match.

## Modernization to Standard Interfaces & Deprecations

The variables we usually set in our scripts and profiles still work, but are deprecated and warn on configure.

### Environment variables

| old (deprecated, warns)             | new                    |
|-------------------------------------|------------------------|
| `export AMREX_CUDA_ARCH=8.0`        | `export CUDAARCHS=80`  |
| `export AMREX_CUDA_ARCH="7.0;7.5"`  | `export CUDAARCHS="70;75"` |

### CMake options

| old (deprecated, warns)      | new                              |
|------------------------------|----------------------------------|
| `-DAMReX_CUDA_ARCH=8.0`      | `-DCMAKE_CUDA_ARCHITECTURES=80`  |
| `-DAMReX_CUDA_ARCH=Auto`     | `-DCMAKE_CUDA_ARCHITECTURES=native` (new default) |
| `-DAMReX_CUDA_ARCH=Common`   | `-DCMAKE_CUDA_ARCHITECTURES=all-major` |

Values are integers (`80`, not `8.0`); `native`, `all`, `all-major` and the `90a` forms are supported as well.

### User-facing
- CMake 3.25.0+ is now required (was 3.24.0).
- The default is `native`, resolved from the GPUs visible to `cmake`. Configuring where no GPU is visible (HPC login node, container, CI) now requires an explicit architecture — our profiles and CI set one.
- `Tools/machines/{ookami,crusher,fugaku,leonardo}` still load CMake modules older than 3.25 and need a site-specific replacement; not changed here.

### Internal
- Removed `cmake_policy(SET CMP0104 OLD)`, the pre-3.20 path AMReX dropped; keeping it would clear `CMAKE_CUDA_ARCHITECTURES`. The `CMAKE_WARN_DEPRECATED OFF` work-around it motivated is gone with it.
- `AMReX_CUDA_LTO` now performs real device LTO and requires RDC. Since `WarpX_IPO` forwards to it, `-DWarpX_COMPUTE=CUDA -DWarpX_IPO=ON` aborted; `AMReX_GPU_RDC` is now enabled for that combination.
- Migrated `.github/workflows/cuda.yml`, `.gitlab/ci.yaml`, all `Tools/machines/**` CUDA profiles and the Perlmutter Containerfiles.

## Testing

- 3D + Python CPU build against the new AMReX pin: configure and build clean, no new deprecation warnings.
- `-DWarpX_COMPUTE=CUDA -DWarpX_IPO=ON -DCMAKE_CUDA_ARCHITECTURES=80` configures (reports `CUDA architectures: 80`); the same configure with `-DAMReX_GPU_RDC=OFF` reproduces the `AMReX_CUDA_LTO requires relocatable device code` abort this PR fixes.
- `-DAMReX_CUDA_ARCH=8.0` still configures, warns as documented and resolves to `80`.
- Sphinx docs build with no warnings from the changed pages.
