### PR TITLE
Update Dane (LC) setup scripts

### DIFF
--- a/Docs/source/install/hpc/dane.rst
+++ b/Docs/source/install/hpc/dane.rst
@@ -72,10 +72,11 @@ They are by default installed in the workspace directory (which is recommended),
 The second command activates the Python virtual environment.
 This would normally be done by the ``dane_warpx.profile`` script, but the environment is created by the install script and so wasn't created yet when the profile was run above.
 So the activation needs to be done this way only this one time.
+The install_dependencies.sh must be run in batch since it is compute intensive. The "runNode" is an alias that does "srun" and is defined in dane_warpx.profile.
 
 .. code-block:: bash
 
-   bash /usr/workspace/${USER}/dane/src/warpx/Tools/machines/dane-llnl/install_dependencies.sh
+   runNode /usr/workspace/${USER}/dane/src/warpx/Tools/machines/dane-llnl/install_dependencies.sh
    source /usr/workspace/${USER}/dane/venvs/warpx-dane/bin/activate
 
 .. dropdown:: Script Details

--- a/Tools/machines/dane-llnl/dane.sbatch
+++ b/Tools/machines/dane-llnl/dane.sbatch
@@ -6,14 +6,14 @@
 #SBATCH -A <allocation ID>
 
 #SBATCH -J WarpX
-#SBATCH -q pbatch
+#SBATCH -p pbatch
 #SBATCH --qos=normal
 #SBATCH --license=lustre1,lustre2
 #SBATCH --export=ALL
 #SBATCH -e error.txt
 #SBATCH -o output.txt
 # one MPI rank per half-socket (see below)
-#SBATCH --tasks-per-node=2
+#SBATCH --ntasks-per-node=2
 # request all logical (virtual) cores per half-socket
 #SBATCH --cpus-per-task=112
 
@@ -36,4 +36,8 @@ export OMP_NUM_THREADS=112
 
 EXE="<path/to/executable>"  # e.g. ./warpx
 
+date
+
 srun --cpu_bind=cores -n $(( ${SLURM_JOB_NUM_NODES} * ${WARPX_NMPI_PER_NODE} )) ${EXE} <input file>
+
+date

--- a/Tools/machines/dane-llnl/dane_warpx.profile.example
+++ b/Tools/machines/dane-llnl/dane_warpx.profile.example
@@ -32,7 +32,7 @@ export LD_LIBRARY_PATH=${WARPX_SW_DIR}/install/lapackpp-2024.10.26/lib64:$LD_LIB
 # optional: for implicit solvers
 # only do this is PETSC_DIR is not already defined
 if [[ -z "${PETSC_DIR:-}" ]]; then
-    export PETSC_DIR="${WARPX_SW_DIR}/install/petsc"
+    export PETSC_DIR="${WARPX_SW_DIR}/src/petsc"
     export PETSC_ARCH="arch-opt"
 fi
 

--- a/Tools/machines/dane-llnl/dane_warpx.profile.example
+++ b/Tools/machines/dane-llnl/dane_warpx.profile.example
@@ -2,15 +2,15 @@
 #export proj="<yourProjectNameHere>"  # edit this and comment in
 
 # required dependencies
-module load cmake/3.26.3
-module load clang/14.0.6-magic
+module load cmake/3.30.5
+module load clang/22.1.5-magic
 module load mvapich2/2.3.7
 
 # optional: for PSATD support
 module load fftw/3.3.10
 
 # optional: for QED lookup table generation support
-module load boost/1.80.0
+module load boost/1.86.0
 
 # optional: for openPMD support
 module load hdf5-parallel/1.14.0
@@ -29,9 +29,16 @@ export CMAKE_PREFIX_PATH=${WARPX_SW_DIR}/install/lapackpp-2024.10.26:$CMAKE_PREF
 export LD_LIBRARY_PATH=${WARPX_SW_DIR}/install/blaspp-2024.10.26/lib64:$LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=${WARPX_SW_DIR}/install/lapackpp-2024.10.26/lib64:$LD_LIBRARY_PATH
 
