### PR TITLE
WarnManager.cpp: simplify an expression using std::format (C++20 feature)

### DIFF
--- a/Source/ablastr/warn_manager/WarnManager.cpp
+++ b/Source/ablastr/warn_manager/WarnManager.cpp
@@ -17,6 +17,7 @@
 #include <AMReX_ParmParse.H>
 
 #include <algorithm>
+#include <format>
 #include <sstream>
 #include <vector>
 
@@ -70,12 +71,8 @@ void WarnManager::RecordWarning(
 
         amrex::Warning(
             ablastr::utils::TextMsg::Warn(
-                "["
-                + std::string(abl_msg_logger::PriorityToString(msg_priority))
-                + "]["
-                + topic
-                + "] "
-                + text));
+                std::format("[{}][{}] {}",
+                    abl_msg_logger::PriorityToString(msg_priority), topic, text)));
     }
 
 #ifdef AMREX_USE_OMP


### PR DESCRIPTION
C++20 has introduced a [text formatting library](see https://en.cppreference.com/cpp/utility/format) that greatly simplifies certain expressions.

This PR exemplifies this new feature by changing  the expression : 
```C++20
                "["
                + std::string(abl_msg_logger::PriorityToString(msg_priority))
                + "]["
                + topic
                + "] "
                + text));
```
into
```C++20
                std::format("[{}][{}] {}",
                    abl_msg_logger::PriorityToString(msg_priority), topic, text)));
```

I've verified that, after this substitution, the warning logger produces a text message identical to the one of the test presented here: https://warpx.readthedocs.io/en/latest/developers/warning_logger.html .

If no issues are reported, I would like to expand the usage of `std::format` in WarpX.