### PR TITLE
Reduce excessive implicit particle suborbit warnings

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -290,6 +290,8 @@ Overall simulation parameters
           - ``implicit_evolve.max_particle_iterations`` (``integer``, default: 21)
           - ``implicit_evolve.particle_tolerance`` (``float``, default: 1.e-10)
           - ``implicit_evolve.particle_suborbits`` (``bool``, default: false)
+          - ``implicit_evolve.suborbit_warning_threshold`` (``int``, default: 5)
+          - ``implicit_evolve.suborbit_statistics_interval`` (``int``, default: 100)
           - ``implicit_evolve.print_unconverged_particle_details`` (``bool``, default: false)
 
         - ``implicit_evolve.use_mass_matrices_jacobian`` (``bool``, default: false).

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
@@ -15,8 +15,12 @@
 #include "NonlinearSolvers/NonlinearSolverLibrary.H"
 
 #include <AMReX_Array.H>
+#include <AMReX_INT.H>
 #include <AMReX_REAL.H>
 #include <AMReX_LO_BCTYPES.H>
+
+#include <map>
+#include <string>
 
 /**
  * \brief Base class for implicit time solvers. The base functions are those
@@ -206,6 +210,17 @@ protected:
      * m_max_particle_iterations iterations
      */
     bool m_particle_suborbits = false;
+
+    int m_suborbit_warning_threshold = 5;
+    int m_suborbit_statistics_interval = 100;
+    std::map<std::string, amrex::Long> m_accumulated_suborbit_counts;
+    int m_suborbit_statistics_start_step = -1;
+
+    void FinishImplicitParticleUpdate (amrex::Real time, int step);
+
+    void AccumulateSuborbitStatistics (
+        std::map<std::string, amrex::Long> const& local_suborbit_counts,
+        int step);
 
     /**
      * \brief whether the details of unconverged particles are printed out during

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
@@ -163,6 +163,11 @@ public:
      */
     void FinishMassMatrices ();
 
