### PR TITLE
Blank electric field option for implicit solvers

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -248,6 +248,16 @@ Overall simulation parameters
         - Numerically stable for large :math:`\Delta t` (does not require resolving the plasma period or satisfying the CFL condition for light waves).
         - Practical limits on :math:`\Delta t` set by solver efficiency, number of particle cell crossings, and physics resolution.
 
+      - **Electric field blanking:**
+        Selective components of the electric field can be prevented from evolving in time (set to zero in the implicit solve). This is useful for electrostatic approximations where transverse field components are not needed.
+
+        - ``implicit_evolve.blank_electric_field`` (3 ``integers``, default: ``0 0 0``)
+          Three integer flags (0 or 1) corresponding to the x, y, and z components of the electric field.
+          Setting a component to 1 prevents that component from evolving during the implicit solve.
+
+          - Example: ``implicit_evolve.blank_electric_field = 1 1 0`` blanks Ex and Ey, allowing only Ez to evolve (electrostatic approximation in 1D Z geometry).
+          - Example: ``implicit_evolve.blank_electric_field = 1 0 1`` blanks Ey, allowing only Ex and Ez to evolve (useful for 2D XZ and RZ geometries if only interested in ``m = 0`` modes).
+
       - **Nonlinear solvers:**
         Advancing the implicit system in time requires solving a nonlinear system. The nonlinear solver options are ``picard`` and ``newton``.
 

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -249,7 +249,7 @@ Overall simulation parameters
         - Practical limits on :math:`\Delta t` set by solver efficiency, number of particle cell crossings, and physics resolution.
 
       - **Electric field blanking:**
-        Selective components of the electric field can be prevented from evolving in time (set to zero in the implicit solve). This is useful for electrostatic approximations where transverse field components are not needed.
+        Selective components of the electric field can be prevented from evolving in time (set to zero in the implicit solve). This is useful when assumed symmetries permit neglecting those components.
 
         - ``implicit_evolve.blank_electric_field`` (3 ``integers``, default: ``0 0 0``)
           Three integer flags (0 or 1) corresponding to the x, y, and z components of the electric field.

--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -256,7 +256,7 @@ Overall simulation parameters
           Setting a component to 1 prevents that component from evolving during the implicit solve.
 
           - Example: ``implicit_evolve.blank_electric_field = 1 1 0`` blanks Ex and Ey, allowing only Ez to evolve (electrostatic approximation in 1D Z geometry).
-          - Example: ``implicit_evolve.blank_electric_field = 1 0 1`` blanks Ey, allowing only Ex and Ez to evolve (useful for 2D XZ and RZ geometries if only interested in ``m = 0`` modes).
+          - Example: ``implicit_evolve.blank_electric_field = 0 1 0`` blanks Ey, allowing only Ex and Ez to evolve (useful for 2D XZ and RZ geometries if only interested in ``m = 0`` modes).
 
       - **Nonlinear solvers:**
         Advancing the implicit system in time requires solving a nonlinear system. The nonlinear solver options are ``picard`` and ``newton``.

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
@@ -172,19 +172,6 @@ public:
         return m_blank_electric_field;
     }
 
-    /**
-     * \brief Set RHS arrays to zero for components of the electric field that are not evolved
-     */
-    void ApplyElectricFieldBlanking (WarpXSolverVec& a_RHSE) {
-        for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-            for (int dir = 0; dir < 3; ++dir) {
-                if (m_blank_electric_field[dir]) {
-                    a_RHSE.getArrayVec()[lev][dir]->setVal(0.0);
-                }
-            }
-        }
-    }
-
 protected:
 
     /**
@@ -213,6 +200,19 @@ protected:
      * \brief Flags to turn off evolving select components of the electric field
      */
     amrex::Array<bool,3> m_blank_electric_field{false, false, false};
+
+    /**
+     * \brief Set RHS arrays to zero for components of the electric field that are not evolved
+     */
+    void ApplyElectricFieldBlanking (WarpXSolverVec& a_RHSE) {
+        for (int lev = 0; lev < m_num_amr_levels; ++lev) {
+            for (int dir = 0; dir < 3; ++dir) {
+                if (m_blank_electric_field[dir]) {
+                    a_RHSE.getArrayVec()[lev][dir]->setVal(0.0);
+                }
+            }
+        }
+    }
 
 #if defined(WARPX_DIM_1D_Z)
     bool m_oneD_electrostatic_periodic = false;

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
@@ -168,6 +168,10 @@ public:
      */
     void FinishImplicitParticleUpdate (amrex::Real time, int step);
 
+    const amrex::Array<bool,3>& GetBlankElectricField () const {
+        return m_blank_electric_field;
+    }
+
 protected:
 
     /**
@@ -191,6 +195,11 @@ protected:
      * \brief Time-biasing parameter for fields used on RHS to advance system.
      */
     amrex::Real m_theta = 0.5;
+
+    /**
+     * \brief Flags to turn off evolving select components of the electric field
+     */
+    amrex::Array<bool,3> m_blank_electric_field{false,false,false};
 
     /**
      * \brief Nonlinear solver type and object
@@ -282,10 +291,12 @@ protected:
      */
     amrex::Vector<amrex::Array<amrex::MultiFab*,3>> m_mmpc_mfarrvec;
 
