### PR TITLE
CMake: keep derived AMReX options in sync on re-configure

### DIFF
--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -21,23 +21,23 @@ macro(find_amrex)
         set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
 
         # see https://amrex-codes.github.io/amrex/docs_html/BuildingAMReX.html#customization-options
-        if(WarpX_ASCENT)
-            set(AMReX_ASCENT ON CACHE INTERNAL "")
+        set(AMReX_ASCENT "${WarpX_ASCENT}" CACHE INTERNAL "")
+        set(AMReX_CATALYST "${WarpX_CATALYST}" CACHE INTERNAL "")
+        if(WarpX_ASCENT OR WarpX_CATALYST)
             set(AMReX_CONDUIT ON CACHE INTERNAL "")
-        endif()
-
-        if(WarpX_CATALYST)
-            set(AMReX_CATALYST ON CACHE INTERNAL "")
-            set(AMReX_CONDUIT ON CACHE INTERNAL "")
-        endif()
-
-        if("${CMAKE_BUILD_TYPE}" MATCHES "Debug")
-            set(AMReX_ASSERTIONS ON CACHE BOOL "")
-            # note: floating-point exceptions can slow down debug runs a lot
-            set(AMReX_FPE ON CACHE BOOL "")
         else()
-            set(AMReX_ASSERTIONS OFF CACHE BOOL "")
-            set(AMReX_FPE OFF CACHE BOOL "")
+            set(AMReX_CONDUIT OFF CACHE INTERNAL "")
+        endif()
+
+        # FORCE: we derive these from CMAKE_BUILD_TYPE, so they have to follow it
+        # when an existing build directory is re-configured to another build type
+        if("${CMAKE_BUILD_TYPE}" MATCHES "Debug")
+            set(AMReX_ASSERTIONS ON CACHE BOOL "" FORCE)
+            # note: floating-point exceptions can slow down debug runs a lot
+            set(AMReX_FPE ON CACHE BOOL "" FORCE)
+        else()
+            set(AMReX_ASSERTIONS OFF CACHE BOOL "" FORCE)
+            set(AMReX_FPE OFF CACHE BOOL "" FORCE)
         endif()
 
         if(WarpX_COMPUTE STREQUAL OMP)
@@ -105,9 +105,7 @@ macro(find_amrex)
             set(AMReX_PARTICLES_PRECISION "SINGLE" CACHE INTERNAL "")
         endif()
 
-        if(WarpX_SENSEI)
-            set(AMReX_SENSEI ON CACHE INTERNAL "")
-        endif()
+        set(AMReX_SENSEI "${WarpX_SENSEI}" CACHE INTERNAL "")
 
         set(AMReX_AMRLEVEL OFF CACHE INTERNAL "")
         set(AMReX_ENABLE_TESTS OFF CACHE INTERNAL "")
@@ -133,19 +131,25 @@ macro(find_amrex)
         endif()
 
         # shared libs, i.e. for Python bindings, need relocatable code
+        # (the second condition below is a subset of this one)
         if(WarpX_PYTHON OR
            ABLASTR_POSITION_INDEPENDENT_CODE OR
            (WarpX_LIB AND BUILD_SHARED_LIBS))
             set(AMReX_PIC ON CACHE INTERNAL "" FORCE)
+        else()
+            set(AMReX_PIC OFF CACHE INTERNAL "" FORCE)
         endif()
-        if(WarpX_PYTHON OR (WarpX_LIB AND BUILD_SHARED_LIBS))
-            set(AMReX_PIC ON CACHE INTERNAL "" FORCE)
 
-            # WE NEED AMReX AS SHARED LIB, OTHERWISE WE CANNOT SHARE ITS GLOBALS
-            # BETWEEN MULTIPLE PYTHON MODULES
-            # TODO this is likely an export/symbol hiding issue that we could
-            #      alleviate later on
+        # WE NEED AMReX AS SHARED LIB, OTHERWISE WE CANNOT SHARE ITS GLOBALS
+        # BETWEEN MULTIPLE PYTHON MODULES
+        # TODO this is likely an export/symbol hiding issue that we could
+        #      alleviate later on
+        if(WarpX_PYTHON OR (WarpX_LIB AND BUILD_SHARED_LIBS))
             set(AMReX_BUILD_SHARED_LIBS ON CACHE BOOL "Build AMReX shared library" FORCE)
+        elseif(DEFINED AMReX_BUILD_SHARED_LIBS)
+            # do not leave a stale ON behind: AMReX_INSTALL below distinguishes
+            # "we forced it" from "the user/BUILD_SHARED_LIBS decides"
+            unset(AMReX_BUILD_SHARED_LIBS CACHE)
         endif()
 
         # IPO/LTO

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -146,9 +146,13 @@ macro(find_amrex)
         #      alleviate later on
         if(WarpX_PYTHON OR (WarpX_LIB AND BUILD_SHARED_LIBS))
             set(AMReX_BUILD_SHARED_LIBS ON CACHE BOOL "Build AMReX shared library" FORCE)
