### PR TITLE
Docs: record where CI is configured in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,16 +74,12 @@ Test output goes to `build/bin/<test_name>/`.
 
 ### Where CI is Configured
 
-Before claiming that some code path is not covered by CI, check **both** of these:
 
 - **Compile-time tests: `.github/workflows/`** — build-only jobs across compilers and backends
   (AppleClang, Clang, GCC, HIP, NVCC, Intel, ...). The exception is `clang_sanitizers.yml`,
   which also runs `ctest` under the UB/address sanitizers.
 - **Runtime tests: `.azure-pipelines.yml`** — builds the `matrix:` of dimensionality/feature
-  combinations and runs the full `ctest` suite for each. This matrix holds the CMake flags
-  (`WARPX_CMAKE_FLAGS`) that decide which optional code is compiled at all, so an
-  `#ifdef`-guarded subsystem may be built and tested here even when nothing in
-  `.github/workflows/` enables it.
+  combinations and runs the full `ctest` suite for each.
 
 ### Adding a Test
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,19 @@ Test output goes to `build/bin/<test_name>/`.
 - When running tests: ignore checksum failures, since they can be platform-dependent.
 - When debugging/fixing tests: do not modify the tolerance of assert statements in the Python analysis files just to make the tests pass (unless explicitly asked to do so).
 
+### Where CI is Configured
+
+Before claiming that some code path is not covered by CI, check **both** of these:
+
+- **Compile-time tests: `.github/workflows/`** — build-only jobs across compilers and backends
+  (AppleClang, Clang, GCC, HIP, NVCC, Intel, ...). The exception is `clang_sanitizers.yml`,
+  which also runs `ctest` under the UB/address sanitizers.
+- **Runtime tests: `.azure-pipelines.yml`** — builds the `matrix:` of dimensionality/feature
+  combinations and runs the full `ctest` suite for each. This matrix holds the CMake flags
+  (`WARPX_CMAKE_FLAGS`) that decide which optional code is compiled at all, so an
+  `#ifdef`-guarded subsystem may be built and tested here even when nothing in
+  `.github/workflows/` enables it.
+
 ### Adding a Test
 
 Use `add_warpx_test()` in the test directory's `CMakeLists.txt`. Generate checksums with `CHECKSUM_RESET=ON ctest --test-dir build -R your_test_name`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,9 @@ Test output goes to `build/bin/<test_name>/`.
   which also runs `ctest` under the UB/address sanitizers.
 - **Runtime tests: `.azure-pipelines.yml`** — builds the `matrix:` of dimensionality/feature
   combinations and runs the full `ctest` suite for each.
+- **GPU tests: `.gitlab/ci.yaml`** — builds and runs one smoke test on NVIDIA H100 and AMD MI300
+  runners, through a GitHub-to-GitLab mirror. Only triggered on merges to `development` and on
+  PRs labeled `bot: run GPU`, so it is absent from a default PR's checks.
 
 ### Adding a Test
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,7 @@ Test output goes to `build/bin/<test_name>/`.
 - When debugging/fixing tests: do not modify the tolerance of assert statements in the Python analysis files just to make the tests pass (unless explicitly asked to do so).
 
 ### Where CI is Configured
+
 - **Compile-time tests: `.github/workflows/`** — build-only jobs across compilers and backends
   (AppleClang, Clang, GCC, HIP, NVCC, Intel, ...). The exception is `clang_sanitizers.yml`,
   which also runs `ctest` under the UB/address sanitizers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,8 +73,6 @@ Test output goes to `build/bin/<test_name>/`.
 - When debugging/fixing tests: do not modify the tolerance of assert statements in the Python analysis files just to make the tests pass (unless explicitly asked to do so).
 
 ### Where CI is Configured
-
-
 - **Compile-time tests: `.github/workflows/`** — build-only jobs across compilers and backends
   (AppleClang, Clang, GCC, HIP, NVCC, Intel, ...). The exception is `clang_sanitizers.yml`,
   which also runs `ctest` under the UB/address sanitizers.


### PR DESCRIPTION
In several conversations with Claude Opus 5, I have noticed that it seems to accidentally overlook `.azure-pipelines.yml`. For instance:

```
Agent: no CI job enables WarpX_PETSC, so that path is unverified [...].

Me: See .azure-pipelines.yml: isn't this using PETSc in CI?

Agent: You're right to push back — I only grepped .github/workflows/ and Regression/, 
never the Azure pipeline. Let me check. [...] I was wrong — this is well covered by CI.
```

This PR updates the `AGENTS.md` to prevent this error from recurring.