### PR TITLE
ECT: CheckAreaLedger

### DIFF
--- a/Source/EmbeddedBoundary/WarpXFaceExtensions.cpp
+++ b/Source/EmbeddedBoundary/WarpXFaceExtensions.cpp
@@ -16,9 +16,16 @@
 
 #include <AMReX_Functional.H>
 #include <AMReX_GpuAtomic.H>
+#include <AMReX_Math.H>
 #include <AMReX_Scan.H>
 #include <AMReX_iMultiFab.H>
 #include <AMReX_MultiFab.H>
+
+#include <algorithm>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+#include <string>
 
 using namespace ablastr::fields;
 
@@ -69,7 +76,142 @@ namespace
         return sums;
     }
 
+
+    /**
+    * \brief Check that face extensions conserved area and did not overdraft
+    * any lending face to S_mod <= 0.  The global sum of original areas S must
+    * equal sum of modified areas S_mod to within a round-off error tolerance.
+    * This routine must be called before BCK correction, which overwrites
+    * face_areas.
+    *
+    * @param[in] tag Annotation for verbose/error print statements
+    * @param[in] all_fields The field manager
+    * @param[in] owner_mask Per-direction face owner masks
+    * @param[in] max_level The maximum refinement level
+    * @param[in] verbose Integer level of verbosity for print statements
+    */
+    void CheckAreaLedger (
+        [[maybe_unused]] const std::string& tag,
+        [[maybe_unused]] const ablastr::fields::MultiFabRegister& all_fields,
+        [[maybe_unused]] const amrex::Vector<std::array< std::unique_ptr<amrex::iMultiFab>, 3 > >& owner_mask,
+        [[maybe_unused]] const int max_level,
+        [[maybe_unused]] const int verbose)
+    {
+#ifndef WARPX_DIM_RZ
+        using warpx::fields::FieldType;
+
+#ifdef WARPX_DIM_XZ
+        // In 2D we only need the case idim=1
+        for (int idim = 1; idim < AMREX_SPACEDIM; ++idim) {
+#elif defined(WARPX_DIM_3D)
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+#else
+            WARPX_ABORT_WITH_MESSAGE(
+                "CheckAreaLedger: Only implemented in 2D3V and 3D3V");
 #endif
+            auto* const S_mf     = all_fields.get(FieldType::face_areas, Direction{idim}, max_level);
+            auto* const S_mod_mf = all_fields.get(FieldType::area_mod,   Direction{idim}, max_level);
+            auto* const owner_mf = owner_mask[max_level][idim].get();
+
+            amrex::Real net;        // sum(S - S_mod)
+            amrex::Real S_max_sum;  // sum(max(S,S_mod)) to estimate roundoff error
+            amrex::Real S_mod_min;  // min(S_mod) verify no overdraft
+            {
+                amrex::ReduceOps< amrex::ReduceOpSum,
+                                  amrex::ReduceOpSum,
+                                  amrex::ReduceOpMin > reduce_ops;
+                amrex::ReduceData< amrex::Real,
+                                   amrex::Real,
+                                   amrex::Real > reduce_data(reduce_ops);
+
+                for (amrex::MFIter mfi(*S_mf); mfi.isValid(); ++mfi) {
+                    amrex::Box const &box   = mfi.validbox();
+                    auto       const &S     = S_mf    ->const_array(mfi);
+                    auto       const &S_mod = S_mod_mf->const_array(mfi);
+                    auto       const &owner = owner_mf->const_array(mfi);
+
+                    reduce_ops.eval(box, reduce_data,
+                        [=] AMREX_GPU_DEVICE(int i, int j, int k)
+                        -> amrex::GpuTuple<amrex::Real, amrex::Real, amrex::Real> {
+
+                            const amrex::Real d = S(i,j,k) - S_mod(i,j,k);
+                            if (owner(i,j,k) == 0 || d == amrex::Real(0.)) {
+                                // skip non-owned faces on shared nodal planes
+                                // skip faces that neither lend nor borrow
+                                return { amrex::Real(0.),
+                                         amrex::Real(0.),
+                                         std::numeric_limits<amrex::Real>::max() };
+                            } else {
+                                return { d,
+                                         std::max(S(i,j,k),S_mod(i,j,k)),
+                                         S_mod(i,j,k) };
+                            }
+
+                        });
+                }
+
+                auto r = reduce_data.value();
+                net       = amrex::get<0>(r);
+                S_max_sum = amrex::get<1>(r);
+                S_mod_min = amrex::get<2>(r);
+                amrex::ParallelDescriptor::ReduceRealSum(net);
+                amrex::ParallelDescriptor::ReduceRealSum(S_max_sum);
+                amrex::ParallelDescriptor::ReduceRealMin(S_mod_min);
+            }
+
+            // Round-off error may arise from the parallel reduction or from
+            // the S -> S_mod debiting.  Worst-case estimates for each case:
+            //    error ~ releps * \sum |S - S_mod|
+            //    error ~ releps * \sum max(S_mod, S)
+            // Use the latter.  Prefactor 100x is a bit arbitrary; in practice
+            // large-N sums should have residual << tolerance.
+            constexpr auto rtol = amrex::Real(1.e2) * std::numeric_limits<amrex::Real>::epsilon();
+
+            // Perform assert checks + printout only if faces are lent.
+            // Otherwise, printing imbalance=0, residual=0, min(S_mod)=huge
+            // looks weird/confusing.
+            if (S_max_sum > amrex::Real(0.)) {
+
+                std::ostringstream msg;
+                msg << "Embedded Boundary: ECT CheckAreaLedger"
+                    << " " << tag << " (idim=" << idim << ")"
+                    << std::scientific << std::setprecision(6)
+                    << " imbalance sum(S-S_mod) = " << net
+                    << " tolerance = "              << rtol*S_max_sum;
+
+                const bool balance = amrex::Math::abs(net) <= rtol*S_max_sum;
+                if (balance) {
+                    msg << " OK.";
+                } else {
+                    msg << " exceeded, borrowed and lent area do not balance, exiting!";
+                }
+
+                msg << " Modified faces min(S_mod) = " << S_mod_min;
+
+                const bool no_overdraft = S_mod_min > amrex::Real(0.);
+                if (no_overdraft) {
+                    msg << " > 0 OK.";
+                } else {
+                    msg << " but expected > 0 for all faces, exiting!";
+                }
+
+                if (!balance || !no_overdraft ) {
+                    msg << " Try resolving embedded boundary with more cells, varying AMReX grid layout, and/or filing bug report.";
+                }
+
+                WARPX_ALWAYS_ASSERT_WITH_MESSAGE(balance && no_overdraft,
+                                                 msg.str());
+
+                if (verbose >= 1) {
+                    amrex::Print() << Utils::TextMsg::Info(msg.str());
+                }
+            }
+
+        } // for(int idim)
+#endif // ifndef WARPX_DIM_RZ
+    } // void CheckAreaLedger(...)
+
+#endif // AMREX_USE_EB
 
 
     /**
@@ -566,6 +708,8 @@ WarpX::ComputeFaceExtensions ()
     ::init_borrowing(m_borrowing[maxLevel()], Bfield);
     ComputeOneWayExtensions();
 
+    ::CheckAreaLedger("after 1-way pass", m_fields, m_ect_face_owner_mask, maxLevel(), verbose);
+
     amrex::Array1D<int, 0, 2> N_ext_faces_after_one_way = ::CountExtFaces(m_flag_ext_face, maxLevel());
     ablastr::warn_manager::WMRecordWarning("Embedded Boundary",
             "Faces to be extended after one way extension in x:\t"
@@ -578,6 +722,9 @@ WarpX::ComputeFaceExtensions ()
     );
 
     ComputeEightWaysExtensions();
+
+    ::CheckAreaLedger("after 8-way pass", m_fields, m_ect_face_owner_mask, maxLevel(), verbose);
+
     ::shrink_borrowing(m_borrowing[maxLevel()], Bfield);
 
     amrex::Array1D<int, 0, 2> N_ext_faces_after_eight_ways = ::CountExtFaces(m_flag_ext_face, maxLevel());

--- a/Source/EmbeddedBoundary/WarpXFaceExtensions.cpp
+++ b/Source/EmbeddedBoundary/WarpXFaceExtensions.cpp
@@ -81,8 +81,9 @@ namespace
     * \brief Check that face extensions conserved area and did not overdraft
     * any lending face to S_mod <= 0.  The global sum of original areas S must
     * equal sum of modified areas S_mod to within a round-off error tolerance.
-    * This routine must be called before BCK correction, which overwrites
-    * face_areas.
+    * This routine must be called (i) before BCK correction, which overwrites
+    * `face_areas`, and (ii) after any cross-box reduction of `area_mod` by
+    * `sync_lent_areas` in `ComputeFaceExtensions`.
     *
     * @param[in] tag Annotation for verbose/error print statements
     * @param[in] all_fields The field manager
@@ -123,6 +124,7 @@ namespace
                 amrex::ReduceData< amrex::Real,
                                    amrex::Real,
                                    amrex::Real > reduce_data(reduce_ops);
+                constexpr auto huge = std::numeric_limits<amrex::Real>::max();
 
                 for (amrex::MFIter mfi(*S_mf); mfi.isValid(); ++mfi) {
                     amrex::Box const &box   = mfi.validbox();
@@ -137,10 +139,10 @@ namespace
                             const amrex::Real d = S(i,j,k) - S_mod(i,j,k);
                             if (owner(i,j,k) == 0 || d == amrex::Real(0.)) {
                                 // skip non-owned faces on shared nodal planes
-                                // skip faces that neither lend nor borrow
+                                // skip faces that neither lend nor borrow (expect S == S_mod, d == 0 exactly)
                                 return { amrex::Real(0.),
                                          amrex::Real(0.),
-                                         std::numeric_limits<amrex::Real>::max() };
+                                         huge };
                             } else {
                                 return { d,
                                          std::max(S(i,j,k),S_mod(i,j,k)),


### PR DESCRIPTION
When using embedded boundary with enlarged-cell technique (ECT) solver, check that global face area is conserved (lent area = borrowed area) to within an automatically-determined round-off error tolerance. Also check that S_mod > 0 for all participating faces to guard against an edge case wherein multiple unstable cells can "overdraft" a neighbor cell's available area.

This PR was created to help test PR #7104, which fixes area-conservation bugs related to cross-box synchronization of lent/borrowed face area.

During review of PR #7104, it was also noticed that S_mod < 0 on a face may occur due to at least one pathological case of an under-resolved embedded boundary with cut-cells at AMReX box corners.  The present PR simply aborts and does not attempt to re-work the ECT algorithm for a relatively obscure edge case.

Questions and notes for reviewers:
* Log with `verbose >=1` or `> 1` ?
* @ax3l 's comment on issue #2257 suggests that ECT boundary face extensions may be recomputed dynamically as a simulation evolves, either PEC boundary moving or AMReX regridding.  Do you think this is a serious practical concern?  If so, this PR may need to be edited to prevent check from running too often: maybe 1x at init, at some regular interval, only if user requests auditing, etc...
* Merge this PR after #7104 (CI compiles will break otherwise)

Example logging if checks passed for a 2D simulation:

```
                                   ___
    __        __             ___  /  /
    \ \      / /_ _ _ __ _ __\  \/  /
     \ \ /\ / / _` | '__| '_ \\    /
      \ V  V / (_| | |  | |_) /    \
       \_/\_/ \__,_|_|  | .__/__/\  \
                        |_|       \__\

Level 0: dt = 1.179327168e-10 ; dx = 0.05 ; dz = 0.05
--- INFO    : Embedded Boundary: ECT CheckAreaLedger after 1-way pass (idim=1)
             imbalance sum(S-S_mod) = 0.000000e+00 tolerance = 5.107026e-15 OK.
             Modified faces min(S_mod) = 1.000000e-03 > 0 OK.
--- INFO    : Embedded Boundary: ECT CheckAreaLedger after 8-way pass (idim=1)
             imbalance sum(S-S_mod) = -2.249720e-18 tolerance = 5.129230e-15
             OK. Modified faces min(S_mod) = 2.500000e-04 > 0 OK.

Grids Summary:
  Level 0   16 grids  1024 cells  100 % of domain
            smallest grid: 8 x 8  biggest grid: 8 x 8
```

Example logging if a check fails:

```
0::Assertion `balance && no_overdraft' failed, file "[...]/warpx/Source/EmbeddedBoundary/WarpXFaceExtensions.cpp", line 203, Msg:
### ERROR   : Embedded Boundary: ECT CheckAreaLedger after 1-way pass (idim=1)
#            imbalance sum(S-S_mod) = -1.734723e-18 tolerance = 9.436896e-16
#            OK. Modified faces min(S_mod) = -5.000000e-04 but expected > 0 for
#            all faces, exiting! Try resolving embedded boundary with more
#            cells, varying AMReX grid layout, and/or filing bug report.
```