### PR TITLE
Cleanup: remove unneeded argument for `Preconditioner::Update`

### DIFF
--- a/Source/FieldSolver/ImplicitSolvers/DarwinLinearFieldOperator.H
+++ b/Source/FieldSolver/ImplicitSolvers/DarwinLinearFieldOperator.H
@@ -69,10 +69,7 @@ public:
     }
 
     inline
-    void updatePreCondMat ( const WarpXSolverVec& a_X ) override
-    {
-        amrex::ignore_unused(a_X);
-    }
+    void updatePreCondMat () override { }
 
     inline
     void getPCMatrix ( amrex::Gpu::DeviceVector<int>& a_ridx_g,

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -313,8 +313,7 @@ public:
     // return the number of AMR levels
     [[nodiscard]] auto numAMRLevels () const { return m_num_amr_levels; }
 
-    // return DOFs object pointer. Static, since the DOF object is shared by
-    // every solver vector.
+    // return DOFs object pointer.
     [[nodiscard]] inline static const auto& getDOFsObject () { return m_dofs; }
 
 private:

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -313,7 +313,7 @@ public:
     // return the number of AMR levels
     [[nodiscard]] auto numAMRLevels () const { return m_num_amr_levels; }
 
-    // return DOFs object pointer.
+    // return DOFs object pointer
     [[nodiscard]] inline static const auto& getDOFsObject () { return m_dofs; }
 
 private:

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -313,8 +313,9 @@ public:
     // return the number of AMR levels
     [[nodiscard]] auto numAMRLevels () const { return m_num_amr_levels; }
 
-    // return DOFs object pointer
-    [[nodiscard]] inline const auto& getDOFsObject () const { return m_dofs; }
+    // return DOFs object pointer. Static, since the DOF object is shared by
+    // every solver vector, so callers do not need an instance to reach it.
+    [[nodiscard]] inline static const auto& getDOFsObject () { return m_dofs; }
 
 private:
 

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -314,7 +314,7 @@ public:
     [[nodiscard]] auto numAMRLevels () const { return m_num_amr_levels; }
 
     // return DOFs object pointer. Static, since the DOF object is shared by
-    // every solver vector, so callers do not need an instance to reach it.
+    // every solver vector.
     [[nodiscard]] inline static const auto& getDOFsObject () { return m_dofs; }
 
 private:

--- a/Source/NonlinearSolvers/CurlCurlMLMGPC.H
+++ b/Source/NonlinearSolvers/CurlCurlMLMGPC.H
@@ -81,7 +81,7 @@ class CurlCurlMLMGPC : public Preconditioner<T,Ops>
         /**
          * \brief Update the preconditioner
          */
-        void Update (const T& a_U) override;
+        void Update () override;
 
         /**
          * \brief Apply (solve) the preconditioner given a RHS
@@ -247,7 +247,7 @@ void CurlCurlMLMGPC<T,Ops>::Define ( const T& a_U,
 }
 
 template <class T, class Ops>
-void CurlCurlMLMGPC<T,Ops>::Update (const T& a_U)
+void CurlCurlMLMGPC<T,Ops>::Update ()
 {
     BL_PROFILE("CurlCurlMLMGPC::Update()");
     using namespace amrex;
@@ -255,9 +255,6 @@ void CurlCurlMLMGPC<T,Ops>::Update (const T& a_U)
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
         IsDefined(),
         "CurlCurlMLMGPC::Update() called on undefined object" );
-
-    // a_U is not needed for a linear operator
-    amrex::ignore_unused(a_U);
 
     // set the alpha coefficient for the curl-curl op
     const RT thetaDt = m_ops->GetThetaForPC()*this->m_dt;

--- a/Source/NonlinearSolvers/JacobiPC.H
+++ b/Source/NonlinearSolvers/JacobiPC.H
@@ -276,7 +276,7 @@ void JacobiPC<T,Ops>::Define ( const T& a_U,
     m_num_amr_levels = m_ops->numAMRLevels();
     m_bcoefs = m_ops->GetMassMatricesCoeff();
 
-    // Save the grid layout of the solver vector. This is then used in 
+    // Save the grid layout of the solver vector. This is then used in
     // `Update` to allocate temporary MultiFabs
     const auto& u_mfarrvec = a_U.getArrayVec();
     m_grids.resize(m_num_amr_levels);

--- a/Source/NonlinearSolvers/JacobiPC.H
+++ b/Source/NonlinearSolvers/JacobiPC.H
@@ -276,9 +276,8 @@ void JacobiPC<T,Ops>::Define ( const T& a_U,
     m_num_amr_levels = m_ops->numAMRLevels();
     m_bcoefs = m_ops->GetMassMatricesCoeff();
 
-    // Cache the grid layout of the solver vector. The scratch MultiFabs are
-    // allocated lazily in Update(), once the mass-matrix coefficients are
-    // known, but their layout is already fixed here.
+    // Save the grid layout of the solver vector. This is then used in 
+    // `Update` to allocate temporary MultiFabs
     const auto& u_mfarrvec = a_U.getArrayVec();
     m_grids.resize(m_num_amr_levels);
     m_dmap.resize(m_num_amr_levels);

--- a/Source/NonlinearSolvers/JacobiPC.H
+++ b/Source/NonlinearSolvers/JacobiPC.H
@@ -72,7 +72,7 @@ class JacobiPC : public Preconditioner<T,Ops>
 
         void Define (const T&, Ops*) override;
 
-        void Update (const T& a_U) override;
+        void Update () override;
 
         /**
          * \brief Solve (I + M) x = b via damped Jacobi iteration
@@ -109,6 +109,13 @@ class JacobiPC : public Preconditioner<T,Ops>
         Ops* m_ops = nullptr;
 
         int m_num_amr_levels = 0;
+
+        /**
+         * \brief Grid layout of the solver vector, cached in Define() so that
+         *  Update() can allocate its scratch without being handed a vector.
+         */
+        amrex::Vector<amrex::Array<amrex::BoxArray,3>> m_grids;
+        amrex::Vector<amrex::Array<amrex::DistributionMapping,3>> m_dmap;
 
         const amrex::Vector<amrex::Array<amrex::MultiFab*,3>>* m_bcoefs = nullptr;
 
@@ -269,13 +276,26 @@ void JacobiPC<T,Ops>::Define ( const T& a_U,
     m_num_amr_levels = m_ops->numAMRLevels();
     m_bcoefs = m_ops->GetMassMatricesCoeff();
 
+    // Cache the grid layout of the solver vector. The scratch MultiFabs are
+    // allocated lazily in Update(), once the mass-matrix coefficients are
+    // known, but their layout is already fixed here.
+    const auto& u_mfarrvec = a_U.getArrayVec();
+    m_grids.resize(m_num_amr_levels);
+    m_dmap.resize(m_num_amr_levels);
+    for (int n = 0; n < m_num_amr_levels; n++) {
+        for (int dim = 0; dim < 3; dim++) {
+            m_grids[n][dim] = u_mfarrvec[n][dim]->boxArray();
+            m_dmap[n][dim]  = u_mfarrvec[n][dim]->DistributionMap();
+        }
+    }
+
     readParameters();
 
     m_is_defined = true;
 }
 
 template <class T, class Ops>
-void JacobiPC<T,Ops>::Update (const T& a_U)
+void JacobiPC<T,Ops>::Update ()
 {
     BL_PROFILE("JacobiPC::Update()");
     using namespace amrex;
@@ -285,7 +305,6 @@ void JacobiPC<T,Ops>::Update (const T& a_U)
         "JacobiPC::Update() called on undefined object" );
 
     if (m_bcoefs != nullptr && !m_work_defined) {
-        auto& u_mfarrvec = a_U.getArrayVec();
         m_work.resize(m_num_amr_levels);
         m_x_ghost.resize(m_num_amr_levels);
 
@@ -307,15 +326,10 @@ void JacobiPC<T,Ops>::Update (const T& a_U)
         const amrex::IntVect nghost(m_stencil_width);
         for (int n = 0; n < m_num_amr_levels; n++) {
             for (int dim = 0; dim < 3; dim++) {
-                m_work[n][dim].define(
-                    u_mfarrvec[n][dim]->boxArray(),
-                    u_mfarrvec[n][dim]->DistributionMap(),
-                    1, 0);
+                m_work[n][dim].define(m_grids[n][dim], m_dmap[n][dim], 1, 0);
                 if (m_has_offdiag) {
-                    m_x_ghost[n][dim].define(
-                        u_mfarrvec[n][dim]->boxArray(),
-                        u_mfarrvec[n][dim]->DistributionMap(),
-                        1, nghost);
+                    m_x_ghost[n][dim].define(m_grids[n][dim], m_dmap[n][dim],
+                                             1, nghost);
                 }
             }
         }

--- a/Source/NonlinearSolvers/JacobianFunctionMF.H
+++ b/Source/NonlinearSolvers/JacobianFunctionMF.H
@@ -52,9 +52,9 @@ class JacobianFunctionMF : public LinearFunction<T,Ops>
     }
 
     inline
-    void updatePreCondMat ( const T&  a_X ) override
+    void updatePreCondMat () override
     {
-        if (m_usePreCond) { m_preCond->Update(a_X); }
+        if (m_usePreCond) { m_preCond->Update(); }
     }
 
     inline

--- a/Source/NonlinearSolvers/LinearFunction.H
+++ b/Source/NonlinearSolvers/LinearFunction.H
@@ -58,7 +58,7 @@ class LinearFunction
         virtual void precond ( T& a_U, const T& a_X ) = 0;
 
         //! update preconditioner
-        virtual void updatePreCondMat ( const T&  a_X ) = 0;
+        virtual void updatePreCondMat () = 0;
 
         //! get sparse matrix representation of preconditioner
         virtual void getPCMatrix( amrex::Gpu::DeviceVector<int>&,

--- a/Source/NonlinearSolvers/MatrixPC.H
+++ b/Source/NonlinearSolvers/MatrixPC.H
@@ -345,8 +345,7 @@ int MatrixPC<T,Ops>::Assemble ()
                        << "alpha = " << alpha << "\n";
     }
 
-    // The DOF object is shared by every solver vector, so it can be reached
-    // without one.
+    // The DOF object is shared by every solver vector.
     const auto& dofs_mfarrvec = T::getDOFsObject()->m_array;
 
     m_r_indices_g.clear();

--- a/Source/NonlinearSolvers/MatrixPC.H
+++ b/Source/NonlinearSolvers/MatrixPC.H
@@ -21,6 +21,8 @@
 #include <AMReX_Vector.H>
 #include <AMReX_MultiFab.H>
 
+#include <utility>
+
 namespace MatrixPCUtils
 {
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -104,7 +106,7 @@ class MatrixPC : public Preconditioner<T,Ops>
         /**
          * \brief Update the preconditioner
          */
-        void Update (const T& a_U) override;
+        void Update () override;
 
         /**
          * \brief Assemble the matrix
@@ -114,7 +116,7 @@ class MatrixPC : public Preconditioner<T,Ops>
          * non-zero elements (return value is difference in current number
          * of nonzero elements and the desired number).
          */
-        int Assemble (const T& a_U);
+        int Assemble ();
 
         /**
          * \brief Apply (solve) the preconditioner given a RHS
@@ -185,6 +187,15 @@ class MatrixPC : public Preconditioner<T,Ops>
 
         int m_ndofs_l = 0;
         int m_ndofs_g = 0;
+
+        /**
+         * \brief The DOF numbering object of the solver vector, cached in
+         *  Define(). The solver vector class owns a single instance of it that
+         *  lives until AMReX finalization, so a non-owning pointer is safe.
+         */
+        using DOFsPtr = decltype(std::declval<const T&>().getDOFsObject().get());
+        DOFsPtr m_dofs = nullptr;
+
         bool m_pc_diag_only = false;
         int m_pc_mat_nnz = 1;
         bool m_include_mass_matrices = false;
@@ -247,9 +258,6 @@ void MatrixPC<T,Ops>::Define ( const T& a_U,
     // read preconditioner parameters
     readParameters();
 
-    // a_U is not needed
-    amrex::ignore_unused(a_U);
-
     // Set number of AMR levels and create geometry, grids, and
     // distribution mapping vectors.
     m_num_amr_levels = m_ops->numAMRLevels();
@@ -260,6 +268,13 @@ void MatrixPC<T,Ops>::Define ( const T& a_U,
     for (int n = 0; n < m_num_amr_levels; n++) {
         m_geom[n] = m_ops->GetGeometry(n);
     }
+
+    // Cache the DOF numbering object, so that Assemble() can read the local
+    // and global DOF index maps without being handed a vector.
+    m_dofs = a_U.getDOFsObject().get();
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+        (m_dofs != nullptr),
+        "MatrixPC::Define(): the solver vector has no DOF object" );
 
     m_ndofs_l = a_U.nDOF_local();
     m_ndofs_g = a_U.nDOF_global();
@@ -282,7 +297,7 @@ void MatrixPC<T,Ops>::Define ( const T& a_U,
 }
 
 template <class T, class Ops>
-void MatrixPC<T,Ops>::Update (const T& a_U)
+void MatrixPC<T,Ops>::Update ()
 {
     BL_PROFILE("MatrixPC::Update()");
     using namespace amrex;
@@ -293,7 +308,7 @@ void MatrixPC<T,Ops>::Update (const T& a_U)
 
     while(true) {
 
-        auto nnz_diff = Assemble(a_U);
+        auto nnz_diff = Assemble();
         AMREX_ALWAYS_ASSERT(nnz_diff >= 0);
         if (nnz_diff) {
 
@@ -315,7 +330,7 @@ void MatrixPC<T,Ops>::Update (const T& a_U)
 }
 
 template <class T, class Ops>
-int MatrixPC<T,Ops>::Assemble (const T& a_U)
+int MatrixPC<T,Ops>::Assemble ()
 {
     // Assemble the sparse matrix representation of the preconditioner
     //      A = curl (alpha * curl []) + M
@@ -347,11 +362,10 @@ int MatrixPC<T,Ops>::Assemble (const T& a_U)
                        << "alpha = " << alpha << "\n";
     }
 
-    // Get DOF object from a_U
-    const auto& dofs_obj = a_U.getDOFsObject();
-    const auto& dofs_mfarrvec = dofs_obj->m_array;
-    AMREX_ALWAYS_ASSERT(m_ndofs_l == dofs_obj->m_nDoFs_l);
-    AMREX_ALWAYS_ASSERT(m_ndofs_g == dofs_obj->m_nDoFs_g);
+    // DOF object cached in Define()
+    const auto& dofs_mfarrvec = m_dofs->m_array;
+    AMREX_ALWAYS_ASSERT(m_ndofs_l == m_dofs->m_nDoFs_l);
+    AMREX_ALWAYS_ASSERT(m_ndofs_g == m_dofs->m_nDoFs_g);
 
     m_r_indices_g.clear();
     m_num_nz.clear();

--- a/Source/NonlinearSolvers/MatrixPC.H
+++ b/Source/NonlinearSolvers/MatrixPC.H
@@ -20,10 +20,6 @@
 #include <AMReX_Array.H>
 #include <AMReX_Vector.H>
 #include <AMReX_MultiFab.H>
-#include <AMReX_iMultiFab.H>
-
-#include <array>
-#include <memory>
 
 namespace MatrixPCUtils
 {
@@ -190,14 +186,6 @@ class MatrixPC : public Preconditioner<T,Ops>
         int m_ndofs_l = 0;
         int m_ndofs_g = 0;
 
-        /**
-         * \brief The per-level, per-direction DOF index maps of the solver
-         *  vector, cached in Define(). The solver vector class owns a single
-         *  DOF object that lives until AMReX finalization, so a non-owning
-         *  pointer is safe.
-         */
-        const amrex::Vector<std::array<std::unique_ptr<amrex::iMultiFab>,3>>* m_dofs_array = nullptr;
-
         bool m_pc_diag_only = false;
         int m_pc_mat_nnz = 1;
         bool m_include_mass_matrices = false;
@@ -273,11 +261,6 @@ void MatrixPC<T,Ops>::Define ( const T& a_U,
 
     m_ndofs_l = a_U.nDOF_local();
     m_ndofs_g = a_U.nDOF_global();
-
-    // Cache the DOF index maps, so that Assemble() can read them without being
-    // handed a vector. The nDOF queries above already assert that the solver
-    // vector's DOF object exists.
-    m_dofs_array = &a_U.getDOFsObject()->m_array;
 
     auto n_rows = size_t(m_ndofs_l);
     auto n_cols = size_t(m_pc_mat_nnz) * size_t(m_ndofs_l);
@@ -362,8 +345,9 @@ int MatrixPC<T,Ops>::Assemble ()
                        << "alpha = " << alpha << "\n";
     }
 
-    // DOF index maps cached in Define()
-    const auto& dofs_mfarrvec = *m_dofs_array;
+    // The DOF object is shared by every solver vector, so it can be reached
+    // without one.
+    const auto& dofs_mfarrvec = T::getDOFsObject()->m_array;
 
     m_r_indices_g.clear();
     m_num_nz.clear();

--- a/Source/NonlinearSolvers/MatrixPC.H
+++ b/Source/NonlinearSolvers/MatrixPC.H
@@ -20,8 +20,10 @@
 #include <AMReX_Array.H>
 #include <AMReX_Vector.H>
 #include <AMReX_MultiFab.H>
+#include <AMReX_iMultiFab.H>
 
-#include <utility>
+#include <array>
+#include <memory>
 
 namespace MatrixPCUtils
 {
@@ -189,12 +191,12 @@ class MatrixPC : public Preconditioner<T,Ops>
         int m_ndofs_g = 0;
 
         /**
-         * \brief The DOF numbering object of the solver vector, cached in
-         *  Define(). The solver vector class owns a single instance of it that
-         *  lives until AMReX finalization, so a non-owning pointer is safe.
+         * \brief The per-level, per-direction DOF index maps of the solver
+         *  vector, cached in Define(). The solver vector class owns a single
+         *  DOF object that lives until AMReX finalization, so a non-owning
+         *  pointer is safe.
          */
-        using DOFsPtr = decltype(std::declval<const T&>().getDOFsObject().get());
-        DOFsPtr m_dofs = nullptr;
+        const amrex::Vector<std::array<std::unique_ptr<amrex::iMultiFab>,3>>* m_dofs_array = nullptr;
 
         bool m_pc_diag_only = false;
         int m_pc_mat_nnz = 1;
@@ -269,15 +271,13 @@ void MatrixPC<T,Ops>::Define ( const T& a_U,
         m_geom[n] = m_ops->GetGeometry(n);
     }
 
-    // Cache the DOF numbering object, so that Assemble() can read the local
-    // and global DOF index maps without being handed a vector.
-    m_dofs = a_U.getDOFsObject().get();
-    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
-        (m_dofs != nullptr),
-        "MatrixPC::Define(): the solver vector has no DOF object" );
-
     m_ndofs_l = a_U.nDOF_local();
     m_ndofs_g = a_U.nDOF_global();
+
+    // Cache the DOF index maps, so that Assemble() can read them without being
+    // handed a vector. The nDOF queries above already assert that the solver
+    // vector's DOF object exists.
+    m_dofs_array = &a_U.getDOFsObject()->m_array;
 
     auto n_rows = size_t(m_ndofs_l);
     auto n_cols = size_t(m_pc_mat_nnz) * size_t(m_ndofs_l);
@@ -362,10 +362,8 @@ int MatrixPC<T,Ops>::Assemble ()
                        << "alpha = " << alpha << "\n";
     }
 
-    // DOF object cached in Define()
-    const auto& dofs_mfarrvec = m_dofs->m_array;
-    AMREX_ALWAYS_ASSERT(m_ndofs_l == m_dofs->m_nDoFs_l);
-    AMREX_ALWAYS_ASSERT(m_ndofs_g == m_dofs->m_nDoFs_g);
+    // DOF index maps cached in Define()
+    const auto& dofs_mfarrvec = *m_dofs_array;
 
     m_r_indices_g.clear();
     m_num_nz.clear();

--- a/Source/NonlinearSolvers/NewtonSolver.H
+++ b/Source/NonlinearSolvers/NewtonSolver.H
@@ -388,7 +388,7 @@ void NewtonSolver<Vec,Ops>::Solve (Vec&         a_U,
         m_ops->PreLinearSolve();
         m_linear_function->setBaseSolution(a_U);
         m_linear_function->setBaseRHS(m_R);
-        m_linear_function->updatePreCondMat(a_U);
+        m_linear_function->updatePreCondMat();
 
         // Solve linear system for Newton step [Jac]*dU = F
         m_dU.zero();

--- a/Source/NonlinearSolvers/Preconditioner.H
+++ b/Source/NonlinearSolvers/Preconditioner.H
@@ -57,12 +57,6 @@ class Preconditioner
 
         /**
          * \brief Update the preconditioner
-         *
-         *  This takes no argument: preconditioners draw the state they need
-         *  from the Ops object and the grid layout they cached in Define(),
-         *  plus the time and time step size set via CurTime()/CurTimeStep().
-         *  Should a preconditioner ever need to re-linearize about the
-         *  current iterate, pass it in here.
          */
         virtual void Update () = 0;
 

--- a/Source/NonlinearSolvers/Preconditioner.H
+++ b/Source/NonlinearSolvers/Preconditioner.H
@@ -57,8 +57,14 @@ class Preconditioner
 
         /**
          * \brief Update the preconditioner
+         *
+         *  This takes no argument: preconditioners draw the state they need
+         *  from the Ops object and the grid layout they cached in Define(),
+         *  plus the time and time step size set via CurTime()/CurTimeStep().
+         *  Should a preconditioner ever need to re-linearize about the
+         *  current iterate, pass it in here.
          */
-        virtual void Update ( const T& a_U ) = 0;
+        virtual void Update () = 0;
 
         /**
          * \brief Apply (solve) the preconditioner given a RHS

--- a/Source/NonlinearSolvers/WarpX_PETSc.cpp
+++ b/Source/NonlinearSolvers/WarpX_PETSc.cpp
@@ -106,7 +106,7 @@ PetscErrorCode RHSFunction( SNES a_solver, Vec a_U, Vec a_F, void* ctxt)
     VecAXPBY(a_F, 1.0, -1.0, a_U);
 
     if (!context->m_fd_jac_comput) {
-        dynamic_cast<JacobianFunctionMF<VecType,TIType>*>(context->m_linop.get())->updatePreCondMat(context->m_U);
+        dynamic_cast<JacobianFunctionMF<VecType,TIType>*>(context->m_linop.get())->updatePreCondMat();
     }
     PetscFunctionReturn(PETSC_SUCCESS);
 }


### PR DESCRIPTION
I found the interface of `Preconditioner::Update` confusing, because we pass `a_X` (a `WarpXSolverVec`) to it, but in practice the information from `a_X` is never really used. 

(Instead `Update` uses other objects, stored internally in the `Preconditioner` object, to update the equation it needs to solve.)

This PR aims to make the interface less confusing by simply not passing `a_X` to `Update`.