### PR TITLE
Fix access to global_debye_length with tiling

### DIFF
--- a/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
+++ b/Source/Particles/Collision/BinaryCollision/BinaryCollision.H
@@ -323,12 +323,11 @@ public:
         auto *tile_products_data = tile_products.data();
 
         bool const use_global_debye_length = m_use_global_debye_length;
-        amrex::Real * global_debye_length_data = nullptr;
+        amrex::Array4<amrex::Real> global_debye_length_array;
         if (use_global_debye_length) {
             WarpX & warpx = WarpX::GetInstance();
-            amrex::MultiFab & global_debye_length = *warpx.m_fields.get(warpx::fields::FieldType::global_debye_length, lev);
-            amrex::FArrayBox & global_debye_length_fab = global_debye_length[mfi];
-            global_debye_length_data = global_debye_length_fab.dataPtr();
+            amrex::MultiFab * global_debye_length = warpx.m_fields.get(warpx::fields::FieldType::global_debye_length, lev);
+            global_debye_length_array = global_debye_length->array(mfi);
         }
 
         const amrex::Box tilebox = mfi.tilebox();
@@ -686,7 +685,7 @@ public:
 
                     amrex::Real global_lamdb = 0.;
                     if (use_global_debye_length) {
-                        global_lamdb = global_debye_length_data[i_cell];
+                        global_lamdb = global_debye_length_array(global_index);
                     }
 
                     // Call the function in order to perform collisions
@@ -1281,7 +1280,7 @@ public:
 
                     amrex::Real global_lamdb = 0.;
                     if (use_global_debye_length) {
-                        global_lamdb = global_debye_length_data[i_cell];
+                        global_lamdb = global_debye_length_array(global_index);
                     }
 
                     // Call the function in order to perform collisions


### PR DESCRIPTION
The calculation of the global Debye length during binary collisions was added in PR #5763. It was recently realized that the access was being done incorrectly, not taking into account that the MFIter loop was using tiling. With tiling, the `i_cell` index is relative to the tile and cannot be directly used to access MultiFab data. The fix is to use the `global_index` that was add in PR #6954.

Note that this error was not detected since the CI test does not use tiling.