+    void parseBaseImplicitSolverParams ();
+
     /**
      * \brief parse nonlinear solver parameters (if one is used)
      */
-    void parseNonlinearSolverParams ( const amrex::ParmParse&  pp );
+    void parseNonlinearSolverParams (const amrex::ParmParse& pp);
 
     void SaveEoldMultifab ();
 

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
@@ -179,7 +179,7 @@ public:
         for (int lev = 0; lev < m_num_amr_levels; ++lev) {
             for (int dir = 0; dir < 3; ++dir) {
                 if (m_blank_electric_field[dir]) {
-                    a_RHSE.getArrayVec()[lev][dir]->setVal(0._rt);
+                    a_RHSE.getArrayVec()[lev][dir]->setVal(0.0);
                 }
             }
         }

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
@@ -199,7 +199,15 @@ protected:
     /**
      * \brief Flags to turn off evolving select components of the electric field
      */
-    amrex::Array<bool,3> m_blank_electric_field{false,false,false};
+    amrex::Array<bool,3> m_blank_electric_field{false, false, false};
+
+#if defined(WARPX_DIM_1D_Z)
+    bool m_oneD_electrostatic_periodic = false;
+
+    void setOneDElectrostaticPeriodicFlag ();
+
+    void Enforce1DESPeriodic (WarpXSolverVec& a_RHS);
+#endif
 
     /**
      * \brief Nonlinear solver type and object

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
@@ -172,6 +172,19 @@ public:
         return m_blank_electric_field;
     }
 
+    /**
+     * \brief Set RHS arrays to zero for components of the electric field that are not evolved
+     */
+    void ApplyElectricFieldBlanking (WarpXSolverVec& a_RHSE) {
+        for (int lev = 0; lev < m_num_amr_levels; ++lev) {
+            for (int dir = 0; dir < 3; ++dir) {
+                if (m_blank_electric_field[dir]) {
+                    a_RHSE.getArrayVec()[lev][dir]->setVal(0._rt);
+                }
+            }
+        }
+    }
+
 protected:
 
     /**

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -216,6 +216,9 @@ void ImplicitSolver::Enforce1DESPeriodic (WarpXSolverVec& a_RHS)
     // Subtract the average Jz from a_RHS to enforce zero potential
     // drop for 1D electrostatic model with periodic BCs.
 
+    // See G. Chen and L. Chacon and D. Barnes, An energy- and charge-conserving,
+    // implicit, electrostatic particle-in-cell algorithm, JCP 230 (2011).
+
     if (!m_oneD_electrostatic_periodic) { return; }
 
     const amrex::Real norm_factor = PhysConst::c2 * PhysConst::mu0 * m_theta * m_dt;

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -1326,7 +1326,7 @@ void ImplicitSolver::PrintBaseImplicitSolverParameters () const
 {
     amrex::Print() << "Blank x-electric field:              " << (m_blank_electric_field[0] ? "true":"false") << "\n";
     amrex::Print() << "Blank y-electric field:              " << (m_blank_electric_field[1] ? "true":"false") << "\n";
-    amrex::Print() << "Blank z-electric field:              " << (m_blank_electric_field[2] ? "true":"false") << "\n"
+    amrex::Print() << "Blank z-electric field:              " << (m_blank_electric_field[2] ? "true":"false") << "\n";
     amrex::Print() << "max particle iterations:             " << m_max_particle_iterations << "\n";
     amrex::Print() << "particle relative tolerance:         " << m_particle_tolerance << "\n";
     amrex::Print() << "use particle suborbits:              " << (m_particle_suborbits ? "true":"false") << "\n";

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -190,6 +190,59 @@ Array<LinOpBCType,AMREX_SPACEDIM> ImplicitSolver::convertFieldBCToLinOpBC (const
     return lbc;
 }
 
+#if defined(WARPX_DIM_1D_Z)
+void ImplicitSolver::setOneDElectrostaticPeriodicFlag ()
+{
+    // Check if doing electrostatic (must not evolve out-of-plane E)
+    if (m_blank_electric_field[0] && m_blank_electric_field[1]) {
+
+        auto const& fbc_lo = m_WarpX->GetFieldBoundaryLo();
+        auto const& fbc_hi = m_WarpX->GetFieldBoundaryHi();
+
+        // Check if using periodic boundary conditions
+        if (fbc_lo[0] == FieldBoundaryType::Periodic &&
+            fbc_hi[0] == FieldBoundaryType::Periodic)
+        {
+            m_oneD_electrostatic_periodic = true;
+        }
+
+    }
+}
+
+void ImplicitSolver::Enforce1DESPeriodic (WarpXSolverVec& a_RHS)
+{
+    BL_PROFILE("ImplicitSolver::Enforce1DESPeriodic()");
+
+    // Subtract the average Jz from a_RHS to enforce zero potential
+    // drop for 1D electrostatic model with periodic BCs.
+
+    if (!m_oneD_electrostatic_periodic) { return; }
+
+    const amrex::Real norm_factor = PhysConst::c2 * PhysConst::mu0 * m_theta * m_dt;
+
+    using warpx::fields::FieldType;
+    using ablastr::fields::Direction;
+    for (int lev = 0; lev < m_num_amr_levels; ++lev) {
+
+        const amrex::Geometry& geom = m_WarpX->Geom(lev);
+        amrex::Real const *dx = geom.CellSize();
+        const amrex::RealBox& prob_domain = geom.ProbDomain();
+        const amrex::Real Lz = prob_domain.hi(0) - prob_domain.lo(0);
+
+        // Compute the spatial average of Jz
+        const amrex::MultiFab& Jz = *m_WarpX->m_fields.get(FieldType::current_fp, Direction{2}, lev);
+        const bool local_sum = false;
+        const amrex::Real sumJz_global = Jz.sum(0,amrex::IntVect(0),local_sum);
+        const amrex::Real meanJz = sumJz_global*dx[0]/Lz;
+
+        // RHSz += cvac^2*m_theta*dt*mu0*sum(Jg^{n+1/2})*dz/Lz
+        amrex::MultiFab& RHSz = *a_RHS.getArrayVec()[lev][2];
+        RHSz.plus(norm_factor*meanJz,0,RHSz.nComp());
+    }
+
+}
+#endif
+
 void ImplicitSolver::CumulateJ ()
 {
 
@@ -605,6 +658,10 @@ void ImplicitSolver::parseBaseImplicitSolverParams ()
             m_blank_electric_field[dir] = (tmp[dir] != 0);
         }
     }
+
+#if defined(WARPX_DIM_1D_Z)
+    setOneDElectrostaticPeriodicFlag();
+#endif
 
     parseNonlinearSolverParams(pp);
 }

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.cpp
@@ -358,6 +358,7 @@ void ImplicitSolver::ApplyMassMatrices (
             const amrex::IntVect ncomp_zy = m_ncomp_zy;
             const amrex::IntVect ncomp_zz = m_ncomp_zz;
 
+            if (!m_blank_electric_field[0]) {
             amrex::ParallelFor(
             outbx, ncomps, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
@@ -425,6 +426,8 @@ void ImplicitSolver::ApplyMassMatrices (
                 if (use_baseline) { out_arr_x(i,j,k,n) += baseline_arr_x(i,j,k,n); }
                 out_arr_x(i,j,k,n) += a_scale * (Sxx_d_in_x + Sxy_d_in_y + Sxz_d_in_z);
             });
+            }
+            if (!m_blank_electric_field[1]) {
             amrex::ParallelFor(
             outby, ncomps, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
@@ -492,6 +495,8 @@ void ImplicitSolver::ApplyMassMatrices (
                 if (use_baseline) { out_arr_y(i,j,k,n) += baseline_arr_y(i,j,k,n); }
                 out_arr_y(i,j,k,n) += a_scale * (Syx_d_in_x + Syy_d_in_y + Syz_d_in_z);
             });
+            }
+            if (!m_blank_electric_field[2]) {
             amrex::ParallelFor(
             outbz, ncomps, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
@@ -559,6 +564,7 @@ void ImplicitSolver::ApplyMassMatrices (
                 if (use_baseline) { out_arr_z(i,j,k,n) += baseline_arr_z(i,j,k,n); }
                 out_arr_z(i,j,k,n) += a_scale * (Szx_d_in_x + Szy_d_in_y + Szz_d_in_z);
             });
+            }
         }
     }
 }
@@ -589,7 +595,21 @@ void ImplicitSolver::ComputeJfromMassMatrices (const bool  a_J_from_MM_only)
 }
 
 
-void ImplicitSolver::parseNonlinearSolverParams ( const amrex::ParmParse&  pp )
+void ImplicitSolver::parseBaseImplicitSolverParams ()
+{
+    const amrex::ParmParse pp("implicit_evolve");
+
+    amrex::Vector<int> tmp(3);
+    if (pp.queryarr("blank_electric_field", tmp)) {
+        for (int dir = 0; dir < 3; ++dir) {
+            m_blank_electric_field[dir] = (tmp[dir] != 0);
+        }
+    }
+
+    parseNonlinearSolverParams(pp);
+}
+
+void ImplicitSolver::parseNonlinearSolverParams (const amrex::ParmParse& pp)
 {
 
     pp.get("nonlinear_solver", m_nlsolver_type);
@@ -1304,6 +1324,9 @@ void ImplicitSolver::FinishMassMatrices ()
 
 void ImplicitSolver::PrintBaseImplicitSolverParameters () const
 {
+    amrex::Print() << "Blank x-electric field:              " << (m_blank_electric_field[0] ? "true":"false") << "\n";
+    amrex::Print() << "Blank y-electric field:              " << (m_blank_electric_field[1] ? "true":"false") << "\n";
+    amrex::Print() << "Blank z-electric field:              " << (m_blank_electric_field[2] ? "true":"false") << "\n"
     amrex::Print() << "max particle iterations:             " << m_max_particle_iterations << "\n";
     amrex::Print() << "particle relative tolerance:         " << m_particle_tolerance << "\n";
     amrex::Print() << "use particle suborbits:              " << (m_particle_suborbits ? "true":"false") << "\n";

--- a/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
@@ -141,4 +141,9 @@ void SemiImplicitEM::ComputeRHS (WarpXSolverVec&  a_RHS,
         }
     }
 
+#if defined(WARPX_DIM_1D_Z)
+    // RHS += cvac^2*m_theta*dt*mu0*sum(Jg^{n+1/2})*dz/Lz
+    Enforce1DESPeriodic(a_RHS);
+#endif
+
 }

--- a/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
@@ -132,14 +132,7 @@ void SemiImplicitEM::ComputeRHS (WarpXSolverVec&  a_RHS,
     // RHS = cvac^2*0.5*dt*( curl(Bg^{n+1/2}) - mu0*Jg^{n+1/2} )
     m_WarpX->ImplicitComputeRHSE(0.5_rt*m_dt, a_RHS);
 
-    // Apply blanking to electric field RHS vector
-    for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-        for (int dir = 0; dir < 3; ++dir) {
-            if (m_blank_electric_field[dir]) {
-                a_RHS.getArrayVec()[lev][dir]->setVal(0._rt);
-            }
-        }
-    }
+    ApplyElectricFieldBlanking(a_RHS);
 
 #if defined(WARPX_DIM_1D_Z)
     // RHS += cvac^2*m_theta*dt*mu0*sum(Jg^{n+1/2})*dz/Lz

--- a/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
@@ -31,9 +31,7 @@ void SemiImplicitEM::Define (WarpX*  a_WarpX, bool  a_from_restart)
     m_E.Copy(FieldType::Efield_fp);
     m_Eold.Copy(a_from_restart ? FieldType::E_old : FieldType::Efield_fp, FieldType::None, true);
 
-    // Parse implicit solver parameters
-    const amrex::ParmParse pp("implicit_evolve");
-    parseNonlinearSolverParams(pp);
+    parseBaseImplicitSolverParams();
 
     // Define the nonlinear solver
     m_nlsolver->Define(m_E, this);
@@ -114,23 +112,33 @@ int SemiImplicitEM::OneStep (amrex::Real  start_time,
     return exit_status;
 }
 
-void SemiImplicitEM::ComputeRHS ( WarpXSolverVec&  a_RHS,
-                            const WarpXSolverVec&  a_E,
-                                  amrex::Real      start_time,
-                                  int              a_nl_iter,
-                                  bool             a_from_jacobian )
+void SemiImplicitEM::ComputeRHS (WarpXSolverVec&  a_RHS,
+                           const WarpXSolverVec&  a_E,
+                                 amrex::Real      start_time,
+                                 int              a_nl_iter,
+                                 bool             a_from_jacobian)
 {
     BL_PROFILE("SemiImplicitEM::ComputeRHS()");
 
     // Update WarpX-owned Efield_fp using current state of Eg from
     // the nonlinear solver at time n+theta
     const amrex::Real half_time = start_time + 0.5_rt*m_dt;
-    m_WarpX->SetElectricFieldAndApplyBCs( a_E, half_time );
+    m_WarpX->SetElectricFieldAndApplyBCs(a_E, half_time);
 
     // Update particle positions and velocities using the current state
     // of Eg and Bg. Deposit current density at time n+1/2
-    PreRHSOp( half_time, a_nl_iter, a_from_jacobian );
+    PreRHSOp(half_time, a_nl_iter, a_from_jacobian);
 
     // RHS = cvac^2*0.5*dt*( curl(Bg^{n+1/2}) - mu0*Jg^{n+1/2} )
     m_WarpX->ImplicitComputeRHSE(0.5_rt*m_dt, a_RHS);
+
+    // Apply blanking to electric field RHS vector
+    for (int lev = 0; lev < m_num_amr_levels; ++lev) {
+        for (int dir = 0; dir < 3; ++dir) {
+            if (m_blank_electric_field[dir]) {
+                a_RHS.getArrayVec()[lev][dir]->setVal(0._rt);
+            }
+        }
+    }
+
 }

--- a/Source/FieldSolver/ImplicitSolvers/StrangImplicitSpectralEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/StrangImplicitSpectralEM.cpp
@@ -29,9 +29,7 @@ void StrangImplicitSpectralEM::Define (WarpX* const a_WarpX, bool a_from_restart
     m_E.Copy(FieldType::Efield_fp);
     m_Eold.Copy(a_from_restart ? FieldType::E_old : FieldType::Efield_fp, FieldType::None, true);
 
-    // Parse nonlinear solver parameters
-    const amrex::ParmParse pp_implicit_evolve("implicit_evolve");
-    parseNonlinearSolverParams( pp_implicit_evolve );
+    parseBaseImplicitSolverParams();
 
     // Define the nonlinear solver
     m_nlsolver->Define(m_E, this);

--- a/Source/FieldSolver/ImplicitSolvers/StrangImplicitSpectralEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/StrangImplicitSpectralEM.cpp
@@ -125,6 +125,8 @@ void StrangImplicitSpectralEM::ComputeRHS ( WarpXSolverVec& a_RHS,
     amrex::Real constexpr coeff = PhysConst::c2 * PhysConst::mu0;
     a_RHS.scale(-coeff * 0.5_rt*m_dt);
 
+    ApplyElectricFieldBlanking(a_RHS);
+
 }
 
 void StrangImplicitSpectralEM::UpdateWarpXFields (WarpXSolverVec const & a_E,

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.H
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.H
@@ -84,6 +84,11 @@ public:
                       int              a_nl_iter,
                       bool             a_from_jacobian ) override;
 
+#if defined(WARPX_DIM_1D_Z)
+    void Enforce1DESPeriodic (WarpXSolverVec&  a_RHS,
+                              amrex::Real      a_theta_dt);
+#endif
+
     // This parameter is used for the time-step fraction in the PC for implicit
     // treatment of light waves in the curl-curl MLMG solver.
     // This function should return zero if light waves are not treated implicitly

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.H
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.H
@@ -84,11 +84,6 @@ public:
                       int              a_nl_iter,
                       bool             a_from_jacobian ) override;
 
-#if defined(WARPX_DIM_1D_Z)
-    void Enforce1DESPeriodic (WarpXSolverVec&  a_RHS,
-                              amrex::Real      a_theta_dt);
-#endif
-
     // This parameter is used for the time-step fraction in the PC for implicit
     // treatment of light waves in the curl-curl MLMG solver.
     // This function should return zero if light waves are not treated implicitly

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
@@ -181,14 +181,6 @@ void ThetaImplicitEM::UpdateWarpXFields (const WarpXSolverVec&  a_E,
     const amrex::Real theta_time = start_time + m_theta*m_dt;
     m_WarpX->SetElectricFieldAndApplyBCs(a_E, theta_time);
 
-    // Apply blanking to the electric field vector
-    for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-        ablastr::fields::VectorField Efp = m_WarpX->m_fields.get_alldirs(FieldType::Efield_fp, lev);
-        for (int dir = 0; dir < 3; ++dir) {
-            if (m_blank_electric_field[dir]) { Efp[dir]->setVal(0._rt); }
-        }
-    }
-
     // Update Bfield_fp owned by WarpX
     ablastr::fields::MultiLevelVectorField const& B_old = m_WarpX->m_fields.get_mr_levels_alldirs(FieldType::B_old, 0);
     m_WarpX->UpdateMagneticFieldAndApplyBCs(B_old, m_theta*m_dt, start_time);

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
@@ -156,14 +156,7 @@ void ThetaImplicitEM::ComputeRHS (WarpXSolverVec&  a_RHS,
     // RHS = cvac^2*m_theta*dt*( curl(Bg^{n+theta}) - mu0*Jg^{n+1/2} )
     m_WarpX->ImplicitComputeRHSE(m_theta*m_dt, a_RHS);
 
-    // Apply blanking to electric field RHS vector
-    for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-        for (int dir = 0; dir < 3; ++dir) {
-            if (m_blank_electric_field[dir]) {
-                a_RHS.getArrayVec()[lev][dir]->setVal(0._rt);
-            }
-        }
-    }
+    ApplyElectricFieldBlanking(a_RHS);
 
 #if defined(WARPX_DIM_1D_Z)
     // RHS += cvac^2*m_theta*dt*mu0*sum(Jg^{n+1/2})*dz/Lz

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
@@ -165,7 +165,58 @@ void ThetaImplicitEM::ComputeRHS (WarpXSolverVec&  a_RHS,
         }
     }
 
+#if defined(WARPX_DIM_1D_Z)
+    // RHS += cvac^2*m_theta*dt*mu0*sum(Jg^{n+1/2})*dz/Lz
+    Enforce1DESPeriodic(a_RHS, m_theta*m_dt);
+#endif
+
 }
+
+#if defined(WARPX_DIM_1D_Z)
+void ThetaImplicitEM::Enforce1DESPeriodic ( WarpXSolverVec&  a_RHS,
+                                      const amrex::Real      a_theta_dt )
+{
+    BL_PROFILE("ImplicitSolver::Enforce1DESPeriodic()");
+
+    // Subtract the average Jz from the RHS to enforce zero potential
+    // drop in 1D electrostatic with periodic BCs.
+
+    // Check if doing electrostatic (must not evolve out-of-plane E)
+    if (!m_blank_electric_field[0] || !m_blank_electric_field[1]) { return; }
+
+    // Check if using periodic BCs
+    auto const& fbc_lo = m_WarpX->GetFieldBoundaryLo();
+    auto const& fbc_hi = m_WarpX->GetFieldBoundaryHi();
+    if (fbc_lo[0] != FieldBoundaryType::Periodic ||
+        fbc_hi[0] != FieldBoundaryType::Periodic)
+    {
+        return;
+    }
+
+    const amrex::Real norm_factor = PhysConst::c * PhysConst::c * PhysConst::mu0 * a_theta_dt;
+
+    using warpx::fields::FieldType;
+    using ablastr::fields::Direction;
+    for (int lev = 0; lev < m_num_amr_levels; ++lev) {
+
+        const amrex::Geometry& geom = m_WarpX->Geom(lev);
+        amrex::Real const *dx = geom.CellSize();
+        const amrex::RealBox& prob_domain = geom.ProbDomain();
+        const amrex::Real Lz = prob_domain.hi(0) - prob_domain.lo(0);
+
+        // Compute the spatial average of Jz
+        const amrex::MultiFab& Jz = *m_WarpX->m_fields.get(FieldType::current_fp, Direction{2}, lev);
+        const bool local_sum = false;
+        const amrex::Real sumJz_global = Jz.sum(0,amrex::IntVect(0),local_sum);
+        const amrex::Real meanJz = sumJz_global*dx[0]/Lz;
+
+        // RHSz += cvac^2*m_theta*dt*mu0*sum(Jg^{n+1/2})*dz/Lz
+        amrex::MultiFab& RHSz = *a_RHS.getArrayVec()[lev][2];
+        RHSz.plus(norm_factor*meanJz,0,RHSz.nComp());
+    }
+
+}
+#endif
 
 void ThetaImplicitEM::UpdateWarpXFields (const WarpXSolverVec&  a_E,
                                          amrex::Real start_time)

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
@@ -52,8 +52,7 @@ void ThetaImplicitEM::Define (WarpX* const a_WarpX, bool a_from_restart)
         m_theta>=0.5 && m_theta<=1.0,
         "theta parameter for theta implicit time solver must be between 0.5 and 1.0");
 
-    // Parse nonlinear solver parameters
-    parseNonlinearSolverParams( pp );
+    parseBaseImplicitSolverParams();
 
     // Define the nonlinear solver
     m_nlsolver->Define(m_E, this);
@@ -137,40 +136,57 @@ int ThetaImplicitEM::OneStep (const amrex::Real  start_time,
     return exit_status;
 }
 
-void ThetaImplicitEM::ComputeRHS ( WarpXSolverVec&  a_RHS,
-                             const WarpXSolverVec&  a_E,
-                                   amrex::Real      start_time,
-                                   int              a_nl_iter,
-                                   bool             a_from_jacobian )
+void ThetaImplicitEM::ComputeRHS (WarpXSolverVec&  a_RHS,
+                            const WarpXSolverVec&  a_E,
+                                  amrex::Real      start_time,
+                                  int              a_nl_iter,
+                                  bool             a_from_jacobian)
 {
     BL_PROFILE("ThetaImplicitEM::ComputeRHS()");
 
     // Update WarpX-owned Efield_fp and Bfield_fp using current state of
     // Eg from the nonlinear solver at time n+theta
-    UpdateWarpXFields( a_E, start_time );
+    UpdateWarpXFields(a_E, start_time);
 
     // Update particle positions and velocities using the current state
     // of Eg and Bg. Deposit current density at time n+1/2
     const amrex::Real theta_time = start_time + m_theta*m_dt;
-    PreRHSOp( theta_time, a_nl_iter, a_from_jacobian );
+    PreRHSOp(theta_time, a_nl_iter, a_from_jacobian);
 
     // RHS = cvac^2*m_theta*dt*( curl(Bg^{n+theta}) - mu0*Jg^{n+1/2} )
-    m_WarpX->ImplicitComputeRHSE( m_theta*m_dt, a_RHS);
+    m_WarpX->ImplicitComputeRHSE(m_theta*m_dt, a_RHS);
+
+    // Apply blanking to electric field RHS vector
+    for (int lev = 0; lev < m_num_amr_levels; ++lev) {
+        for (int dir = 0; dir < 3; ++dir) {
+            if (m_blank_electric_field[dir]) {
+                a_RHS.getArrayVec()[lev][dir]->setVal(0._rt);
+            }
+        }
+    }
 
 }
 
-void ThetaImplicitEM::UpdateWarpXFields ( const WarpXSolverVec&  a_E,
-                                          amrex::Real start_time )
+void ThetaImplicitEM::UpdateWarpXFields (const WarpXSolverVec&  a_E,
+                                         amrex::Real start_time)
 {
     BL_PROFILE("ThetaImplicitEM::UpdateWarpXFields()");
 
     // Update Efield_fp owned by WarpX
     const amrex::Real theta_time = start_time + m_theta*m_dt;
-    m_WarpX->SetElectricFieldAndApplyBCs( a_E, theta_time );
+    m_WarpX->SetElectricFieldAndApplyBCs(a_E, theta_time);
+
+    // Apply blanking to the electric field vector
+    for (int lev = 0; lev < m_num_amr_levels; ++lev) {
+        ablastr::fields::VectorField Efp = m_WarpX->m_fields.get_alldirs(FieldType::Efield_fp, lev);
+        for (int dir = 0; dir < 3; ++dir) {
+            if (m_blank_electric_field[dir]) { Efp[dir]->setVal(0._rt); }
+        }
+    }
 
     // Update Bfield_fp owned by WarpX
     ablastr::fields::MultiLevelVectorField const& B_old = m_WarpX->m_fields.get_mr_levels_alldirs(FieldType::B_old, 0);
-    m_WarpX->UpdateMagneticFieldAndApplyBCs( B_old, m_theta*m_dt, start_time );
+    m_WarpX->UpdateMagneticFieldAndApplyBCs(B_old, m_theta*m_dt, start_time);
 
 }
 

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
@@ -167,56 +167,10 @@ void ThetaImplicitEM::ComputeRHS (WarpXSolverVec&  a_RHS,
 
 #if defined(WARPX_DIM_1D_Z)
     // RHS += cvac^2*m_theta*dt*mu0*sum(Jg^{n+1/2})*dz/Lz
-    Enforce1DESPeriodic(a_RHS, m_theta*m_dt);
+    Enforce1DESPeriodic(a_RHS);
 #endif
 
 }
-
-#if defined(WARPX_DIM_1D_Z)
-void ThetaImplicitEM::Enforce1DESPeriodic ( WarpXSolverVec&  a_RHS,
-                                      const amrex::Real      a_theta_dt )
-{
-    BL_PROFILE("ImplicitSolver::Enforce1DESPeriodic()");
-
-    // Subtract the average Jz from the RHS to enforce zero potential
-    // drop in 1D electrostatic with periodic BCs.
-
-    // Check if doing electrostatic (must not evolve out-of-plane E)
-    if (!m_blank_electric_field[0] || !m_blank_electric_field[1]) { return; }
-
-    // Check if using periodic BCs
-    auto const& fbc_lo = m_WarpX->GetFieldBoundaryLo();
-    auto const& fbc_hi = m_WarpX->GetFieldBoundaryHi();
-    if (fbc_lo[0] != FieldBoundaryType::Periodic ||
-        fbc_hi[0] != FieldBoundaryType::Periodic)
-    {
-        return;
-    }
-
-    const amrex::Real norm_factor = PhysConst::c * PhysConst::c * PhysConst::mu0 * a_theta_dt;
-
-    using warpx::fields::FieldType;
-    using ablastr::fields::Direction;
-    for (int lev = 0; lev < m_num_amr_levels; ++lev) {
-
-        const amrex::Geometry& geom = m_WarpX->Geom(lev);
-        amrex::Real const *dx = geom.CellSize();
-        const amrex::RealBox& prob_domain = geom.ProbDomain();
-        const amrex::Real Lz = prob_domain.hi(0) - prob_domain.lo(0);
-
-        // Compute the spatial average of Jz
-        const amrex::MultiFab& Jz = *m_WarpX->m_fields.get(FieldType::current_fp, Direction{2}, lev);
-        const bool local_sum = false;
-        const amrex::Real sumJz_global = Jz.sum(0,amrex::IntVect(0),local_sum);
-        const amrex::Real meanJz = sumJz_global*dx[0]/Lz;
-
-        // RHSz += cvac^2*m_theta*dt*mu0*sum(Jg^{n+1/2})*dz/Lz
-        amrex::MultiFab& RHSz = *a_RHS.getArrayVec()[lev][2];
-        RHSz.plus(norm_factor*meanJz,0,RHSz.nComp());
-    }
-
-}
-#endif
 
 void ThetaImplicitEM::UpdateWarpXFields (const WarpXSolverVec&  a_E,
                                          amrex::Real start_time)

--- a/Source/NonlinearSolvers/CurlCurlMLMGPC.H
+++ b/Source/NonlinearSolvers/CurlCurlMLMGPC.H
@@ -375,9 +375,10 @@ void CurlCurlMLMGPC<T,Ops>::Apply (T& a_x, const T& a_b)
         // preconditioner is a fixed linear operator, as required by GMRES.
         m_solver->solve({&solution}, {&rhs}, m_rtol, m_atol);
 
-        const bool blank_Ey = m_ops->GetBlankElectricField()[1];
-        if (blank_Ey) {
-            x_mfarrvec[n][1]->setVal(0.0);
+        // Apply E-field blanking to the solution vector
+        const amrex::Array<bool,3>& blank_Efield = m_ops->GetBlankElectricField();
+        for (dir = 0; dir < 3; ++dir) {
+            if (blank_Efield[dir]) { x_mfarrvec[n][dir]->setVal(0.0); }
         }
     }
 }

--- a/Source/NonlinearSolvers/CurlCurlMLMGPC.H
+++ b/Source/NonlinearSolvers/CurlCurlMLMGPC.H
@@ -377,7 +377,7 @@ void CurlCurlMLMGPC<T,Ops>::Apply (T& a_x, const T& a_b)
 
         // Apply E-field blanking to the solution vector
         const amrex::Array<bool,3>& blank_Efield = m_ops->GetBlankElectricField();
-        for (dir = 0; dir < 3; ++dir) {
+        for (int dir = 0; dir < 3; ++dir) {
             if (blank_Efield[dir]) { x_mfarrvec[n][dir]->setVal(0.0); }
         }
     }

--- a/Source/NonlinearSolvers/CurlCurlMLMGPC.H
+++ b/Source/NonlinearSolvers/CurlCurlMLMGPC.H
@@ -374,6 +374,11 @@ void CurlCurlMLMGPC<T,Ops>::Apply (T& a_x, const T& a_b)
         // number of iterations (m_max_iter V-cycles), for any right-hand side, so that the
         // preconditioner is a fixed linear operator, as required by GMRES.
         m_solver->solve({&solution}, {&rhs}, m_rtol, m_atol);
+
+        const bool blank_Ey = m_ops->GetBlankElectricField()[1];
+        if (blank_Ey) {
+            x_mfarrvec[n][1]->setVal(0.0);
+        }
     }
 }
 

--- a/Source/NonlinearSolvers/MatrixPC.H
+++ b/Source/NonlinearSolvers/MatrixPC.H
@@ -385,6 +385,8 @@ int MatrixPC<T,Ops>::Assemble (const T& a_U)
         Gpu::Buffer<int> nnz_actual_d({nnz_max});
         auto* nnz_actual_ptr = nnz_actual_d.data();
 
+        const amrex::Array<bool,3>& blank_Efield = m_ops->GetBlankElectricField();
+
         for (int dir = 0; dir < 3; dir++) {
 
             for (amrex::MFIter mfi(*dofs_mfarrvec[lev][dir]); mfi.isValid(); ++mfi) {
@@ -456,6 +458,7 @@ int MatrixPC<T,Ops>::Assemble (const T& a_U)
 
                         int icol = num_nz_ptr[ridx_l]; //NOLINT (misc-const-correctness)
 
+                        if (!blank_Efield[dir]) {
 #if defined(WARPX_DIM_1D_Z)
                         // dir = 0: xhat\cdot[\nabla\times\nabla E] = -[d2/dx2]Ex
                         // dir = 1: yhat\cdot[\nabla\times\nabla E] = -[d2/dx2]Ey
@@ -624,6 +627,7 @@ int MatrixPC<T,Ops>::Assemble (const T& a_U)
                             // DIM_RZ:
                             // dir = 0: d/dr(dEz/dz) at Er(i,j) with Er centered in r and nodal in z
                             // dir = 2: 1/r*d/dr[r*dEr/dz] at Ez(i,j) with Ez centered in z and nodal in r
+                            if (!blank_Efield[tdir]) {
 #if defined(WARPX_DIM_RZ)
                             const amrex::Real geom_m = (dir == 2 && i != 0 ? 1.0_rt - 0.5_rt / i_real : 1.0_rt);
                             const amrex::Real geom_p = (dir == 2 && i != 0 ? 1.0_rt + 0.5_rt / i_real : 1.0_rt);
@@ -666,6 +670,7 @@ int MatrixPC<T,Ops>::Assemble (const T& a_U)
                                                                               &a_ij_ptr[ridx_l*nnz_max],
                                                                               nnz_max, icol );
                                 if (!flag) { Gpu::Atomic::Max(nnz_actual_ptr, icol); }
+                            }
                             }
                         } else if (dir==1) {
                             for (int jdir = 0; jdir <= 2; jdir+=2) {
@@ -734,6 +739,7 @@ int MatrixPC<T,Ops>::Assemble (const T& a_U)
                         for (int ctr_dir = -1; ctr_dir <= 0; ctr_dir++) {
                             for (int ctr_tdir = -1; ctr_tdir <= 0; ctr_tdir++) {
                                 for (int tdir = 1; tdir <= 2; tdir++) {
+                                    if (blank_Efield[dvec[tdir]]) { continue; }
                                     auto iv = ic; iv[dvec[0]] += (ctr_dir+1); iv[dvec[tdir]] += ctr_tdir;
                                     const auto sign = std::copysign(1,ctr_dir) * std::copysign(1,ctr_tdir);
                                     const int cidx_g_rhs = dof_arrays[tdir](iv,1);
@@ -748,6 +754,7 @@ int MatrixPC<T,Ops>::Assemble (const T& a_U)
                             }
                         }
 #endif
+                        }
                         num_nz_ptr[ridx_l] = icol;
                     });
                 }
@@ -762,7 +769,7 @@ int MatrixPC<T,Ops>::Assemble (const T& a_U)
                 // Similarly for Jy/Ey (m_bcoefs[dir=1]) and Jz/Ez (m_bcoefs[dir=2]).
                 // The mapping to the components is given by:
                 // mm_comp = i0 + MM_width[0] + MM_comp[0]*(j0 + MM_width[1]) + (MM_comp[0] + MM_comp[1])*(k0 + MM_width[2])
-                if (m_include_mass_matrices) {
+                if (m_include_mass_matrices && !blank_Efield[dir]) {
 
                     auto sigma_ii_arr = (*m_bcoefs)[lev][dir]->const_array(mfi);
                     amrex::GpuArray<int,3> MM_ncomp = {1,1,1};


### PR DESCRIPTION
This is the first of two PRs adding the capability to not evolve ("blank") user-specified components of the electric field when using the electromagnetic implicit solvers. This PR introduces the basic functionality, while a follow-on PR will exploit the blanking options to improve the efficiency of the implicit solve.

In 1D geometry, this feature enables the electromagnetic implicit solvers to be used as the energy-conserving electrostatic model described in https://doi.org/10.1016/j.jcp.2011.05.031, in which the electric field is advanced via Ampère's law. This approach has been used in the following works:

- [10.1103/PhysRevE.104.055205](https://link.aps.org/doi/10.1103/PhysRevE.104.055205)
- https://doi.org/10.1103/pr7n-48wl
- https://doi.org/10.1103/zwjx-jbxl

In 2D XZ and RZ geometries, this feature can be used to disable evolution of the out-of-plane y-component of the electric field. This is suitable for problems with symmetries for which only in-plane currents are relevant (e.g. m=0 modes in a Z-pinch).

When symmetries permit field blanking, there is potential to significantly improve the efficiency of the implicit solvers. For example, when the y-component of the electric field can be ignored, the number of required mass matrices is reduced from 9 to 4: only `sigma_xx`, `sigma_xz`, `sigma_zx`, and `sigma_zz` are needed.

TODO list:

- [ ] Add CI test. 