+# optional: for implicit solvers
+# only do this is PETSC_DIR is not already defined
+if [[ -z "${PETSC_DIR:-}" ]]; then
+    export PETSC_DIR="${WARPX_SW_DIR}/install/petsc"
+    export PETSC_ARCH="arch-opt"
+fi
+
 # optional: for Python bindings
 #module load python/3.12.2 # Note this version uses a too new GLIBCXX and breaks the adios build
-module load python/3.11.5
+module load python/3.14.6
 
 if [ -d "${WARPX_SW_DIR}/venvs/warpx-dane" ]
 then
@@ -39,10 +46,10 @@ then
 fi
 
 # optional: an alias to request an interactive node for two hours
-alias getNode="srun --time=0:30:00 --nodes=1 --ntasks-per-node=2 --cpus-per-task=56 -p pdebug --pty bash"
-# an alias to run a command on a batch node for up to 30min
+alias getNode="srun --time=2:00:00 --nodes=1 --ntasks-per-node=2 --cpus-per-task=56 -p pdebug --pty bash"
+# an alias to run a command on a batch node for up to 1 hour
 #   usage: runNode <command>
-alias runNode="srun --time=0:30:00 --nodes=1 --ntasks-per-node=2 --cpus-per-task=56 -p pdebug"
+alias runNode="srun --time=1:00:00 --nodes=1 --ntasks-per-node=1 --cpus-per-task=56 -p pdebug"
 
 # fix system defaults: do not escape $ with a \ on tab completion
 shopt -s direxpand

--- a/Tools/machines/dane-llnl/install_dependencies.sh
+++ b/Tools/machines/dane-llnl/install_dependencies.sh
@@ -78,7 +78,7 @@ else
   git clone -b v2.10.2 https://github.com/ornladios/ADIOS2.git ${WARPX_SW_DIR}/src/adios2
 fi
 cmake -S ${WARPX_SW_DIR}/src/adios2 -B ${build_dir}/adios2-dane-build -DBUILD_TESTING=OFF -DADIOS2_BUILD_EXAMPLES=OFF -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_SST=OFF -DADIOS2_USE_ZeroMQ=OFF -DADIOS2_USE_HDF5=OFF -DCMAKE_INSTALL_PREFIX=${WARPX_SW_DIR}/install/adios2-2.10.2
-cmake --build ${build_dir}/adios2-dane-build --target install -parallel
+cmake --build ${build_dir}/adios2-dane-build --target install --parallel
 
 # BLAS++ (for PSATD+RZ)
 if [ -d ${WARPX_SW_DIR}/src/blaspp ]

--- a/Tools/machines/dane-llnl/install_dependencies.sh
+++ b/Tools/machines/dane-llnl/install_dependencies.sh
@@ -50,6 +50,9 @@ mkdir -p ${WARPX_SW_DIR}/install
 # General extra dependencies ##################################################
 #
 
+# Use all available cpus on a batch node
+PARALLEL=112
+
 # tmpfs build directory: avoids issues often seen with ${HOME} and is faster
 build_dir=$(mktemp -d)
 
@@ -64,7 +67,7 @@ else
   git clone -b v1.21.6 https://github.com/Blosc/c-blosc.git ${WARPX_SW_DIR}/src/c-blosc
 fi
 cmake -S ${WARPX_SW_DIR}/src/c-blosc -B ${build_dir}/c-blosc-dane-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${WARPX_SW_DIR}/install/c-blosc-1.21.6
-cmake --build ${build_dir}/c-blosc-dane-build --target install --parallel
+cmake --build ${build_dir}/c-blosc-dane-build --target install --parallel ${PARALLEL}
 
 # ADIOS2
 if [ -d ${WARPX_SW_DIR}/src/adios2 ]
@@ -77,7 +80,7 @@ else
   git clone -b v2.10.2 https://github.com/ornladios/ADIOS2.git ${WARPX_SW_DIR}/src/adios2
 fi
 cmake -S ${WARPX_SW_DIR}/src/adios2 -B ${build_dir}/adios2-dane-build -DBUILD_TESTING=OFF -DADIOS2_BUILD_EXAMPLES=OFF -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_SST=OFF -DADIOS2_USE_ZeroMQ=OFF -DADIOS2_USE_HDF5=OFF -DCMAKE_INSTALL_PREFIX=${WARPX_SW_DIR}/install/adios2-2.10.2