-        elseif(DEFINED AMReX_BUILD_SHARED_LIBS)
+        elseif(DEFINED AMReX_BUILD_SHARED_LIBS AND
+               CMAKE_SOURCE_DIR STREQUAL WarpX_SOURCE_DIR)
             # do not leave a stale ON behind: AMReX_INSTALL below distinguishes
-            # "we forced it" from "the user/BUILD_SHARED_LIBS decides"
+            # "we forced it" from "the user/BUILD_SHARED_LIBS decides".
+            # Only when WarpX is the top-level project: as a subproject (e.g. of
+            # ImpactX) the parent sets this for its own Python bindings before
+            # adding us, and clearing it would break its install(EXPORT).
             unset(AMReX_BUILD_SHARED_LIBS CACHE)
         endif()
 

--- a/cmake/dependencies/AMReX.cmake
+++ b/cmake/dependencies/AMReX.cmake
@@ -29,16 +29,21 @@ macro(find_amrex)
             set(AMReX_CONDUIT OFF CACHE INTERNAL "")
         endif()
 
-        # FORCE: we derive these from CMAKE_BUILD_TYPE, so they have to follow it
-        # when an existing build directory is re-configured to another build type
+        # Set re-evaluated defaults without caching them. With CMP0077 NEW, AMReX's
+        # option() honors these normal variables, while explicit caller values win.
         if("${CMAKE_BUILD_TYPE}" MATCHES "Debug")
-            set(AMReX_ASSERTIONS ON CACHE BOOL "" FORCE)
-            # note: floating-point exceptions can slow down debug runs a lot
-            set(AMReX_FPE ON CACHE BOOL "" FORCE)
+            set(_WarpX_AMReX_DEBUG_DEFAULT ON)
         else()
-            set(AMReX_ASSERTIONS OFF CACHE BOOL "" FORCE)
-            set(AMReX_FPE OFF CACHE BOOL "" FORCE)
+            set(_WarpX_AMReX_DEBUG_DEFAULT OFF)
         endif()
+        if(NOT DEFINED AMReX_ASSERTIONS)
+            set(AMReX_ASSERTIONS "${_WarpX_AMReX_DEBUG_DEFAULT}")
+        endif()
+        if(NOT DEFINED AMReX_FPE)
+            # note: floating-point exceptions can slow down debug runs a lot
+            set(AMReX_FPE "${_WarpX_AMReX_DEBUG_DEFAULT}")
+        endif()
+        unset(_WarpX_AMReX_DEBUG_DEFAULT)
 
         if(WarpX_COMPUTE STREQUAL OMP)
             set(AMReX_GPU_BACKEND  "NONE" CACHE INTERNAL "")
@@ -135,9 +140,9 @@ macro(find_amrex)
         if(WarpX_PYTHON OR
            ABLASTR_POSITION_INDEPENDENT_CODE OR
            (WarpX_LIB AND BUILD_SHARED_LIBS))
-            set(AMReX_PIC ON CACHE INTERNAL "" FORCE)
-        else()
-            set(AMReX_PIC OFF CACHE INTERNAL "" FORCE)
+            # A normal variable applies the requirement without overwriting a
+            # caller-owned cache entry when the requirement later disappears.
+            set(AMReX_PIC ON)
         endif()
 
         # WE NEED AMReX AS SHARED LIB, OTHERWISE WE CANNOT SHARE ITS GLOBALS
@@ -145,15 +150,10 @@ macro(find_amrex)
         # TODO this is likely an export/symbol hiding issue that we could
         #      alleviate later on
         if(WarpX_PYTHON OR (WarpX_LIB AND BUILD_SHARED_LIBS))
-            set(AMReX_BUILD_SHARED_LIBS ON CACHE BOOL "Build AMReX shared library" FORCE)
-        elseif(DEFINED AMReX_BUILD_SHARED_LIBS AND
-               CMAKE_SOURCE_DIR STREQUAL WarpX_SOURCE_DIR)
-            # do not leave a stale ON behind: AMReX_INSTALL below distinguishes
-            # "we forced it" from "the user/BUILD_SHARED_LIBS decides".
-            # Only when WarpX is the top-level project: as a subproject (e.g. of
-            # ImpactX) the parent sets this for its own Python bindings before
-            # adding us, and clearing it would break its install(EXPORT).
-            unset(AMReX_BUILD_SHARED_LIBS CACHE)
+            # Do not cache this requirement. AMReX's option() honors the normal
+            # variable for this configure, and a caller-owned cache entry becomes
+            # visible again if the requirement later disappears.
+            set(AMReX_BUILD_SHARED_LIBS ON)
         endif()
 
         # IPO/LTO


