### PR TITLE
Fix particle boundary conditions in curvilinear geometries

### DIFF
--- a/Source/Particles/ParticleBoundaries_K.H
+++ b/Source/Particles/ParticleBoundaries_K.H
@@ -100,10 +100,12 @@ namespace ApplyParticleBoundaries {
      *        is changed appropriately.
      *        Note that periodic boundaries are handled in AMReX code.
      *
-     * \param x, xmin, xmax: particle x position, location of x boundary
-     * \param y, ymin, ymax: particle y position, location of y boundary (3D only)
-     * \param z, zmin, zmax: particle z position, location of z boundary
-     * \param ux, uy, uz: particle momenta
+     * \param x, y, z: particle position. For RZ and RCYLINDER, these are the mapped
+     *                  coordinates (r, theta, z); for RSPHERE, they are (r, theta, phi).
+     * \param gridmin, gridmax: locations of the lower and upper boundaries in mapped space
+     * \param ux, uy, uz: particle momentum. For RZ and RCYLINDER, these are the mapped
+     *                    components (u_r, u_theta, u_z); for RSPHERE, they are
+     *                    (u_r, u_theta, u_phi).
      * \param particle_lost: output, flags whether the particle was lost
      * \param boundaries: object with boundary condition settings
     */
@@ -159,43 +161,9 @@ namespace ApplyParticleBoundaries {
             change_sign_uz = true;
         }
 
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-        // Note that the reflection of the position does "r = 2*rmax - r", but this is only approximate.
-        // The exact calculation requires the position at the start of the step.
-        if (change_sign_ux && change_sign_uy) {
-            ux = -ux;
-            uy = -uy;
-        } else if (change_sign_ux) {
-            // Reflect only ur
-            // Note that y is theta
-            amrex::Real ur = ux*std::cos(y) + uy*std::sin(y);
-            const amrex::Real ut = -ux*std::sin(y) + uy*std::cos(y);
-            ur = -ur;
-            ux = ur*std::cos(y) - ut*std::sin(y);
-            uy = ur*std::sin(y) + ut*std::cos(y);
-        }
-        if (change_sign_uz) { uz = -uz; }
-#elif defined(WARPX_DIM_RSPHERE)
-        // "y" is theta
-        // "z" is phi
-        const amrex::Real costheta = std::cos(y);
-        const amrex::Real sintheta = std::sin(y);
-        const amrex::Real cosphi = std::cos(z);
-        const amrex::Real sinphi = std::sin(z);
-        amrex::Real ur = +ux*costheta*sinphi + uy*sintheta*sinphi + uz*cosphi;
-        amrex::Real ut = -ux*sintheta + uy*costheta;
-        amrex::Real up = -ux*costheta*cosphi - uy*sintheta*cosphi + uz*sinphi;
-        if (change_sign_ux) { ur = -ur; }
-        if (change_sign_uy) { ut = -ut; }
-        if (change_sign_uz) { up = -up; }
-        ux = sinphi*costheta*ur - sintheta*ut - cosphi*costheta*up;
-        uy = sinphi*sintheta*ur + costheta*ut - cosphi*sintheta*up;
-        uz = cosphi*ur + sinphi*up;
-#else
         if (change_sign_ux) { ux = -ux; }
         if (change_sign_uy) { uy = -uy; }
         if (change_sign_uz) { uz = -uz; }
-#endif
     }
 
 }

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -3008,19 +3008,17 @@ WarpXParticleContainer::ApplyBoundaryConditions () {
 
                     bool particle_lost = false;
 
-                    bool const outside_domain =
+                    bool outside_domain = false;
 #ifndef WARPX_DIM_1D_Z
-                                             (x < gridmin.x || x > gridmax.x)
-#else
-                                             false
+                    outside_domain = (x < gridmin.x || x > gridmax.x);
 #endif
 #ifdef WARPX_DIM_3D
-                                             || (y < gridmin.y || y > gridmax.y)
+                    outside_domain |= (y < gridmin.y || y > gridmax.y);
 #endif
 #ifdef WARPX_ZINDEX
-                                             || (z < gridmin.z || z > gridmax.z)
+                    outside_domain |= (z < gridmin.z || z > gridmax.z);
 #endif
-                                             ;
+
 
                     if (outside_domain) {
 #if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -3008,9 +3008,11 @@ WarpXParticleContainer::ApplyBoundaryConditions () {
 
                     bool particle_lost = false;
 
-                    bool const outside_domain = false
+                    bool const outside_domain =
 #ifndef WARPX_DIM_1D_Z
                                              || x < gridmin.x || x > gridmax.x
+#else
+                                             false
 #endif
 #ifdef WARPX_DIM_3D
                                              || y < gridmin.y || y > gridmax.y

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -3010,15 +3010,15 @@ WarpXParticleContainer::ApplyBoundaryConditions () {
 
                     bool const outside_domain =
 #ifndef WARPX_DIM_1D_Z
-                                             || x < gridmin.x || x > gridmax.x
+                                             (x < gridmin.x || x > gridmax.x)
 #else
                                              false
 #endif
 #ifdef WARPX_DIM_3D
-                                             || y < gridmin.y || y > gridmax.y
+                                             || (y < gridmin.y || y > gridmax.y)
 #endif
 #ifdef WARPX_ZINDEX
-                                             || z < gridmin.z || z > gridmax.z
+                                             || (z < gridmin.z || z > gridmax.z)
 #endif
                                              ;
 

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2953,7 +2953,7 @@ WarpXParticleContainer::particlePostLocate(ParticleType& p,
 }
 
 void
-WarpXParticleContainer::ApplyBoundaryConditions (){
+WarpXParticleContainer::ApplyBoundaryConditions () {
     ABLASTR_PROFILE("WarpXParticleContainer::ApplyBoundaryConditions()");
 
     // Periodic boundaries are handled in AMReX code
@@ -3007,9 +3007,29 @@ WarpXParticleContainer::ApplyBoundaryConditions (){
                     // and for RSPHERE (r, theta, phi).
 
                     bool particle_lost = false;
-                    ApplyParticleBoundaries::apply_boundaries(x, y, z, gridmin, gridmax,
-                                                              ux[i], uy[i], uz[i], particle_lost,
-                                                              boundary_conditions, engine);
+
+                    bool const outside_domain = false
+#ifndef WARPX_DIM_1D_Z
+                                             || x < gridmin.x || x > gridmax.x
+#endif
+#ifdef WARPX_DIM_3D
+                                             || y < gridmin.y || y > gridmax.y
+#endif
+#ifdef WARPX_ZINDEX
+                                             || z < gridmin.z || z > gridmax.z
+#endif
+                                             ;
+
+                    if (outside_domain) {
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+                        transform_momentum_to_curvilinear(ux[i], uy[i], uz[i], y, z);
+#endif
+                        ApplyParticleBoundaries::apply_boundaries(x, y, z, gridmin, gridmax,
+                                                                  ux[i], uy[i], uz[i], particle_lost,
+                                                                  boundary_conditions, engine);
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
+                        transform_momentum_to_cartesian(ux[i], uy[i], uz[i], y, z);
+#endif
 
                     if (particle_lost) {
                         pidw.make_invalid();

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -3030,6 +3030,7 @@ WarpXParticleContainer::ApplyBoundaryConditions () {
 #if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
                         transform_momentum_to_cartesian(ux[i], uy[i], uz[i], y, z);
 #endif
+                    }
 
                     if (particle_lost) {
                         pidw.make_invalid();

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -84,53 +84,45 @@ using namespace amrex;
 
 namespace
 {
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void transform_momentum_to_curvilinear (
         amrex::ParticleReal& ux, amrex::ParticleReal& uy,
-        amrex::ParticleReal const theta)
+        [[maybe_unused]] amrex::ParticleReal& uz,
+        amrex::ParticleReal const theta,
+        [[maybe_unused]] amrex::ParticleReal const phi)
     {
         amrex::ParticleReal const ux_save = ux;
         amrex::ParticleReal const uy_save = uy;
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
         ux = ux_save*std::cos(theta) + uy_save*std::sin(theta);
         uy = -ux_save*std::sin(theta) + uy_save*std::cos(theta);
-    }
-
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    void transform_momentum_to_cartesian (
-        amrex::ParticleReal& ux, amrex::ParticleReal& uy,
-        amrex::ParticleReal const theta)
-    {
-        amrex::ParticleReal const ux_save = ux;
-        amrex::ParticleReal const uy_save = uy;
-        ux = ux_save*std::cos(theta) - uy_save*std::sin(theta);
-        uy = ux_save*std::sin(theta) + uy_save*std::cos(theta);
-    }
 #elif defined(WARPX_DIM_RSPHERE)
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    void transform_momentum_to_curvilinear (
-        amrex::ParticleReal& ux, amrex::ParticleReal& uy, amrex::ParticleReal& uz,
-        amrex::ParticleReal const theta, amrex::ParticleReal const phi)
-    {
-        amrex::ParticleReal const ux_save = ux;
-        amrex::ParticleReal const uy_save = uy;
         amrex::ParticleReal const uz_save = uz;
         ux = +ux_save*std::cos(theta)*std::cos(phi) + uy_save*std::sin(theta)*std::cos(phi) + uz_save*std::sin(phi);
         uy = -ux_save*std::sin(theta) + uy_save*std::cos(theta);
         uz = -ux_save*std::cos(theta)*std::sin(phi) - uy_save*std::sin(theta)*std::sin(phi) + uz_save*std::cos(phi);
+#endif
     }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void transform_momentum_to_cartesian (
-        amrex::ParticleReal& ux, amrex::ParticleReal& uy, amrex::ParticleReal& uz,
-        amrex::ParticleReal const theta, amrex::ParticleReal const phi)
+        amrex::ParticleReal& ux, amrex::ParticleReal& uy,
+        [[maybe_unused]] amrex::ParticleReal& uz,
+        amrex::ParticleReal const theta,
+        [[maybe_unused]] amrex::ParticleReal const phi)
     {
         amrex::ParticleReal const ux_save = ux;
         amrex::ParticleReal const uy_save = uy;
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
+        ux = ux_save*std::cos(theta) - uy_save*std::sin(theta);
+        uy = ux_save*std::sin(theta) + uy_save*std::cos(theta);
+#elif defined(WARPX_DIM_RSPHERE)
         amrex::ParticleReal const uz_save = uz;
         ux = +ux_save*std::cos(theta)*std::cos(phi) - uy_save*std::sin(theta) - uz_save*std::cos(theta)*std::sin(phi);
         uy = +ux_save*std::sin(theta)*std::cos(phi) + uy_save*std::cos(theta) - uz_save*std::sin(theta)*std::sin(phi);
         uz = +ux_save*std::sin(phi) + uz_save*std::cos(phi);
+#endif
     }
 #endif
 }
@@ -2810,50 +2802,43 @@ WarpXParticleContainer::TransformMomentumToCurvilinear ([[maybe_unused]]bool for
             auto& attribs = pti.GetAttribs();
             amrex::ParticleReal * AMREX_RESTRICT ux = attribs[PIdx::ux].dataPtr();
             amrex::ParticleReal * AMREX_RESTRICT uy = attribs[PIdx::uy].dataPtr();
-            amrex::ParticleReal * AMREX_RESTRICT theta_data = attribs[PIdx::theta].dataPtr();
-
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
-
-            // Loop over the particles, rotating their momenta by theta
-            amrex::ParallelFor(pti.numParticles(),
-                [=] AMREX_GPU_DEVICE (long i) {
-                    if (forward) {
-                        transform_momentum_to_curvilinear(ux[i], uy[i], theta_data[i]);
-                    } else {
-                        transform_momentum_to_cartesian(ux[i], uy[i], theta_data[i]);
-                    }
-                }
-            );
-
-#elif defined(WARPX_DIM_RSPHERE)
-
             amrex::ParticleReal * AMREX_RESTRICT uz = attribs[PIdx::uz].dataPtr();
+            amrex::ParticleReal * AMREX_RESTRICT theta_data = attribs[PIdx::theta].dataPtr();
+#if defined(WARPX_DIM_RSPHERE)
             amrex::ParticleReal * AMREX_RESTRICT phi_data = attribs[PIdx::phi].dataPtr();
+#endif
 
             if (forward) {
 
-                // Loop over the particles, rotating to theta = phi = 0
+                // Loop over the particles, rotating to the curvilinear frame
                 amrex::ParallelFor(pti.numParticles(),
                     [=] AMREX_GPU_DEVICE (long i) {
                         const amrex::ParticleReal theta = theta_data[i];
+#if defined(WARPX_DIM_RSPHERE)
                         const amrex::ParticleReal phi = phi_data[i];
+#else
+                        const amrex::ParticleReal phi = 0._prt;
+#endif
                         transform_momentum_to_curvilinear(ux[i], uy[i], uz[i], theta, phi);
                     }
                 );
 
             } else {
 
-                // Loop over the particles, rotating from zero to theta and phi
+                // Loop over the particles, rotating to the Cartesian frame
                 amrex::ParallelFor(pti.numParticles(),
                     [=] AMREX_GPU_DEVICE (long i) {
                         const amrex::ParticleReal theta = theta_data[i];
+#if defined(WARPX_DIM_RSPHERE)
                         const amrex::ParticleReal phi = phi_data[i];
+#else
+                        const amrex::ParticleReal phi = 0._prt;
+#endif
                         transform_momentum_to_cartesian(ux[i], uy[i], uz[i], theta, phi);
                     }
                 );
 
             }
-#endif
         }
     }
     }

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -2953,7 +2953,8 @@ WarpXParticleContainer::particlePostLocate(ParticleType& p,
 }
 
 void
-WarpXParticleContainer::ApplyBoundaryConditions () {
+WarpXParticleContainer::ApplyBoundaryConditions ()
+{
     ABLASTR_PROFILE("WarpXParticleContainer::ApplyBoundaryConditions()");
 
     // Periodic boundaries are handled in AMReX code

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -82,6 +82,59 @@
 
 using namespace amrex;
 
+namespace
+{
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void transform_momentum_to_curvilinear (
+        amrex::ParticleReal& ux, amrex::ParticleReal& uy,
+        amrex::ParticleReal const theta)
+    {
+        amrex::ParticleReal const ux_save = ux;
+        amrex::ParticleReal const uy_save = uy;
+        ux = ux_save*std::cos(theta) + uy_save*std::sin(theta);
+        uy = -ux_save*std::sin(theta) + uy_save*std::cos(theta);
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void transform_momentum_to_cartesian (
+        amrex::ParticleReal& ux, amrex::ParticleReal& uy,
+        amrex::ParticleReal const theta)
+    {
+        amrex::ParticleReal const ux_save = ux;
+        amrex::ParticleReal const uy_save = uy;
+        ux = ux_save*std::cos(theta) - uy_save*std::sin(theta);
+        uy = ux_save*std::sin(theta) + uy_save*std::cos(theta);
+    }
+#elif defined(WARPX_DIM_RSPHERE)
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void transform_momentum_to_curvilinear (
+        amrex::ParticleReal& ux, amrex::ParticleReal& uy, amrex::ParticleReal& uz,
+        amrex::ParticleReal const theta, amrex::ParticleReal const phi)
+    {
+        amrex::ParticleReal const ux_save = ux;
+        amrex::ParticleReal const uy_save = uy;
+        amrex::ParticleReal const uz_save = uz;
+        ux = +ux_save*std::cos(theta)*std::cos(phi) + uy_save*std::sin(theta)*std::cos(phi) + uz_save*std::sin(phi);
+        uy = -ux_save*std::sin(theta) + uy_save*std::cos(theta);
+        uz = -ux_save*std::cos(theta)*std::sin(phi) - uy_save*std::sin(theta)*std::sin(phi) + uz_save*std::cos(phi);
+    }
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    void transform_momentum_to_cartesian (
+        amrex::ParticleReal& ux, amrex::ParticleReal& uy, amrex::ParticleReal& uz,
+        amrex::ParticleReal const theta, amrex::ParticleReal const phi)
+    {
+        amrex::ParticleReal const ux_save = ux;
+        amrex::ParticleReal const uy_save = uy;
+        amrex::ParticleReal const uz_save = uz;
+        ux = +ux_save*std::cos(theta)*std::cos(phi) - uy_save*std::sin(theta) - uz_save*std::cos(theta)*std::sin(phi);
+        uy = +ux_save*std::sin(theta)*std::cos(phi) + uy_save*std::cos(theta) - uz_save*std::sin(theta)*std::sin(phi);
+        uz = +ux_save*std::sin(phi) + uz_save*std::cos(phi);
+    }
+#endif
+}
+
 WarpXParIter::WarpXParIter (ContainerType& pc, int level)
     : amrex::ParIterSoA<PIdx::nattribs, 0, amrex::PolymorphicArenaAllocator>(pc, level,
              MFItInfo().SetDynamic(WarpX::do_dynamic_scheduling))
@@ -2761,15 +2814,14 @@ WarpXParticleContainer::TransformMomentumToCurvilinear ([[maybe_unused]]bool for
 
 #if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER)
 
-            // Loop over the particles, rotating their velocities by theta
+            // Loop over the particles, rotating their momenta by theta
             amrex::ParallelFor(pti.numParticles(),
                 [=] AMREX_GPU_DEVICE (long i) {
-                    const amrex::ParticleReal theta_sign = forward ? -1._prt : +1._prt;
-                    const amrex::ParticleReal theta = theta_sign*theta_data[i];
-                    const amrex::ParticleReal uxsave = ux[i];
-                    const amrex::ParticleReal uysave = uy[i];
-                    ux[i] = uxsave*std::cos(theta) - uysave*std::sin(theta);
-                    uy[i] = uxsave*std::sin(theta) + uysave*std::cos(theta);
+                    if (forward) {
+                        transform_momentum_to_curvilinear(ux[i], uy[i], theta_data[i]);
+                    } else {
+                        transform_momentum_to_cartesian(ux[i], uy[i], theta_data[i]);
+                    }
                 }
             );
 
@@ -2785,12 +2837,7 @@ WarpXParticleContainer::TransformMomentumToCurvilinear ([[maybe_unused]]bool for
                     [=] AMREX_GPU_DEVICE (long i) {
                         const amrex::ParticleReal theta = theta_data[i];
                         const amrex::ParticleReal phi = phi_data[i];
-                        const amrex::ParticleReal uxsave = ux[i];
-                        const amrex::ParticleReal uysave = uy[i];
-                        const amrex::ParticleReal uzsave = uz[i];
-                        ux[i] = +uxsave*std::cos(theta)*std::cos(phi) + uysave*std::sin(theta)*std::cos(phi) + uzsave*std::sin(phi);
-                        uy[i] = -uxsave*std::sin(theta) + uysave*std::cos(theta);
-                        uz[i] = -uxsave*std::cos(theta)*std::sin(phi) - uysave*std::sin(theta)*std::sin(phi) + uzsave*std::cos(phi);
+                        transform_momentum_to_curvilinear(ux[i], uy[i], uz[i], theta, phi);
                     }
                 );
 
@@ -2801,12 +2848,7 @@ WarpXParticleContainer::TransformMomentumToCurvilinear ([[maybe_unused]]bool for
                     [=] AMREX_GPU_DEVICE (long i) {
                         const amrex::ParticleReal theta = theta_data[i];
                         const amrex::ParticleReal phi = phi_data[i];
-                        const amrex::ParticleReal uxsave = ux[i];
-                        const amrex::ParticleReal uysave = uy[i];
-                        const amrex::ParticleReal uzsave = uz[i];
-                        ux[i] = +uxsave*std::cos(theta)*std::cos(phi) - uysave*std::sin(theta) - uzsave*std::cos(theta)*std::sin(phi);
-                        uy[i] = +uxsave*std::sin(theta)*std::cos(phi) + uysave*std::cos(theta) - uzsave*std::sin(theta)*std::sin(phi);
-                        uz[i] = +uxsave*std::sin(phi) + uzsave*std::cos(phi);
+                        transform_momentum_to_cartesian(ux[i], uy[i], uz[i], theta, phi);
                     }
                 );
 

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -82,9 +82,9 @@
 
 using namespace amrex;
 
+#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
 namespace
 {
-#if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     void transform_momentum_to_curvilinear (
         amrex::ParticleReal& ux, amrex::ParticleReal& uy,
@@ -124,8 +124,8 @@ namespace
         uz = +ux_save*std::sin(phi) + uz_save*std::cos(phi);
 #endif
     }
-#endif
 }
+#endif
 
 WarpXParIter::WarpXParIter (ContainerType& pc, int level)
     : amrex::ParIterSoA<PIdx::nattribs, 0, amrex::PolymorphicArenaAllocator>(pc, level,

--- a/Source/Particles/WarpXParticleContainer.cpp
+++ b/Source/Particles/WarpXParticleContainer.cpp
@@ -3019,7 +3019,6 @@ WarpXParticleContainer::ApplyBoundaryConditions () {
                     outside_domain |= (z < gridmin.z || z > gridmax.z);
 #endif
 
-
                     if (outside_domain) {
 #if defined(WARPX_DIM_RZ) || defined(WARPX_DIM_RCYLINDER) || defined(WARPX_DIM_RSPHERE)
                         transform_momentum_to_curvilinear(ux[i], uy[i], uz[i], y, z);


### PR DESCRIPTION
This PR adds helper routines for transforming a particle’s momentum between Cartesian coordinates and the local curvilinear basis. Before calling `ApplyParticleBoundaries::apply_boundaries()`, particle momentum is transformed into the curvilinear basis and then transformed back to Cartesian coordinates afterward. This simplifies the logic in `apply_boundaries()` and fixes several bugs and oversights in particle boundary handling for RZ, RCYLINDER, and RSPHERE geometries.

**Issues fixed in this PR for curvilinear geometries:**
- incorrect transform applied for reflecting particles in RSPHERE geometry (see PR #7195)
- forward and backward transformation was applied to **ALL** particles when using RSPHERE geometry
- incorrect normal and tangential velocity components passed to `thermalize_boundary_particles()` at radial (x) boundaries