-cmake --build ${build_dir}/adios2-dane-build --target install --parallel
+cmake --build ${build_dir}/adios2-dane-build --target install --parallel ${PARALLEL}
 
 # BLAS++ (for PSATD+RZ)
 if [ -d ${WARPX_SW_DIR}/src/blaspp ]
@@ -90,7 +93,7 @@ else
   git clone -b v2024.10.26 https://github.com/icl-utk-edu/blaspp.git ${WARPX_SW_DIR}/src/blaspp
 fi
 cmake -S ${WARPX_SW_DIR}/src/blaspp -B ${build_dir}/blaspp-dane-build -Duse_openmp=ON -Duse_cmake_find_blas=ON -DCMAKE_CXX_STANDARD=20 -DCMAKE_INSTALL_PREFIX=${WARPX_SW_DIR}/install/blaspp-2024.10.26
-cmake --build ${build_dir}/blaspp-dane-build --target install --parallel
+cmake --build ${build_dir}/blaspp-dane-build --target install --parallel ${PARALLEL}
 
 # LAPACK++ (for PSATD+RZ)
 if [ -d ${WARPX_SW_DIR}/src/lapackpp ]
@@ -103,7 +106,7 @@ else
   git clone -b v2024.10.26 https://github.com/icl-utk-edu/lapackpp.git ${WARPX_SW_DIR}/src/lapackpp
 fi
 CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S ${WARPX_SW_DIR}/src/lapackpp -B ${build_dir}/lapackpp-dane-build -Duse_cmake_find_lapack=ON -DCMAKE_CXX_STANDARD=20 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${WARPX_SW_DIR}/install/lapackpp-2024.10.26
-cmake --build ${build_dir}/lapackpp-dane-build --target install --parallel
+cmake --build ${build_dir}/lapackpp-dane-build --target install --parallel ${PARALLEL}
 
 if [[ "${PETSC_DIR:-}" == "${WARPX_SW_DIR}/src/petsc" ]]; then
   # PETSC
@@ -112,26 +115,20 @@ if [[ "${PETSC_DIR:-}" == "${WARPX_SW_DIR}/src/petsc" ]]; then
   then
     cd ${WARPX_SW_DIR}/src/petsc
     git fetch --prune
-    git checkout release
+    git checkout v3.24.0
   else
     cd ${WARPX_SW_DIR}/src
-    git clone -b release https://gitlab.com/petsc/petsc.git petsc
+    git clone -b v3.24.0 https://gitlab.com/petsc/petsc.git petsc
     cd ${WARPX_SW_DIR}/src/petsc
   fi
   ./configure --with-batch --with-fortran-bindings=no --with-x=no --with-cc=mpicc --with-fc=mpif90 --with-cxx=mpicxx COPTFLAGS="-O2" FOPTFLAGS="-O2" CXXOPTFLAGS="-O2" --with-shared-libraries --with-debugging=0 --download-hypre --download-superlu --download-superlu_dist --download-parmetis --download-metis --with-cxx-dialect=C++20
-  make -j all
+  make -j ${PARALLEL} all
   cd -
 fi
 
 # Python ######################################################################
 #
 # Create a virtual environment and install the Python packages there.
-EXPECTED_VENV="${WARPX_SW_DIR}/venvs/warpx-dane"
-if [[ -n "${VIRTUAL_ENV:-}" &&
-      "$(realpath "$VIRTUAL_ENV")" == "$(realpath "$EXPECTED_VENV")" ]]; then
-  # If it is activated
-  deactivate
-fi
 rm -rf ${WARPX_SW_DIR}/venvs/warpx-dane
 python3 -m venv ${WARPX_SW_DIR}/venvs/warpx-dane
 source ${WARPX_SW_DIR}/venvs/warpx-dane/bin/activate

