### PR TITLE
Add dt_update_write_interval option

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -3384,6 +3384,13 @@ Time step
 
     When adaptive timestepping is activated, information about the new time step and the simulation conditions are output to the file specified by this parameter.
 
+.. pp:param:: warpx.dt_update_write_interval
+    :type: ``string``
+    :optional:
+
+    When adaptive timestepping is activated and :pp:param:`warpx.dt_update_diagnostic_file` is specified, this specifies the interval when data is written to the diagnostic file.
+    The default is to write every time the time step is updated.
+
 .. pp:param:: warpx.max_omegap_dt
     :type: ``float``
     :optional:

--- a/Source/Evolve/WarpXComputeDt.cpp
+++ b/Source/Evolve/WarpXComputeDt.cpp
@@ -219,7 +219,56 @@ WarpX::GlobalCyclotronFrequencyMax ()
 }
 
 void
-WarpX::ApplyDtLimiters ()
+WarpX::WriteDtUpdateFileHeader ()
+{
+    // Write diagnostics if requested
+    if (amrex::ParallelDescriptor::IOProcessor()
+        && !m_dt_update_diagnostic_file.empty()) {
+
+        std::filesystem::path const diagnostic_path(m_dt_update_diagnostic_file);
+        std::filesystem::path const diagnostic_dir = diagnostic_path.parent_path();
+        if (!diagnostic_dir.empty()) {
+            std::filesystem::create_directories(diagnostic_dir);
+        }
+
+        const amrex::ParmParse pp_amr("amr");
+        pp_amr.query("restart", restart_chkfile);
+        const bool IsNotRestart = restart_chkfile.empty();
+
+        // If not a restart, discard the file if already exists.
+        auto file_mode = std::ofstream::out;
+        if (IsNotRestart) { file_mode |= std::ofstream::trunc; }
+
+        std::ofstream diagnostic_file{m_dt_update_diagnostic_file, file_mode};
+        if (!diagnostic_file.is_open()) {
+            amrex::Abort("Failed to open file: " + m_dt_update_diagnostic_file);
+        }
+
+        int c = 0;
+        diagnostic_file << "#";
+        diagnostic_file << "[" << c++ << "]step()";
+        diagnostic_file << " ";
+        diagnostic_file << "[" << c++ << "]time(s)";
+        diagnostic_file << " ";
+        diagnostic_file << "[" << c++ << "]new_dt";
+        diagnostic_file << " ";
+        diagnostic_file << "[" << c++ << "]vmax_dt";
+        if (m_max_omegap_dt.has_value()) {
+            diagnostic_file << " ";
+            diagnostic_file << "[" << c++ << "]omegap_dt";
+        }
+        if (m_max_omegac_dt.has_value()) {
+            diagnostic_file << " ";
+            diagnostic_file << "[" << c++ << "]omegac_dt";
+        }
+        diagnostic_file << "\n";
+        diagnostic_file.close();
+    }
+
+}
+
+void
+WarpX::ApplyDtLimiters (int const step)
 {
     using namespace amrex::literals;
 
@@ -262,42 +311,7 @@ WarpX::ApplyDtLimiters ()
     // Write diagnostics if requested
     if (amrex::ParallelDescriptor::IOProcessor()
         && !m_dt_update_diagnostic_file.empty()
-        && !amrex::FileExists(m_dt_update_diagnostic_file)) {
-
-        std::filesystem::path const diagnostic_path(m_dt_update_diagnostic_file);
-        std::filesystem::path const diagnostic_dir = diagnostic_path.parent_path();
-        if (!diagnostic_dir.empty()) {
-            std::filesystem::create_directories(diagnostic_dir);
-        }
-
-        std::ofstream diagnostic_file{m_dt_update_diagnostic_file, std::ofstream::out | std::ofstream::trunc};
-        if (!diagnostic_file.is_open()) {
-            amrex::Abort("Failed to open file: " + m_dt_update_diagnostic_file);
-        }
-
-        int c = 0;
-        diagnostic_file << "#";
-        diagnostic_file << "[" << c++ << "]step()";
-        diagnostic_file << " ";
-        diagnostic_file << "[" << c++ << "]time(s)";
-        diagnostic_file << " ";
-        diagnostic_file << "[" << c++ << "]new_dt";
-        diagnostic_file << " ";
-        diagnostic_file << "[" << c++ << "]vmax_dt";
-        if (m_max_omegap_dt.has_value()) {
-            diagnostic_file << " ";
-            diagnostic_file << "[" << c++ << "]omegap_dt";
-        }
-        if (m_max_omegac_dt.has_value()) {
-            diagnostic_file << " ";
-            diagnostic_file << "[" << c++ << "]omegac_dt";
-        }
-        diagnostic_file << "\n";
-        diagnostic_file.close();
-    }
-
-    if (amrex::ParallelDescriptor::IOProcessor()
-        && !m_dt_update_diagnostic_file.empty()) {
+        && m_dt_update_write_interval.contains(step + 1)) {
 
         std::ofstream diagnostic_file{m_dt_update_diagnostic_file, std::ofstream::out | std::ofstream::app};
         if (!diagnostic_file.is_open()) {

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -199,7 +199,7 @@ WarpX::Evolve (int numsteps)
         // (electrostatic and theta-implicit EM), provided const_dt is not specified.
         if (m_dt_update_interval.contains(step+1) || (step == 0 && m_max_dt.has_value())) {
             SynchronizeVelocityWithPosition();
-            ApplyDtLimiters();
+            ApplyDtLimiters(step);
             if (verbose_step) {
                 std::ostringstream oss;
                 oss << "updating timestep to DT = " << std::scientific << std::setprecision(6) << dt[0];

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -815,6 +815,9 @@ WarpX::InitData ()
     /** create object for reduced diagnostics */
     reduced_diags = std::make_unique<MultiReducedDiags>();
 
+    // Set the header for the file saving dt_update data
+    WriteDtUpdateFileHeader();
+
     // WarpX::computeMaxStepBoostAccelerator
     // needs to start from the initial zmin_domain_boost,
     // even if restarting from a checkpoint file

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -433,7 +433,7 @@ public:
      */
     amrex::Real GlobalPlasmaFrequencyMax ();
     amrex::Real GlobalCyclotronFrequencyMax ();
-    void ApplyDtLimiters ();
+    void ApplyDtLimiters (int const step);
 
     /** Print main PIC parameters to stdout */
     void PrintMainPICparameters ();
@@ -1218,7 +1218,9 @@ private:
     amrex::Vector<amrex::Real> dt;
     // How often to update the timestep when using adaptive timestepping
     ablastr::utils::text::IntervalsParser m_dt_update_interval;
+    ablastr::utils::text::IntervalsParser m_dt_update_write_interval;
     std::string m_dt_update_diagnostic_file;
+    void WriteDtUpdateFileHeader ();
 
     bool m_safe_guard_cells = false;
 

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -433,7 +433,7 @@ public:
      */
     amrex::Real GlobalPlasmaFrequencyMax ();
     amrex::Real GlobalCyclotronFrequencyMax ();
-    void ApplyDtLimiters (int const step);
+    void ApplyDtLimiters (int step);
 
     /** Print main PIC parameters to stdout */
     void PrintMainPICparameters ();

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -848,6 +848,9 @@ WarpX::ReadParameters ()
         m_dt_update_interval = ablastr::utils::text::IntervalsParser(dt_interval_vec);
         if (m_dt_update_interval.isActivated()) {
             pp_warpx.query("dt_update_diagnostic_file", m_dt_update_diagnostic_file);
+            std::vector<std::string> dt_write_interval_vec = {"1"};
+            pp_warpx.queryarr("dt_update_write_interval", dt_write_interval_vec);
+            m_dt_update_write_interval = ablastr::utils::text::IntervalsParser(dt_write_interval_vec);
             WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
                 !m_const_dt.has_value(),
                 "warpx.const_dt and warpx.dt_update_interval cannot be defined simultaneously."


### PR DESCRIPTION
When `dt_update_interval` is specified, there is the option `dt_update_diagnostic_file` which turns on writing the updated time size information to a diagnostic file. This adds the new option `dt_update_write_interval` to control when the diagnostic is written out.

This PR fixes the initialization of the diagnostic file. It now creates the file and writes the header only during WarpX initialization. Also, any existing file is overwritten except when doing a restart.