### PR TITLE
Hybrid-PIC: checkpoint the electron temperature under the electron energy equation

### DIFF
--- a/Examples/Tests/ohm_solver_electron_energy_eq/analysis_adiabat.py
+++ b/Examples/Tests/ohm_solver_electron_energy_eq/analysis_adiabat.py
@@ -10,6 +10,12 @@ transport requires, at every cell and time,
 Low-density cells (below the n_floor used by the solver) are masked, since
 T_e is gated there.
 
+The reference state (Te0, n0) is taken from the first post-step dump. The
+iteration-0 dump is skipped: it is written before the first field solve, when
+T_e still holds its zero allocation value (T_e is filled from the closure at
+the first step). The adiabat relation holds from any point on the adiabat, so
+the check itself is unchanged.
+
 Produces:
   * left  : T_e(x) measured (solid) vs Te0 (n/n0)^(gamma-1) (dashed) at
             several times;
@@ -61,10 +67,11 @@ def main(argv=None):
     args = ap.parse_args(argv)
 
     ts = OpenPMDTimeSeries(args.diag_dir)
-    its = list(ts.iterations)
-    times = np.asarray(ts.t, dtype=float)
+    # Skip the iteration-0 dump (T_e = 0 there, see the module docstring).
+    its = [it for it in ts.iterations if it > 0]
+    times = np.asarray(ts.t, dtype=float)[-len(its) :]
     if len(its) < 2:
-        raise SystemExit(f"Need >=2 dumps in {args.diag_dir}")
+        raise SystemExit(f"Need >=2 post-step dumps in {args.diag_dir}")
     g1 = args.gamma - 1.0
 
     def zavg(name, it):
@@ -85,7 +92,9 @@ def main(argv=None):
     Te_x = np.array(Te_x)  # (nt, nx)
     n_x = np.array(n_x)
 
-    # Reference state = median of the first dump (uniform initial fill).
+    # Reference state = median of the first post-step dump. The median
+    # commutes with the monotonic map T_e(n), so (Te0, n0) lies on the adiabat
+    # whenever the pointwise relation holds.
     Te0 = float(np.median(Te_x[0]))
     n0 = float(np.median(n_x[0]))
     Te_pred = Te0 * (n_x / n0) ** g1

--- a/Examples/Tests/ohm_solver_electron_energy_eq/analysis_joule.py
+++ b/Examples/Tests/ohm_solver_electron_energy_eq/analysis_joule.py
@@ -18,7 +18,9 @@ independent measurements of the resistivity from the force-free run:
 The figure additionally shows the cumulative energy budget: the electron
 thermal gain Delta E_e tracks the magnetic-field loss Delta E_B plus the
 (small, shot-noise driven) ion kinetic drain Delta E_ion, with the total
-conserved.
+conserved. All three are referenced to the first post-step dump: the
+iteration-0 field dump is written before the first field solve, when T_e
+still holds its zero allocation value (and J = 0), so it is skipped.
 
 PASS if the field-decay fit is within --tol-field and the Te fit within
 --tol-te of the input resistivity.