--- a/Tools/machines/dane-llnl/install_dependencies.sh
+++ b/Tools/machines/dane-llnl/install_dependencies.sh
@@ -126,6 +126,12 @@ fi
 # Python ######################################################################
 #
 # Create a virtual environment and install the Python packages there.
+EXPECTED_VENV="${WARPX_SW_DIR}/venvs/warpx-dane"
+if [[ -n "${VIRTUAL_ENV:-}" &&
+      "$(realpath "$VIRTUAL_ENV")" == "$(realpath "$EXPECTED_VENV")" ]]; then
+  # If it is activated
+  deactivate
+fi
 rm -rf ${WARPX_SW_DIR}/venvs/warpx-dane
 python3 -m venv ${WARPX_SW_DIR}/venvs/warpx-dane
 source ${WARPX_SW_DIR}/venvs/warpx-dane/bin/activate

--- a/Tools/machines/dane-llnl/install_dependencies.sh
+++ b/Tools/machines/dane-llnl/install_dependencies.sh
@@ -110,7 +110,7 @@ cmake --build ${build_dir}/lapackpp-dane-build --target install --parallel ${PAR
 
 if [[ "${PETSC_DIR:-}" == "${WARPX_SW_DIR}/src/petsc" ]]; then
   # PETSC
-  # Only build it if PERSC_DIR points to this work space
+  # Only build it if PETSC_DIR points to this work space
   if [ -d ${WARPX_SW_DIR}/src/petsc ]
   then
     cd ${WARPX_SW_DIR}/src/petsc

--- a/Tools/machines/dane-llnl/install_dependencies.sh
+++ b/Tools/machines/dane-llnl/install_dependencies.sh
@@ -6,11 +6,21 @@
 #
 # Author: Axel Huebl, David Grote
 # License: BSD-3-Clause-LBNL
+#
+# This must be run in batch since it is compute intensive.
+# Also, the dane_warpx.profile script must already have been sourced.
+# Run like this:
+#    runNode path/to/warpx/Tools/machines/dane-llnl/install_dependencies.sh
 
 # Exit on first error encountered #############################################
 #
 set -eu -o pipefail
 
+# Make sure the script is running in batch
+if [[ -z "${SLURM_JOB_ID:-}" ]]; then
+    echo "Error: this script must be run as a SLURM batch job." >&2
+    exit 1
+fi
 
 # Check: ######################################################################
 #
@@ -55,7 +65,7 @@ else
   git clone -b v1.21.6 https://github.com/Blosc/c-blosc.git ${WARPX_SW_DIR}/src/c-blosc
 fi
 cmake -S ${WARPX_SW_DIR}/src/c-blosc -B ${build_dir}/c-blosc-dane-build -DBUILD_TESTS=OFF -DBUILD_BENCHMARKS=OFF -DDEACTIVATE_AVX2=OFF -DCMAKE_INSTALL_PREFIX=${WARPX_SW_DIR}/install/c-blosc-1.21.6
-cmake --build ${build_dir}/c-blosc-dane-build --target install --parallel 6
+cmake --build ${build_dir}/c-blosc-dane-build --target install --parallel
 
 # ADIOS2
 if [ -d ${WARPX_SW_DIR}/src/adios2 ]
@@ -67,8 +77,8 @@ then
 else
   git clone -b v2.10.2 https://github.com/ornladios/ADIOS2.git ${WARPX_SW_DIR}/src/adios2
 fi
-cmake -S ${WARPX_SW_DIR}/src/adios2 -B ${build_dir}/adios2-dane-build -DBUILD_TESTING=OFF -DADIOS2_BUILD_EXAMPLES=OFF -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_SST=OFF -DADIOS2_USE_ZeroMQ=OFF -DCMAKE_INSTALL_PREFIX=${WARPX_SW_DIR}/install/adios2-2.10.2
-cmake --build ${build_dir}/adios2-dane-build --target install -j 6
+cmake -S ${WARPX_SW_DIR}/src/adios2 -B ${build_dir}/adios2-dane-build -DBUILD_TESTING=OFF -DADIOS2_BUILD_EXAMPLES=OFF -DADIOS2_USE_Blosc=ON -DADIOS2_USE_Fortran=OFF -DADIOS2_USE_Python=OFF -DADIOS2_USE_SST=OFF -DADIOS2_USE_ZeroMQ=OFF -DADIOS2_USE_HDF5=OFF -DCMAKE_INSTALL_PREFIX=${WARPX_SW_DIR}/install/adios2-2.10.2
+cmake --build ${build_dir}/adios2-dane-build --target install -parallel
 
 # BLAS++ (for PSATD+RZ)
 if [ -d ${WARPX_SW_DIR}/src/blaspp ]
@@ -81,7 +91,7 @@ else
   git clone -b v2024.10.26 https://github.com/icl-utk-edu/blaspp.git ${WARPX_SW_DIR}/src/blaspp
 fi
 cmake -S ${WARPX_SW_DIR}/src/blaspp -B ${build_dir}/blaspp-dane-build -Duse_openmp=ON -Duse_cmake_find_blas=ON -DCMAKE_CXX_STANDARD=20 -DCMAKE_INSTALL_PREFIX=${WARPX_SW_DIR}/install/blaspp-2024.10.26
-cmake --build ${build_dir}/blaspp-dane-build --target install --parallel 6
+cmake --build ${build_dir}/blaspp-dane-build --target install --parallel
 
 # LAPACK++ (for PSATD+RZ)
 if [ -d ${WARPX_SW_DIR}/src/lapackpp ]
@@ -94,8 +104,25 @@ else
   git clone -b v2024.10.26 https://github.com/icl-utk-edu/lapackpp.git ${WARPX_SW_DIR}/src/lapackpp
 fi
 CXXFLAGS="-DLAPACK_FORTRAN_ADD_" cmake -S ${WARPX_SW_DIR}/src/lapackpp -B ${build_dir}/lapackpp-dane-build -Duse_cmake_find_lapack=ON -DCMAKE_CXX_STANDARD=20 -Dbuild_tests=OFF -DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON -DCMAKE_INSTALL_PREFIX=${WARPX_SW_DIR}/install/lapackpp-2024.10.26
-cmake --build ${build_dir}/lapackpp-dane-build --target install --parallel 6
+cmake --build ${build_dir}/lapackpp-dane-build --target install --parallel
 
+if [[ "${PETSC_DIR:-}" == "${WARPX_SW_DIR}/src/petsc" ]]; then
+  # PETSC
+  # Only build it if PERSC_DIR points to this work space
+  if [ -d ${WARPX_SW_DIR}/src/petsc ]
+  then
+    cd ${WARPX_SW_DIR}/src/petsc
+    git fetch --prune
+    git checkout release
+  else
+    cd ${WARPX_SW_DIR}/src
+    git clone -b release https://gitlab.com/petsc/petsc.git petsc
+    cd ${WARPX_SW_DIR}/src/petsc
+  fi
+  ./configure --with-batch --with-fortran-bindings=no --with-x=no --with-cc=mpicc --with-fc=mpif90 --with-cxx=mpicxx COPTFLAGS="-O2" FOPTFLAGS="-O2" CXXOPTFLAGS="-O2" --with-shared-libraries --with-debugging=0 --download-hypre --download-superlu --download-superlu_dist --download-parmetis --download-metis --with-cxx-dialect=C++20
+  make -j all
+  cd -
+fi
 
 # Python ######################################################################
 #

--- a/Tools/machines/dane-llnl/install_dependencies.sh
+++ b/Tools/machines/dane-llnl/install_dependencies.sh
@@ -39,7 +39,6 @@ python3 -m pip uninstall -qqq -y mpi4py 2>/dev/null || true
 
 # clean out caches, e.g., depending on old system modules
 python3 -m pip cache purge || true
-rm -rf ${HOME}/.cupy/kernel_cache ${HOME}/.nv/ComputeCache ${HOME}/.cache/numba ${HOME}/.triton
 
 # Setup the directories where the packages will be installed
 if [ -z "${WARPX_SW_DIR+x}" ]; then


### PR DESCRIPTION
This updates the setup scripts on dane (at LLNL) to use the latest version of the modules. It also now includes the optional build of PETSC. Some other cleanup was done.