+    /**
+     * \brief Finish the implicit particle update after the converged time-centered solve
+     */
+    void FinishImplicitParticleUpdate (amrex::Real time, int step);
+
 protected:
 
     /**
@@ -215,8 +220,6 @@ protected:
     int m_suborbit_statistics_interval = 100;
     std::map<std::string, amrex::Long> m_accumulated_suborbit_counts;
     int m_suborbit_statistics_start_step = -1;
-
-    void FinishImplicitParticleUpdate (amrex::Real time, int step);
 
     void AccumulateSuborbitStatistics (
         std::map<std::string, amrex::Long> const& local_suborbit_counts,

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -4,8 +4,96 @@
 #include "Particles/MultiParticleContainer.H"
 #include "Utils/WarpXAlgorithmSelection.H"
 
+#include <AMReX_GpuAtomic.H>
+#include <AMReX_GpuContainers.H>
+#include <AMReX_ParallelDescriptor.H>
+#include <AMReX_Print.H>
+
+#include <sstream>
+
 using namespace amrex;
 using namespace amrex::literals;
+
+void ImplicitSolver::FinishImplicitParticleUpdate (
+    amrex::Real const time,
+    int const step)
+{
+    m_WarpX->FinishImplicitParticleUpdate(time);
+
+    std::map<std::string, amrex::Long> local_suborbit_counts;
+    for (auto const& pc : m_WarpX->GetPartContainer()) {
+        if (!pc->HasiAttrib("nsuborbits")) { continue; }
+
+        amrex::Gpu::Buffer<amrex::Long> suborbit_count({0});
+        amrex::Long* const suborbit_count_ptr = suborbit_count.data();
+
+        for (int lev = 0; lev <= m_WarpX->finestLevel(); ++lev) {
+#ifdef AMREX_USE_OMP
+#pragma omp parallel
+#endif
+            {
+                for (WarpXParIter pti(*pc, lev); pti.isValid(); ++pti) {
+                    int const* const nsuborbits =
+                        pti.GetiAttribs("nsuborbits").dataPtr();
+                    long const np = pti.numParticles();
+                    int const suborbit_warning_threshold = m_suborbit_warning_threshold;
+                    amrex::ParallelFor(np, [=] AMREX_GPU_DEVICE (long ip)
+                    {
+                        if (nsuborbits[ip] >= suborbit_warning_threshold) {
+                            amrex::Gpu::Atomic::Add(
+                                suborbit_count_ptr, amrex::Long(1));
+                        }
+                    });
+                }
+            }
+        }
+
+        local_suborbit_counts[pc->getName()] =
+            *(suborbit_count.copyToHost());
+    }
+
+    AccumulateSuborbitStatistics(local_suborbit_counts, step);
+}
+
+void ImplicitSolver::AccumulateSuborbitStatistics (
+    std::map<std::string, amrex::Long> const& local_suborbit_counts,
+    int const step)
+{
+    if (m_suborbit_statistics_start_step < 0) {
+        m_suborbit_statistics_start_step = step+1;
+    }
+    for (auto const& [species, local_count] : local_suborbit_counts) {
+        m_accumulated_suborbit_counts[species] += local_count;
+    }
+
+    if ((step+1) % m_suborbit_statistics_interval != 0) { return; }
+
+    std::stringstream statistics_msg;
+    amrex::Long global_total = 0;
+    bool have_statistics = false;
+    if (amrex::ParallelDescriptor::IOProcessor()) {
+        statistics_msg << "During steps "
+                       << m_suborbit_statistics_start_step << "-" << step+1
+                       << ", particles requiring " << m_suborbit_warning_threshold
+                       << " or more suborbits by species:\n";
+    }
+    for (auto& [species, local_count] : m_accumulated_suborbit_counts) {
+        amrex::Long global_count = local_count;
+        amrex::ParallelDescriptor::ReduceLongSum(global_count);
+        if (amrex::ParallelDescriptor::IOProcessor() && global_count > 0) {
+            statistics_msg << "  " << species << ": " << global_count << "\n";
+            global_total += global_count;
+            have_statistics = true;
+        }
+        local_count = 0;
+    }
+    if (amrex::ParallelDescriptor::IOProcessor() && have_statistics) {
+        statistics_msg << "  total: " << global_total;
+        amrex::Print() << "\nImplicitPushXP statistics:\n"
+                       << statistics_msg.str() << "\n\n";
+    }
+    m_suborbit_statistics_start_step = step+2;
+}
 
 void ImplicitSolver::CreateParticleAttributes () const
 {
@@ -531,6 +619,8 @@ void ImplicitSolver::parseNonlinearSolverParams ( const amrex::ParmParse&  pp )
         pp.query("particle_tolerance", m_particle_tolerance);
         pp.query("particle_suborbits", m_particle_suborbits);
         pp.query("print_unconverged_particle_details", m_print_unconverged_particle_details);
+        pp.query("suborbit_warning_threshold", m_suborbit_warning_threshold);
+        pp.query("suborbit_statistics_interval", m_suborbit_statistics_interval);
         pp.query("use_mass_matrices_jacobian", m_use_mass_matrices_jacobian);
         pp.query("use_mass_matrices_pc", m_use_mass_matrices_pc);
         if (m_use_mass_matrices_jacobian || m_use_mass_matrices_pc) {
@@ -1217,7 +1307,11 @@ void ImplicitSolver::PrintBaseImplicitSolverParameters () const
     amrex::Print() << "max particle iterations:             " << m_max_particle_iterations << "\n";
     amrex::Print() << "particle relative tolerance:         " << m_particle_tolerance << "\n";
     amrex::Print() << "use particle suborbits:              " << (m_particle_suborbits ? "true":"false") << "\n";
-    amrex::Print() << "print unconverged particle details:  " << (m_print_unconverged_particle_details ? "true":"false") << "\n";
+    if (m_particle_suborbits) {
+        amrex::Print() << "suborbit warning theshold:           " << m_suborbit_warning_threshold << "\n";
+        amrex::Print() << "suborbit statistics interval:        " << m_suborbit_statistics_interval << "\n";
+        amrex::Print() << "print unconverged particle details:  " << (m_print_unconverged_particle_details ? "true":"false") << "\n";
+    }
     amrex::Print() << "Nonlinear solver type:               " << amrex::getEnumNameString(m_nlsolver_type) << "\n";
     if ( (m_nlsolver_type == NonlinearSolverType::newton)
       || (m_nlsolver_type == NonlinearSolverType::petsc_snes) ) {

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -89,7 +89,7 @@ void ImplicitSolver::AccumulateSuborbitStatistics (
     }
     if (amrex::ParallelDescriptor::IOProcessor() && have_statistics) {
         statistics_msg << "  total: " << global_total;
-        amrex::Print() << "\nImplicitPushXP statistics:\n"
+        amrex::Print() << "\nSuborbit particle statistics:\n"
                        << statistics_msg.str() << "\n\n";
     }
     m_suborbit_statistics_start_step = step+2;

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -1308,7 +1308,7 @@ void ImplicitSolver::PrintBaseImplicitSolverParameters () const
     amrex::Print() << "particle relative tolerance:         " << m_particle_tolerance << "\n";
     amrex::Print() << "use particle suborbits:              " << (m_particle_suborbits ? "true":"false") << "\n";
     if (m_particle_suborbits) {
-        amrex::Print() << "suborbit warning theshold:           " << m_suborbit_warning_threshold << "\n";
+        amrex::Print() << "suborbit warning threshold:          " << m_suborbit_warning_threshold << "\n";
         amrex::Print() << "suborbit statistics interval:        " << m_suborbit_statistics_interval << "\n";
         amrex::Print() << "print unconverged particle details:  " << (m_print_unconverged_particle_details ? "true":"false") << "\n";
     }

--- a/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
@@ -63,8 +63,6 @@ int SemiImplicitEM::OneStep (amrex::Real  start_time,
 {
     BL_PROFILE("SemiImplicitEM::OneStep()");
 
-    amrex::ignore_unused(a_step);
-
     // Set the member time step
     m_dt = a_dt;
 
@@ -102,7 +100,7 @@ int SemiImplicitEM::OneStep (amrex::Real  start_time,
     const amrex::Real new_time = start_time + m_dt;
 
     // Advance particles from time n+1/2 to time n+1
-    m_WarpX->FinishImplicitParticleUpdate(new_time);
+    FinishImplicitParticleUpdate(new_time, a_step);
 
     // Advance Eg from time n+1/2 to time n+1
     // Eg^{n+1} = 2.0*Eg^{n+1/2} - Eg^n

--- a/Source/FieldSolver/ImplicitSolvers/StrangImplicitSpectralEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/StrangImplicitSpectralEM.cpp
@@ -59,8 +59,6 @@ int StrangImplicitSpectralEM::OneStep (amrex::Real start_time,
                                        amrex::Real a_dt,
                                        int a_step)
 {
-    amrex::ignore_unused(a_step);
-
     // Fields have E^{n} and B^{n}
     // Particles have p^{n} and x^{n}.
 
@@ -97,7 +95,7 @@ int StrangImplicitSpectralEM::OneStep (amrex::Real start_time,
     amrex::Real const new_time = start_time + m_dt;
 
     // Advance particles from time n+1/2 to time n+1
-    m_WarpX->FinishImplicitParticleUpdate(new_time);
+    FinishImplicitParticleUpdate(new_time, a_step);
 
     // Advance E and B fields from time n+1/2 to time n+1
     FinishFieldUpdate(new_time);

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
@@ -89,8 +89,6 @@ int ThetaImplicitEM::OneStep (const amrex::Real  start_time,
 {
     BL_PROFILE("ThetaImplicitEM::OneStep()");
 
-    amrex::ignore_unused(a_step);
-
     // Fields have Eg^{n} and Bg^{n}
     // Particles have up^{n} and xp^{n}.
 
@@ -131,7 +129,7 @@ int ThetaImplicitEM::OneStep (const amrex::Real  start_time,
     const amrex::Real new_time = start_time + m_dt;
 
     // Advance particles from time n+1/2 to time n+1
-    m_WarpX->FinishImplicitParticleUpdate(new_time);
+    FinishImplicitParticleUpdate(new_time, a_step);
 
     // Advance Eg and Bg from time n+theta to time n+1
     FinishFieldUpdate(new_time);

--- a/Source/FieldSolver/ImplicitSolvers/WarpXImplicitOps.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXImplicitOps.cpp
@@ -135,6 +135,7 @@ WarpX::SaveParticlesAtImplicitStepStart ( )
     // Thus, we need to save this information.
 
     for (auto const& pc : *mypc) {
+
         for (int lev = 0; lev <= finest_level; ++lev) {
 #ifdef AMREX_USE_OMP
 #pragma omp parallel
@@ -201,6 +202,7 @@ WarpX::SaveParticlesAtImplicitStepStart ( )
         }
 
     }
+
 }
 
 void

--- a/Source/FieldSolver/ImplicitSolvers/WarpXImplicitOps.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXImplicitOps.cpp
@@ -22,7 +22,6 @@
 
 #include <ablastr/profiler/ProfilerWrapper.H>
 #include <ablastr/utils/SignalHandling.H>
-#include <ablastr/warn_manager/WarnManager.H>
 
 #include <AMReX.H>
 #include <AMReX_Array.H>
@@ -136,7 +135,6 @@ WarpX::SaveParticlesAtImplicitStepStart ( )
     // Thus, we need to save this information.
 
     for (auto const& pc : *mypc) {
-
         for (int lev = 0; lev <= finest_level; ++lev) {
 #ifdef AMREX_USE_OMP
 #pragma omp parallel
@@ -203,7 +201,6 @@ WarpX::SaveParticlesAtImplicitStepStart ( )
         }
 
     }
-
 }
 
 void

--- a/Source/Particles/Pusher/ImplicitPushPX.cpp
+++ b/Source/Particles/Pusher/ImplicitPushPX.cpp
@@ -666,14 +666,6 @@ PhysicalParticleContainer::ImplicitPushXP (WarpXParIter & pti,
     SetupSuborbitParticles(pti, offset, np_to_push, num_unconverged_particles,
                            unconverged_indices, saved_weights);
 
-    if (num_unconverged_particles > 0) {
-        ablastr::warn_manager::WMRecordWarning("ImplicitPushXP",
-            "Picard solver for " +
-            std::to_string(num_unconverged_particles) +
-            " particles failed to converge after " +
-            std::to_string(max_iterations) + " iterations."
-         );
-    }
 }
 
 /* \brief Perform the implicit particle push operation for unconverged particles


### PR DESCRIPTION
Some implicit time solvers issue a warning on every Evolve call when particles require suborbits. These warnings are accumulated by the warning manager and printed at the end of the simulation, potentially producing excessively long log messages.

This PR replaces those warnings with a runtime summary of suborbit statistics. At a user-specified step interval, it reports the cumulative number of particles requiring at least a user-specified number of suborbits.

Example log file with this PR:
```
STEP 150400 starts ...
--- INFO    : updating timestep to DT = 1.000000e-10

Suborbit particle statistics:
During steps 150301-150400, particles requiring 3 or more suborbits by species:
  electrons: 16
  total: 16

STEP 150400 ends. TIME = 7.791128241e-06 DT = 1e-10
Evolve time = 128.829982 s; This step = 0.400546763 s; Avg. per step = 0.3220749549 s
```