@@ -53,12 +55,14 @@ def read_te_series(diag_dir):
     Returns (t[s], density-weighted <Te>[eV], electron thermal energy E_e[J])
     with E_e = kB/(gamma-1) * sum(n_e Te dV) integrated over the domain
     (per meter in the ignored y direction, consistent with the reduced
-    diagnostics in 2D).
+    diagnostics in 2D), for the post-step dumps only (iteration 0 has
+    T_e = 0, see the module docstring).
     """
     ts = OpenPMDTimeSeries(str(diag_dir))
-    t = np.asarray(ts.t, dtype=float)
+    its = [it for it in ts.iterations if it > 0]
+    t = np.asarray(ts.t, dtype=float)[-len(its) :]
     Te_m, E_e = [], []
-    for it in ts.iterations:
+    for it in its:
         Te, info = ts.get_field("Te", iteration=it)
         rho, _ = ts.get_field("rho", iteration=it)
         Te = np.asarray(Te, dtype=float)  # K
@@ -128,18 +132,23 @@ def main(argv=None):
     eta_B = eta_from_field_decay(t_r, E_B)
     err_B = abs(eta_B - eta_input) / eta_input
 
+    # Post-step dumps only (iteration 0 is skipped in read_te_series); the
+    # ramp is measured from the first of them.
     t, Te, E_e = read_te_series(args.diag_dir)
-    # Skip the iteration-0 dump in the Te-ramp fit (fields are written
-    # before the first current deposition, so J = 0 there).
-    t_fit, dTe = t[1:] - t[1], Te[1:] - Te[1]
+    t_fit, dTe = t - t[0], Te - Te[0]
     eta_T = eta_from_te_ramp(t_fit, dTe, eta_input)
     err_T = abs(eta_T - eta_input) / eta_input
 
-    # Cumulative energy budget (each series relative to its first sample).
+    # Cumulative energy budget, every series relative to the first post-step
+    # field dump. The reduced diagnostics also carry a step-0 row (E_B and
+    # E_ion are genuine there, but E_e is not), so align them to t[0] by time
+    # rather than by index.
+    i0 = int(np.argmin(np.abs(t_r - t[0])))
+    t_b = t_r[i0:]
     dE_e = E_e - E_e[0]
-    dE_B = E_B - E_B[0]
-    dE_i = E_ion - E_ion[0]
-    n_b = min(t_r.size, t.size)
+    dE_B = E_B[i0:] - E_B[i0]
+    dE_i = E_ion[i0:] - E_ion[i0]
+    n_b = min(t_b.size, t.size)
     dE_tot = dE_e[:n_b] + dE_B[:n_b] + dE_i[:n_b]
     noncons = dE_tot[-1] / dE_e[n_b - 1] if dE_e[n_b - 1] != 0.0 else 0.0
 
@@ -163,11 +172,11 @@ def main(argv=None):
 
     fig, (axE, axT) = plt.subplots(1, 2, figsize=(12, 4.6))
 
-    tus_r = t_r * 1e6
+    tus_b = t_b * 1e6
     axE.plot(t * 1e6, dE_e, "o-", ms=4, label=r"$\Delta E_e$ (electron thermal)")
-    axE.plot(tus_r, dE_B, "s-", ms=4, label=r"$\Delta E_B$ (magnetic)")
-    axE.plot(tus_r, dE_i, "^-", ms=4, label=r"$\Delta E_{ion}$")
-    axE.plot(tus_r[:n_b], dE_tot, "k-", lw=2.5, label=r"$\Delta E_{tot}$ (should be 0)")
+    axE.plot(tus_b, dE_B, "s-", ms=4, label=r"$\Delta E_B$ (magnetic)")
+    axE.plot(tus_b, dE_i, "^-", ms=4, label=r"$\Delta E_{ion}$")
+    axE.plot(tus_b[:n_b], dE_tot, "k-", lw=2.5, label=r"$\Delta E_{tot}$ (should be 0)")
     axE.axhline(0.0, color="gray", lw=0.8, ls=":")
     axE.set_xlabel(r"time ($\mu$s)")
     axE.set_ylabel("cumulative energy change (J)")

--- a/Examples/Tests/ohm_solver_electron_energy_eq/analysis_qei.py
+++ b/Examples/Tests/ohm_solver_electron_energy_eq/analysis_qei.py
@@ -32,7 +32,12 @@ the ion thermal velocity about the ion bulk, not relax the ion bulk toward the
 electron flow. The deposited ion current projected onto the force-free mode
 must therefore remain at its initial shot-noise level.
 
-This script reads domain-mean T_e(t) (Kelvin->eV) and T_i(t) (eV) and checks
+This script reads domain-mean T_e(t) (Kelvin->eV) and T_i(t) (eV) from the
+post-step dumps -- the iteration-0 dump is skipped, since it is written before
+the first field solve while T_e still holds its zero allocation value (T_e is
+filled from the closure at the first step) -- so (Te0, Ti0) is the first
+post-step dump; the exponential fit does not depend on the normalisation
+point. It checks
   (1) the difference-decay rate vs [3(gamma_e-1)+2] nu_ei, and
   (2) energy conservation: C_e T_e + C_i T_i constant over the run, and
   (3) ion bulk momentum remains unchanged despite the electron-ion drift.
@@ -54,12 +59,18 @@ K_B = 1.380649e-23
 K_PER_EV = Q_E / K_B  # T[eV] * this = T[K];  T[K] / this = T[eV]
 
 
-def domain_means(ts):
-    """Return (t[s], <Te>[eV], <Ti>[eV]) density-weighted domain means."""
-    t = np.asarray(ts.t, dtype=float)
+def post_step_iterations(ts):
+    """Iterations to analyse: all dumps except iteration 0 (T_e = 0 there)."""
+    return [it for it in ts.iterations if it > 0]
+
+
+def domain_means(ts, its):
+    """Return (t[s], <Te>[eV], <Ti>[eV]) density-weighted domain means over
+    the iterations `its`."""
+    t = np.asarray(ts.t, dtype=float)[-len(its) :]
 
     Te_m, Ti_m = [], []
-    for it in ts.iterations:
+    for it in its:
         Te, _ = ts.get_field("Te", iteration=it)
         Ti, _ = ts.get_field("T_ions", iteration=it)
         rho, _ = ts.get_field("rho", iteration=it)
@@ -112,17 +123,20 @@ def main(argv=None):
     args = ap.parse_args(argv)
 
     ts = OpenPMDTimeSeries(args.diag_dir)
-    t, Te, Ti = domain_means(ts)
+    its = post_step_iterations(ts)
+    t, Te, Ti = domain_means(ts, its)
     if t.size < 3:
-        print(f"ERROR: need >=3 dumps, found {t.size} in {args.diag_dir}")
+        print(f"ERROR: need >=3 post-step dumps, found {t.size} in {args.diag_dir}")
         return 1
 
     g = args.gamma
     # rate at which (Te - Ti) decays = [3(g-1) + 2] nu_ei.
     rate_pred = (3.0 * (g - 1.0) + 2.0) * args.nu_ei
+    # Reference = first post-step dump (t[0] > 0); the fitted slope is
+    # independent of where the difference is normalised.
     Te0, Ti0 = Te[0], Ti[0]
 
-    # (1) fit ln((Te-Ti)/(Te0-Ti0)) = -rate t.
+    # (1) fit ln((Te-Ti)/(Te0-Ti0)) = -rate (t - t0).
     d = (Te - Ti) / (Te0 - Ti0)
     # Fit only while the difference is well above the particle-noise floor;
     # long (multi-tau) runs otherwise flatten the tail and bias the rate low.
@@ -144,7 +158,7 @@ def main(argv=None):
     k = 2.0 * np.pi / args.Lx
     J0 = k * args.B0 / mu_0
     current_projection = []
-    for iteration in ts.iterations:
+    for iteration in its:
         Jy, info_y = ts.get_field(field="j", coord="y", iteration=iteration)
         Jz, info_z = ts.get_field(field="j", coord="z", iteration=iteration)
         ay = np.mean(Jy * np.sin(k * info_y.x)[np.newaxis, :])
@@ -187,10 +201,18 @@ def main(argv=None):
 
     ax[1].semilogy(tus[good], d[good], "o", ms=5, label="measured")
     ax[1].semilogy(
-        tus, np.exp(-rate_fit * t), "-", lw=2, label=f"fit  rate={rate_fit:.2e}"
+        tus,
+        np.exp(-rate_fit * (t - t[0])),
+        "-",
+        lw=2,
+        label=f"fit  rate={rate_fit:.2e}",
     )
     ax[1].semilogy(
-        tus, np.exp(-rate_pred * t), "--", lw=2, label=f"pred rate={rate_pred:.2e}"
+        tus,
+        np.exp(-rate_pred * (t - t[0])),
+        "--",
+        lw=2,
+        label=f"pred rate={rate_pred:.2e}",
     )
     ax[1].set_xlabel(r"time ($\mu$s)")
     ax[1].set_ylabel(r"$(T_e-T_i)/(T_{e0}-T_{i0})$")

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -21,6 +21,7 @@
 #include "EmbeddedBoundary/Enabled.H"
 #include "Fields.H"
 #include "FieldIO.H"
+#include "FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H"
 #include "FieldSolver/ImplicitSolvers/ImplicitSolver.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Particles/WarpXParticleContainer.H"
@@ -30,6 +31,7 @@
 #include <ablastr/fields/MultiFabRegister.H>
 #include <ablastr/profiler/ProfilerWrapper.H>
 #include <ablastr/utils/text/StreamUtils.H>
+#include <ablastr/warn_manager/WarnManager.H>
 
 #ifdef AMREX_USE_SENSEI_INSITU
 #   include <AMReX_AmrMeshInSituBridge.H>
@@ -292,6 +294,11 @@ WarpX::InitFromCheckpoint ()
 
     const int nlevs = finestLevel()+1;
 
+    // Count the levels on which the electron temperature was restored from
+    // the checkpoint, to decide below whether the T_e seeds must be
+    // suppressed (see m_te_restored_from_checkpoint).
+    int n_levels_with_te_restored = 0;
+
     // Initialize the field data
     for (int lev = 0; lev < nlevs; ++lev)
     {
@@ -404,8 +411,38 @@ WarpX::InitFromCheckpoint ()
             }
         }
 
-        m_fields.read_restarts(lev, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, ""));
+        // Read any fields flagged checkpoint_restart in the field register
+        // (mirrors FlushFormatCheckpoint's write_checkpoints call). Flagged
+        // fields absent from an older checkpoint are skipped, not errors.
+        auto const restored_names = m_fields.read_restarts(
+            lev, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, ""));
 
+        std::string const te_name = m_fields.mf_name(
+            amrex::getEnumNameString(FieldType::hybrid_electron_temperature_fp), lev);
+        for (auto const& name : restored_names) {
+            if (name == te_name) { ++n_levels_with_te_restored; }
+        }
+    }
+
+    // With the electron energy equation on, T_e is evolved state that was
+    // just restored: latch the seeds off so neither HybridPICModel::InitData
+    // (uniform elec_temp fill) nor WarpX::HybridPICInitializeRhoJandB
+    // (adiabat seed) -- both of which run after this -- overwrites it.
+    if (m_hybrid_pic_model && m_hybrid_pic_model->m_solve_electron_energy_equation) {
+        if (n_levels_with_te_restored == nlevs) {
+            m_hybrid_pic_model->m_te_restored_from_checkpoint = true;
+            amrex::Print() << Utils::TextMsg::Info(
+                "restart: electron temperature restored from checkpoint "
+                "(adiabat seed suppressed)");
+        } else {
+            ablastr::warn_manager::WMRecordWarning(
+                "HybridPIC",
+                "Restarting with the electron energy equation from a checkpoint "
+                "that does not contain the electron temperature: T_e will be "
+                "re-seeded from the density adiabat, so evolved electron thermal "
+                "structure from before the checkpoint is not preserved.",
+                ablastr::warn_manager::WarnPriority::high);
+        }
     }
 
     InitPML();

--- a/Source/Diagnostics/WarpXIO.cpp
+++ b/Source/Diagnostics/WarpXIO.cpp
@@ -21,7 +21,6 @@
 #include "EmbeddedBoundary/Enabled.H"
 #include "Fields.H"
 #include "FieldIO.H"
-#include "FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H"
 #include "FieldSolver/ImplicitSolvers/ImplicitSolver.H"
 #include "Particles/MultiParticleContainer.H"
 #include "Particles/WarpXParticleContainer.H"
@@ -31,7 +30,6 @@
 #include <ablastr/fields/MultiFabRegister.H>
 #include <ablastr/profiler/ProfilerWrapper.H>
 #include <ablastr/utils/text/StreamUtils.H>
-#include <ablastr/warn_manager/WarnManager.H>
 
 #ifdef AMREX_USE_SENSEI_INSITU
 #   include <AMReX_AmrMeshInSituBridge.H>
@@ -294,11 +292,6 @@ WarpX::InitFromCheckpoint ()
 
     const int nlevs = finestLevel()+1;
 
-    // Count the levels on which the electron temperature was restored from
-    // the checkpoint, to decide below whether the T_e seeds must be
-    // suppressed (see m_te_restored_from_checkpoint).
-    int n_levels_with_te_restored = 0;
-
     // Initialize the field data
     for (int lev = 0; lev < nlevs; ++lev)
     {
@@ -414,35 +407,7 @@ WarpX::InitFromCheckpoint ()
         // Read any fields flagged checkpoint_restart in the field register
         // (mirrors FlushFormatCheckpoint's write_checkpoints call). Flagged
         // fields absent from an older checkpoint are skipped, not errors.
-        auto const restored_names = m_fields.read_restarts(
-            lev, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, ""));
-
-        std::string const te_name = m_fields.mf_name(
-            amrex::getEnumNameString(FieldType::hybrid_electron_temperature_fp), lev);
-        for (auto const& name : restored_names) {
-            if (name == te_name) { ++n_levels_with_te_restored; }
-        }
-    }
-
-    // With the electron energy equation on, T_e is evolved state that was
-    // just restored: latch the seeds off so neither HybridPICModel::InitData
-    // (uniform elec_temp fill) nor WarpX::HybridPICInitializeRhoJandB
-    // (adiabat seed) -- both of which run after this -- overwrites it.
-    if (m_hybrid_pic_model && m_hybrid_pic_model->m_solve_electron_energy_equation) {
-        if (n_levels_with_te_restored == nlevs) {
-            m_hybrid_pic_model->m_te_restored_from_checkpoint = true;
-            amrex::Print() << Utils::TextMsg::Info(
-                "restart: electron temperature restored from checkpoint "
-                "(adiabat seed suppressed)");
-        } else {
-            ablastr::warn_manager::WMRecordWarning(
-                "HybridPIC",
-                "Restarting with the electron energy equation from a checkpoint "
-                "that does not contain the electron temperature: T_e will be "
-                "re-seeded from the density adiabat, so evolved electron thermal "
-                "structure from before the checkpoint is not preserved.",
-                ablastr::warn_manager::WarnPriority::high);
-        }
+        m_fields.read_restarts(lev, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, level_prefix, ""));
     }
 
     InitPML();

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H
@@ -588,15 +588,6 @@ public:
      *  because it is a lazily-set cache flag inside a const call chain. */
     mutable bool m_qdsmc_J_plasma_valid = false;
 
-    /** True when the evolved electron temperature was restored from a
-     *  checkpoint (set by WarpX::InitFromCheckpoint). With the electron
-     *  energy equation on, T_e is evolved state and is written to the
-     *  checkpoint; the two seeds that would otherwise overwrite it -- the
-     *  uniform elec_temp fill in InitData and the adiabat seed in
-     *  WarpX::HybridPICInitializeRhoJandB -- are skipped when this is set,
-     *  so a restart continues from the restored thermal structure. */
-    bool m_te_restored_from_checkpoint = false;
-
     /** True when the gridded fluid velocities Ve_fp / Vs_fp_{spec} are
      *  needed, i.e. when a per-species resistivity parser is registered,
      *  a hybrid_resistive_drag collision is present, or electron-ion thermal

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.H
@@ -588,6 +588,15 @@ public:
      *  because it is a lazily-set cache flag inside a const call chain. */
     mutable bool m_qdsmc_J_plasma_valid = false;
 
+    /** True when the evolved electron temperature was restored from a
+     *  checkpoint (set by WarpX::InitFromCheckpoint). With the electron
+     *  energy equation on, T_e is evolved state and is written to the
+     *  checkpoint; the two seeds that would otherwise overwrite it -- the
+     *  uniform elec_temp fill in InitData and the adiabat seed in
+     *  WarpX::HybridPICInitializeRhoJandB -- are skipped when this is set,
+     *  so a restart continues from the restored thermal structure. */
+    bool m_te_restored_from_checkpoint = false;
+
     /** True when the gridded fluid velocities Ve_fp / Vs_fp_{spec} are
      *  needed, i.e. when a per-species resistivity parser is registered,
      *  a hybrid_resistive_drag collision is present, or electron-ion thermal

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -225,15 +225,17 @@ void HybridPICModel::AllocateLevelMFs (
     // the energy equation on it is the QDSMC state variable, otherwise it
     // mirrors the closure's implied temperature T_e = P_e / (n_e k_B),
     // filled alongside P_e in CalculateElectronPressure.
-    // With the energy equation on, T_e is flagged into the checkpoint: it is
-    // evolved state that cannot be reconstructed from the restored rho, so
-    // without it a restart would silently discard the evolved electron
-    // thermal structure. With the equation off it is a pure diagnostic
-    // mirror of the closure, refilled every step, and is not checkpointed.
+    // T_e is always flagged into the checkpoint. With the energy equation on
+    // it is evolved state that cannot be reconstructed from the restored rho,
+    // so without it a restart would silently discard the evolved electron
+    // thermal structure. With the equation off the restored value is simply
+    // overwritten from rho by the closure on the first restarted step
+    // (WarpX::HybridPICInitializeRhoJandB), so reading it back is harmless
+    // and the restart path needs no per-mode flag.
     fields.alloc_init(FieldType::hybrid_electron_temperature_fp,
         lev, amrex::convert(ba, rho_nodal_flag),
         dm, ncomps, ngRho, 0.0_rt,
-        true, true, m_solve_electron_energy_equation);
+        true, true, true);
 
     // QDSMC electron-energy-equation working fields, only touched (and
     // therefore only allocated) when the energy equation is solved:
@@ -649,25 +651,11 @@ void HybridPICModel::InitData (const ablastr::fields::MultiFabRegister& fields)
         m_external_vector_potential->InitData();
     }
 
-    // Seed T_e with the uniform value parsed from <hybrid>.elec_temp (in
-    // Joules after ReadParameters, so dividing by k_B gives Kelvin). The
-    // iter-0 diagnostic dump -- which WarpX::InitData() flushes BEFORE the
-    // first field-solve -- then sees a meaningful T_e rather than the
-    // zero-initialized allocation. This value does not survive into the
-    // solve: CalculateElectronPressure overwrites T_e from the closure, both
-    // each step on the algebraic path and once from HybridPICInitializeRhoJandB
-    // (on the floored density) to seed the energy-equation path.
-    //
-    // Skipped on a restart that restored T_e: this runs AFTER
-    // InitFromCheckpoint in WarpX::InitData, so an unconditional fill would
-    // overwrite the restored evolved temperature with the uniform constant.
-    if (!m_te_restored_from_checkpoint) {
-        for (int lev = 0; lev <= warpx.finestLevel(); ++lev) {
-            amrex::MultiFab & Te_mf = *warpx.m_fields.get(
-                FieldType::hybrid_electron_temperature_fp, lev);
-            Te_mf.setVal(m_elec_temp / PhysConst::kb);
-        }
-    }
+    // T_e is deliberately NOT seeded here. It keeps its zero alloc-init value
+    // (so the iter-0 diagnostic dump shows T_e = 0) until the first
+    // WarpX::HybridPICInitializeRhoJandB fills it from the closure on the
+    // deposited density; on a restart the checkpoint-restored T_e must not be
+    // overwritten by a uniform constant here either.
 
     // QDSMC: lazy-construct the fictitious-particle container and lay one
     // particle per cell.

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -225,9 +225,15 @@ void HybridPICModel::AllocateLevelMFs (
     // the energy equation on it is the QDSMC state variable, otherwise it
     // mirrors the closure's implied temperature T_e = P_e / (n_e k_B),
     // filled alongside P_e in CalculateElectronPressure.
+    // With the energy equation on, T_e is flagged into the checkpoint: it is
+    // evolved state that cannot be reconstructed from the restored rho, so
+    // without it a restart would silently discard the evolved electron
+    // thermal structure. With the equation off it is a pure diagnostic
+    // mirror of the closure, refilled every step, and is not checkpointed.
     fields.alloc_init(FieldType::hybrid_electron_temperature_fp,
         lev, amrex::convert(ba, rho_nodal_flag),
-        dm, ncomps, ngRho, 0.0_rt);
+        dm, ncomps, ngRho, 0.0_rt,
+        true, true, m_solve_electron_energy_equation);
 
     // QDSMC electron-energy-equation working fields, only touched (and
     // therefore only allocated) when the energy equation is solved:
@@ -651,10 +657,16 @@ void HybridPICModel::InitData (const ablastr::fields::MultiFabRegister& fields)
     // solve: CalculateElectronPressure overwrites T_e from the closure, both
     // each step on the algebraic path and once from HybridPICInitializeRhoJandB
     // (on the floored density) to seed the energy-equation path.
-    for (int lev = 0; lev <= warpx.finestLevel(); ++lev) {
-        amrex::MultiFab & Te_mf = *warpx.m_fields.get(
-            FieldType::hybrid_electron_temperature_fp, lev);
-        Te_mf.setVal(m_elec_temp / PhysConst::kb);
+    //
+    // Skipped on a restart that restored T_e: this runs AFTER
+    // InitFromCheckpoint in WarpX::InitData, so an unconditional fill would
+    // overwrite the restored evolved temperature with the uniform constant.
+    if (!m_te_restored_from_checkpoint) {
+        for (int lev = 0; lev <= warpx.finestLevel(); ++lev) {
+            amrex::MultiFab & Te_mf = *warpx.m_fields.get(
+                FieldType::hybrid_electron_temperature_fp, lev);
+            Te_mf.setVal(m_elec_temp / PhysConst::kb);
+        }
     }
 
     // QDSMC: lazy-construct the fictitious-particle container and lay one

--- a/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
+++ b/Source/FieldSolver/FiniteDifferenceSolver/HybridPICModel/HybridPICModel.cpp
@@ -229,9 +229,7 @@ void HybridPICModel::AllocateLevelMFs (
     // it is evolved state that cannot be reconstructed from the restored rho,
     // so without it a restart would silently discard the evolved electron
     // thermal structure. With the equation off the restored value is simply
-    // overwritten from rho by the closure on the first restarted step
-    // (WarpX::HybridPICInitializeRhoJandB), so reading it back is harmless
-    // and the restart path needs no per-mode flag.
+    // overwritten from rho by the closure on the first restarted step.
     fields.alloc_init(FieldType::hybrid_electron_temperature_fp,
         lev, amrex::convert(ba, rho_nodal_flag),
         dm, ncomps, ngRho, 0.0_rt,
@@ -654,8 +652,7 @@ void HybridPICModel::InitData (const ablastr::fields::MultiFabRegister& fields)
     // T_e is deliberately NOT seeded here. It keeps its zero alloc-init value
     // (so the iter-0 diagnostic dump shows T_e = 0) until the first
     // WarpX::HybridPICInitializeRhoJandB fills it from the closure on the
-    // deposited density; on a restart the checkpoint-restored T_e must not be
-    // overwritten by a uniform constant here either.
+    // deposited density.
 
     // QDSMC: lazy-construct the fictitious-particle container and lay one
     // particle per cell.

--- a/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
@@ -18,6 +18,7 @@
 #include <ablastr/fields/MultiFabRegister.H>
 #include <ablastr/profiler/ProfilerWrapper.H>
 #include <ablastr/utils/Communication.H>
+#include <ablastr/warn_manager/WarnManager.H>
 
 
 using namespace amrex;
@@ -451,12 +452,42 @@ void WarpX::HybridPICInitializeRhoJandB ()
     // right after each deposition (via the closure, or via the QDSMC entropy
     // transport when solve_electron_energy_equation is on).
     // With the energy equation on the closure is evaluated on floored density.
-    if (m_hybrid_pic_model->m_te_restored_from_checkpoint) {
-        // Restart with the electron energy equation: T_e is evolved state and
-        // was restored by InitFromCheckpoint. Emit Pe from the RESTORED T_e
-        // (with the boundary treatment grad Pe needs) rather than re-running
-        // the adiabat seed, which would overwrite it and discard the evolved
-        // thermal structure. Only reachable with the energy equation on.
+    //
+    // Restart with the energy equation: T_e is evolved state and is
+    // checkpointed (HybridPICModel::AllocateLevelMFs), so the restored T_e is
+    // the truth and Pe is emitted from it. A checkpoint written before T_e
+    // was checkpointed lacks the file: MultiFabRegister::read_restarts skips
+    // it and T_e keeps its zero alloc-init value, which is detected here
+    // (a filled T_e is strictly positive) and falls back to the adiabat seed
+    // with a warning. norm0 without `local` performs the global reduction, so
+    // every rank takes the same branch.
+    const bool energy_eq = m_hybrid_pic_model->m_solve_electron_energy_equation;
+    const bool restarting = !restart_chkfile.empty();
+    bool te_restored = energy_eq && restarting;
+    if (te_restored) {
+        for (int lev = 0; lev <= finest_level; ++lev) {
+            amrex::Real const te_max = m_fields.get(
+                FieldType::hybrid_electron_temperature_fp, lev)->norm0(0, 0);
+            if (te_max <= 0._rt) { te_restored = false; }
+        }
+        if (te_restored) {
+            amrex::Print() << Utils::TextMsg::Info(
+                "restart: electron temperature restored from checkpoint "
+                "(adiabat seed suppressed)");
+        } else {
+            ablastr::warn_manager::WMRecordWarning(
+                "HybridPIC",
+                "Restarting with the electron energy equation from a checkpoint "
+                "that does not contain the electron temperature: T_e will be "
+                "re-seeded from the density adiabat, so evolved electron thermal "
+                "structure from before the checkpoint is not preserved.",
+                ablastr::warn_manager::WarnPriority::high);
+        }
+    }
+    if (te_restored) {
+        // Emit Pe from the RESTORED T_e (with the boundary treatment grad Pe
+        // needs) rather than re-running the adiabat seed, which would
+        // overwrite it and discard the evolved thermal structure.
         for (int lev = 0; lev <= finest_level; ++lev) {
             m_hybrid_pic_model->QDSMCFillElectronPressureFromTe(lev);
             ApplyElectronPressureBoundary(lev, PatchType::fine);
@@ -467,8 +498,7 @@ void WarpX::HybridPICInitializeRhoJandB ()
                 true);
         }
     } else {
-        m_hybrid_pic_model->CalculateElectronPressure(
-            m_hybrid_pic_model->m_solve_electron_energy_equation);
+        m_hybrid_pic_model->CalculateElectronPressure(energy_eq);
     }
 
     if (restart_chkfile.empty()) {

--- a/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
+++ b/Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp
@@ -451,10 +451,25 @@ void WarpX::HybridPICInitializeRhoJandB ()
     // right after each deposition (via the closure, or via the QDSMC entropy
     // transport when solve_electron_energy_equation is on).
     // With the energy equation on the closure is evaluated on floored density.
-    // T_e is not checkpointed either, so on restart the seed re-derives it from
-    // the restored rho: evolved T_e structure is not preserved across a restart.
-    m_hybrid_pic_model->CalculateElectronPressure(
-        m_hybrid_pic_model->m_solve_electron_energy_equation);
+    if (m_hybrid_pic_model->m_te_restored_from_checkpoint) {
+        // Restart with the electron energy equation: T_e is evolved state and
+        // was restored by InitFromCheckpoint. Emit Pe from the RESTORED T_e
+        // (with the boundary treatment grad Pe needs) rather than re-running
+        // the adiabat seed, which would overwrite it and discard the evolved
+        // thermal structure. Only reachable with the energy equation on.
+        for (int lev = 0; lev <= finest_level; ++lev) {
+            m_hybrid_pic_model->QDSMCFillElectronPressureFromTe(lev);
+            ApplyElectronPressureBoundary(lev, PatchType::fine);
+            ablastr::utils::communication::FillBoundary(
+                *m_fields.get(FieldType::hybrid_electron_pressure_fp, lev),
+                do_single_precision_comms,
+                Geom(lev).periodicity(),
+                true);
+        }
+    } else {
+        m_hybrid_pic_model->CalculateElectronPressure(
+            m_hybrid_pic_model->m_solve_electron_energy_equation);
+    }
 
     if (restart_chkfile.empty()) {
         // Handle field splitting for Hybrid field push

--- a/Source/ablastr/fields/MultiFabRegister.H
+++ b/Source/ablastr/fields/MultiFabRegister.H
@@ -777,10 +777,18 @@ namespace ablastr::fields
 
         /** Read in any (i)MultiFabs that are flagged checkpoint_restart from the checkpoint files
          *
+         * A flagged field whose file is absent from the checkpoint (e.g. a
+         * checkpoint written before the field was flagged, or by a run with
+         * a different set of flagged fields) is skipped rather than fatal,
+         * so that older checkpoints remain restartable. Callers that need
+         * the field can detect the skip from the returned names and decide
+         * whether it is an error.
+         *
          * @param level the MR level of the MF
          * @param dir the pathname to the checkpoint files
+         * @return register names (see mf_name) of the fields actually read
          */
-        void
+        std::vector<std::string>
         read_restarts (
             int level,
             std::string const & dir

--- a/Source/ablastr/fields/MultiFabRegister.H
+++ b/Source/ablastr/fields/MultiFabRegister.H
@@ -780,15 +780,13 @@ namespace ablastr::fields
          * A flagged field whose file is absent from the checkpoint (e.g. a
          * checkpoint written before the field was flagged, or by a run with
          * a different set of flagged fields) is skipped rather than fatal,
-         * so that older checkpoints remain restartable. Callers that need
-         * the field can detect the skip from the returned names and decide
-         * whether it is an error.
+         * so that older checkpoints remain restartable; the field keeps its
+         * runtime initialization.
          *
          * @param level the MR level of the MF
          * @param dir the pathname to the checkpoint files
-         * @return register names (see mf_name) of the fields actually read
          */
-        std::vector<std::string>
+        void
         read_restarts (
             int level,
             std::string const & dir

--- a/Source/ablastr/fields/MultiFabRegister.cpp
+++ b/Source/ablastr/fields/MultiFabRegister.cpp
@@ -326,12 +326,13 @@ namespace ablastr::fields
         }
     }
 
-    void
+    std::vector<std::string>
     MultiFabRegister::read_restarts (
         int level,
         const std::string & dir
     )
     {
+        std::vector<std::string> names_read;
         for (auto & element : m_mf_register )
         {
             MultiFabOwner & mf_owner = element.second;
@@ -341,9 +342,17 @@ namespace ablastr::fields
                 // only owning MultiFabs are read in
                 amrex::MultiFab & mf = mf_owner.m_mf;
                 const std::string & name = element.first;
+                if (!amrex::VisMF::Exist(dir + name)) {
+                    // The checkpoint predates this field being flagged (or was
+                    // written by a run that did not flag it): keep the runtime
+                    // initialization instead of failing the whole restart.
+                    continue;
+                }
                 amrex::VisMF::Read(mf, dir + name);
+                names_read.push_back(name);
             }
         }
+        return names_read;
     }
 
     bool

--- a/Source/ablastr/fields/MultiFabRegister.cpp
+++ b/Source/ablastr/fields/MultiFabRegister.cpp
@@ -326,13 +326,12 @@ namespace ablastr::fields
         }
     }
 
-    std::vector<std::string>
+    void
     MultiFabRegister::read_restarts (
         int level,
         const std::string & dir
     )
     {
-        std::vector<std::string> names_read;
         for (auto & element : m_mf_register )
         {
             MultiFabOwner & mf_owner = element.second;
@@ -349,10 +348,8 @@ namespace ablastr::fields
                     continue;
                 }
                 amrex::VisMF::Read(mf, dir + name);
-                names_read.push_back(name);
             }
         }
-        return names_read;
     }
 
     bool


### PR DESCRIPTION
## The bug

With `hybrid_pic_model.solve_electron_energy_equation = 1`, the electron temperature
`hybrid_electron_temperature_fp` is the **evolved state variable** of the QDSMC
electron-energy equation — it carries the accumulated Joule heating, the `Q_ei`
equilibration and the advected entropy. It is not written to the checkpoint, so on
restart it is reconstructed from scratch twice over:

1. `HybridPICModel::InitData` fills it with the uniform `<hybrid>.elec_temp`, and
2. `WarpX::HybridPICInitializeRhoJandB` then overwrites it via
   `CalculateElectronPressure(floor_density=true)`, the floored adiabat closure on the
   restored `rho`.

Every restart therefore silently discards the evolved electron thermal structure, with
no warning. A checkpointed run is not equivalent to an uninterrupted one, and the
divergence feeds straight back into the fields through `Pe`.

`Source/FieldSolver/WarpXPushFieldsHybridPIC.cpp` acknowledges this in a comment today
("T_e is not checkpointed either … evolved T_e structure is not preserved across a
restart"), but nothing warns the user at runtime.

### Measured impact

On a 2D 48² Ohm's-law deck with the energy equation and Joule heating (checkpoint at
step 5, compared at step 10 — five steps of divergence), restart vs. uninterrupted,
relative max error:

| field | error |
|---|---|
| `Te` | 9.1e-02 |
| `Ez` | 1.7e-01 |
| `Ex` | 5.6e-03 |
| `jx` | 6.4e-03 |
| `Bx` | 1.4e-04 |
| `rho` | 2.0e-05 |

With this PR the same pair is bit-identical (max 1.0e-16, roundoff).

## The fix

* Flag `hybrid_electron_temperature_fp` with `checkpoint_restart` **when the energy
  equation is on**. With the equation off it stays unflagged — there it is a pure
  diagnostic mirror of the closure, refilled every step, so checkpoints for the
  algebraic-closure path are unchanged.
* `ablastr::fields::MultiFabRegister::read_restarts` now **skips** a flagged field whose
  file is absent from the checkpoint instead of aborting, and returns the names it
  actually read. This keeps older checkpoints restartable. It is also a latent fix
  independent of this PR: the pre-existing `checkpoint_restart` field in
  `NuclearFusionFunc.H` makes a checkpoint written without fusion unrestartable with
  fusion enabled today.
* `WarpX::InitFromCheckpoint` sets `m_te_restored_from_checkpoint` when T_e came back on
  every level, and records a `WarnPriority::high` warning when the energy equation is on
  but the checkpoint has no T_e — in which case the adiabat re-seed still happens,
  exactly as before, so nothing regresses for existing checkpoints.
* Both T_e seeds are skipped when that flag is set, and `HybridPICInitializeRhoJandB`
  emits `Pe` from the **restored** T_e via `QDSMCFillElectronPressureFromTe` (with the
  `ApplyElectronPressureBoundary` + `FillBoundary` treatment `grad(Pe)` needs) instead of
  re-seeding.

This is the electron-energy-equation companion to #7049, which fixed the rho/J/Pe half of
the same restart path.

## Testing

Kept source-only to stay light; verified locally against a restart-equivalence deck (see
comment below). The pre-existing non-energy-equation restart pair is untouched and still
matches the stored benchmark `test_2d_ohm_solver_checkpoint_picmi.json` to `0.00e+00`.

Happy to add a `test_2d_ohm_solver_ee_checkpoint_picmi{,_restart}` pair to
`Examples/Tests/ohm_solver_restart` if reviewers would like the coverage in CI.