### PR DESCRIPTION
Several AMReX options that WarpX derives from its own options were only assigned in their "on" branch, or through a non-forcing `set(... CACHE BOOL "")` that is a no-op once the cache entry exists, so re-configuring an existing build directory silently kept the old value. Most visibly, switching `CMAKE_BUILD_TYPE` from `Debug` to `Release` left `AMReX_ASSERTIONS` and `AMReX_FPE` on, so a "Release" build still paid for assertions and floating-point exception trapping.

- [x] rebase after #7202

<details>
<summary>Details</summary>

| Option | Derived from | Stale symptom |
|---|---|---|
| `AMReX_ASSERTIONS`, `AMReX_FPE` | `CMAKE_BUILD_TYPE` | `Debug` → `Release` keeps assertions and FPE trapping on |
| `AMReX_BUILD_SHARED_LIBS` | `WarpX_PYTHON`, `WarpX_LIB` | `ON` → `OFF` keeps AMReX a shared library |
| `AMReX_ASCENT`, `AMReX_CATALYST`, `AMReX_CONDUIT` | `WarpX_ASCENT`, `WarpX_CATALYST` | on-only assignment |
| `AMReX_SENSEI` | `WarpX_SENSEI` | on-only assignment |

The options fall into two groups, handled differently.

**Purely derived values** — `AMReX_ASCENT`, `AMReX_CATALYST`, `AMReX_CONDUIT`, `AMReX_SENSEI` — are assigned unconditionally from their WarpX counterpart. These stay `CACHE INTERNAL`, which already implies `FORCE`, so the fix for them is a second assignment rather than an added `FORCE`.

**Caller-facing options** — `AMReX_ASSERTIONS`, `AMReX_FPE`, `AMReX_PIC`, `AMReX_BUILD_SHARED_LIBS` — are set as normal variables instead of cache entries. With `CMP0077 NEW`, which we already request here, AMReX's `option()` honors a normal variable and skips creating the cache entry, so the derivation re-evaluates on every configure and leaves nothing behind for the next one. `AMReX_ASSERTIONS` and `AMReX_FPE` are guarded by `if(NOT DEFINED ...)`, so an explicit `-DAMReX_ASSERTIONS=ON` is a cache entry that keeps winning; `AMReX_PIC` and `AMReX_BUILD_SHARED_LIBS` apply unconditionally, since a Python build genuinely requires them.

`AMReX_INSTALL` keeps working: it is derived from `if(DEFINED AMReX_BUILD_SHARED_LIBS)`, and `DEFINED` is true for a normal variable, so a Python configure still gets `AMReX_INSTALL=ON` and downstream `install(EXPORT ...)` is generated. This is what ImpactX's Python bindings need when they add WarpX/ABLASTR as a subdirectory.

Internal: drops a duplicated `AMReX_PIC` assignment whose condition is a strict subset of the preceding one. `AMReX_PIC` itself was not observably stale, since `ABLASTR_POSITION_INDEPENDENT_CODE` defaults to `ON` and keeps the condition true.

Two consequences worth knowing. A build directory configured by an earlier version still carries its old cache entries and is not healed by this change — one `--fresh` clears it permanently. And these options no longer appear in `ccmake`/`cmake-gui` as tweakable knobs in the common case, though `-D` still works and now sticks across re-configures.

**Testing**

Configured, then re-configured the same directory with the opposite settings, and compared each result against a fresh configure of the same command line. Probed the effective values plus the resulting `amrex_3d` target `TYPE` and `POSITION_INDEPENDENT_CODE`, since the fix intentionally keeps these values out of the cache.

| Scenario | `AMReX_ASSERTIONS` | `AMReX_FPE` | `amrex_3d` |
|---|---|---|---|
| fresh `Release` + `WarpX_PYTHON=OFF` | OFF | OFF | `STATIC`, PIC `ON` |
| `Debug`+`ON` → re-configure `Release`+`OFF` | OFF | OFF | `STATIC`, PIC `ON` |
| fresh `Debug` + `WarpX_PYTHON=ON` | ON | ON | `SHARED`, PIC `ON` |
| `Release`+`OFF` → re-configure `Debug`+`ON` | ON | ON | `SHARED`, PIC `ON` |

Both directions match their fresh reference. A caller's `-DAMReX_ASSERTIONS=ON` in a `Release` build also survives a later re-configure.

Also checked the ImpactX superbuild against this branch, since ImpactX sets these options before adding WarpX/ABLASTR as a subdirectory: `ImpactX_PYTHON=ON` gives AMReX shared and position-independent with `AMReX_INSTALL=ON` and no `install(EXPORT "pyAMReXTargets" ...)` error, and its `ON` → `OFF` re-configure matches a fresh `OFF` configure.

Same class of issue as `AMReX_GPU_RDC`/`AMReX_CUDA_LTO`/`AMReX_IPO` in #7202, and mirrored on the ImpactX side in https://github.com/BLAST-ImpactX/impactx/pull/1637.

</details>
