### PR TITLE
Apply warpx.limit_verbose_step to output of the MLMG solvers

### DIFF
--- a/Docs/source/usage/parameters.rst
+++ b/Docs/source/usage/parameters.rst
@@ -5848,6 +5848,7 @@ When developing, testing and :ref:`debugging WarpX <debugging_warpx>`, the follo
     If set to true, the information normally printed to the terminal at every time step
     is limited: it prints every step for the first 10 steps, every 10 steps for steps between 10 and 100,
     and once every 100 steps for steps greater than 100.
+    This also limits the output from the field solvers.
 
 .. pp:param:: warpx.always_warn_immediately
     :type: ``0`` or ``1``

--- a/Examples/Tests/electrostatic_sphere/inputs_test_3d_electrostatic_sphere_lab_frame
+++ b/Examples/Tests/electrostatic_sphere/inputs_test_3d_electrostatic_sphere_lab_frame
@@ -4,3 +4,5 @@ FILE = inputs_base_3d
 # test input parameters
 diag2.electron.variables = x y z ux uy uz w phi
 warpx.do_electrostatic = labframe
+
+warpx.limit_verbose_step = true

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -234,7 +234,7 @@ WarpX::Evolve (int numsteps)
         ExecutePythonCallback("particleinjection");
 
         // perform collisions and advance fields and particles by one time step
-        OneStep(cur_time, dt[0], step);
+        OneStep(cur_time, dt[0], step, verbose_step);
 
         // Resample particles
         // +1 is necessary here because value of step seen by user (first step is 1) is different than
@@ -405,7 +405,8 @@ WarpX::Evolve (int numsteps)
 void WarpX::OneStep (
     amrex::Real a_cur_time,
     amrex::Real a_dt,
-    int a_step
+    int a_step,
+    bool verbose_step
 )
 {
     ABLASTR_PROFILE("WarpX::OneStep()");
@@ -413,7 +414,7 @@ void WarpX::OneStep (
     // implicit solver
     if (m_implicit_solver) {
         // advance fields and particles by one time step
-        const int exit_status = m_implicit_solver->OneStep(a_cur_time, a_dt, a_step);
+        const int exit_status = m_implicit_solver->OneStep(a_cur_time, a_dt, a_step, verbose_step);
         if (exit_status < 0) {
             std::stringstream solverMsg;
             solverMsg << "ImplicitSolver::OneStep() failed at step = " << a_step

--- a/Source/Evolve/WarpXEvolve.cpp
+++ b/Source/Evolve/WarpXEvolve.cpp
@@ -304,7 +304,7 @@ WarpX::Evolve (int numsteps)
             // loop (i.e. immediately after a `Redistribute` and before particle
             // positions are next pushed) so that the particles do not deposit out of bounds
             // and so that the fields are at the correct time in the output.
-            ComputeSpaceChargeField( reset_E_field, reset_B_field );
+            ComputeSpaceChargeField(reset_E_field, reset_B_field, verbose_step);
             if (electrostatic_solver_id == ElectrostaticSolverAlgo::LabFrameElectroMagnetostatic) {
                 // Call Magnetostatic Solver to solve for the vector potential A and compute the
                 // B field.  Time varying A contribution to E field is neglected.

--- a/Source/FieldSolver/ElectrostaticSolvers/EffectivePotentialES.H
+++ b/Source/FieldSolver/ElectrostaticSolvers/EffectivePotentialES.H
@@ -33,7 +33,8 @@ public:
         ablastr::fields::MultiFabRegister& fields,
         MultiParticleContainer& mpc,
         MultiFluidContainer* mfl,
-        int max_level) override;
+        int max_level,
+        bool verbose_step) override;
 
     void ComputeSigma (
         ablastr::fields::MultiLevelScalarField const& rho_fp
@@ -42,7 +43,8 @@ public:
     void computePhi (
         ablastr::fields::MultiLevelScalarField const& rho,
         ablastr::fields::MultiLevelScalarField const& phi,
-        ablastr::fields::MultiLevelVectorField const& efield
+        ablastr::fields::MultiLevelVectorField const& efield,
+        int verbosity
     );
 
     /**

--- a/Source/FieldSolver/ElectrostaticSolvers/EffectivePotentialES.cpp
+++ b/Source/FieldSolver/ElectrostaticSolvers/EffectivePotentialES.cpp
@@ -38,7 +38,8 @@ void EffectivePotentialES::ComputeSpaceChargeField (
     ablastr::fields::MultiFabRegister& fields,
     [[maybe_unused]] MultiParticleContainer& mpc,
     [[maybe_unused]] MultiFluidContainer* mfl,
-    int max_level)
+    int max_level,
+    bool verbose_step)
 {
     ABLASTR_PROFILE("EffectivePotentialES::ComputeSpaceChargeField");
 
@@ -67,7 +68,8 @@ void EffectivePotentialES::ComputeSpaceChargeField (
     ExecutePythonCallback("afterdeposition");
 
     // perform phi calculation
-    computePhi(rho_fp, phi_fp, Efield_fp);
+    int const verbosity = verbose_step ? self_fields_verbosity : 0;
+    computePhi(rho_fp, phi_fp, Efield_fp, verbosity);
 
     // Compute the electric field. Note that if an EB is used the electric
     // field will be calculated in the computePhi call.
@@ -80,12 +82,13 @@ void EffectivePotentialES::ComputeSpaceChargeField (
 void EffectivePotentialES::computePhi (
     ablastr::fields::MultiLevelScalarField const& rho,
     ablastr::fields::MultiLevelScalarField const& phi,
-    ablastr::fields::MultiLevelVectorField const& efield )
+    ablastr::fields::MultiLevelVectorField const& efield,
+    int const verbosity)
 {
     // Use the AMREX MLMG solver
     computePhi(rho, phi, efield, self_fields_required_precision,
-                self_fields_absolute_tolerance, self_fields_max_iters,
-                self_fields_verbosity);
+               self_fields_absolute_tolerance, self_fields_max_iters,
+               verbosity);
 }
 
 void EffectivePotentialES::ComputeSigma (

--- a/Source/FieldSolver/ElectrostaticSolvers/ElectrostaticSolver.H
+++ b/Source/FieldSolver/ElectrostaticSolvers/ElectrostaticSolver.H
@@ -52,7 +52,8 @@ public:
         ablastr::fields::MultiFabRegister& fields,
         MultiParticleContainer& mpc,
         MultiFluidContainer* mfl,
-        int max_level) = 0;
+        int max_level,
+        bool verbose_step) = 0;
 
     /**
      * \brief Set Dirichlet boundary conditions for the electrostatic solver.

--- a/Source/FieldSolver/ElectrostaticSolvers/LabFrameExplicitES.H
+++ b/Source/FieldSolver/ElectrostaticSolvers/LabFrameExplicitES.H
@@ -25,7 +25,8 @@ public:
         ablastr::fields::MultiFabRegister& fields,
         MultiParticleContainer& mpc,
         MultiFluidContainer* mfl,
-        int max_level) override;
+        int max_level,
+        bool verbose_step) override;
 
     void computePhiTriDiagonal (
         const ablastr::fields::MultiLevelScalarField& rho,

--- a/Source/FieldSolver/ElectrostaticSolvers/LabFrameExplicitES.cpp
+++ b/Source/FieldSolver/ElectrostaticSolvers/LabFrameExplicitES.cpp
@@ -75,6 +75,7 @@ void LabFrameExplicitES::ComputeSpaceChargeField (
 
 #if defined(WARPX_DIM_1D_Z)
         // Use the tridiag solver with 1D
+        amrex::ignore_unused(verbose_step);
         computePhiTriDiagonal(rho_fp, phi_fp);
 #else
         // Use the AMREX MLMG or the FFT (IGF) solver otherwise

--- a/Source/FieldSolver/ElectrostaticSolvers/LabFrameExplicitES.cpp
+++ b/Source/FieldSolver/ElectrostaticSolvers/LabFrameExplicitES.cpp
@@ -25,7 +25,8 @@ void LabFrameExplicitES::ComputeSpaceChargeField (
     ablastr::fields::MultiFabRegister& fields,
     MultiParticleContainer& mpc,
     MultiFluidContainer* mfl,
-    int max_level)
+    int max_level,
+    bool verbose_step)
 {
     using ablastr::fields::MultiLevelScalarField;
     using ablastr::fields::MultiLevelVectorField;
@@ -77,9 +78,10 @@ void LabFrameExplicitES::ComputeSpaceChargeField (
         computePhiTriDiagonal(rho_fp, phi_fp);
 #else
         // Use the AMREX MLMG or the FFT (IGF) solver otherwise
+        int const verbosity = verbose_step ? self_fields_verbosity : 0;
         computePhi(rho_fp, phi_fp, beta, self_fields_required_precision,
                    self_fields_absolute_tolerance, self_fields_max_iters,
-                   self_fields_verbosity, is_igf_2d_slices, Efield_fp);
+                   verbosity, is_igf_2d_slices, Efield_fp);
 #endif
 
     }

--- a/Source/FieldSolver/ElectrostaticSolvers/RelativisticExplicitES.H
+++ b/Source/FieldSolver/ElectrostaticSolvers/RelativisticExplicitES.H
@@ -39,12 +39,14 @@ public:
      * \param mpc Reference to multi-particle container
      * \param mfl Pointer to multi-fluid container
      * \param max_level Maximum level of mesh refinement
+     * \param verbose_step Whether to be verbose on this step
      */
     void ComputeSpaceChargeField (
         ablastr::fields::MultiFabRegister& fields,
         MultiParticleContainer& mpc,
         MultiFluidContainer* mfl,
-        int max_level) override;
+        int max_level,
+        bool verbose_step) override;
 
     /**
      * Compute the charge density of the species paricle container, pc,
@@ -53,11 +55,13 @@ public:
      * \param[in] pc particle container for the selected species
      * \param[in] Efield_fp Efield updated to include potential computed for selected species charge density as source
      * \param[in] Bfield_fp Bfield updated to include potential computed for selected species charge density as source
+     * \param[in] verbosity Level of verbosity
      */
     void AddSpaceChargeField (
         WarpXParticleContainer& pc,
         ablastr::fields::MultiLevelVectorField& Efield_fp,
-        ablastr::fields::MultiLevelVectorField& Bfield_fp
+        ablastr::fields::MultiLevelVectorField& Bfield_fp,
+        int verbosity
     );
 
     /** Compute the potential `phi` by solving the Poisson equation with the

--- a/Source/FieldSolver/ElectrostaticSolvers/RelativisticExplicitES.cpp
+++ b/Source/FieldSolver/ElectrostaticSolvers/RelativisticExplicitES.cpp
@@ -34,7 +34,8 @@ void RelativisticExplicitES::ComputeSpaceChargeField (
     ablastr::fields::MultiFabRegister& fields,
     MultiParticleContainer& mpc,
     [[maybe_unused]] MultiFluidContainer* mfl,
-    int max_level)
+    int max_level,
+    bool verbose_step)
 {
     ABLASTR_PROFILE("RelativisticExplicitES::ComputeSpaceChargeField");
 
@@ -51,7 +52,8 @@ void RelativisticExplicitES::ComputeSpaceChargeField (
     // due to simulation boundary potentials
     for (auto const& species : mpc) {
         if (always_run_solve || (species->initialize_self_fields)) {
-            AddSpaceChargeField(*species, Efield_fp, Bfield_fp);
+            int const verbosity = verbose_step ? species->self_fields_verbosity : 0;
+            AddSpaceChargeField(*species, Efield_fp, Bfield_fp, verbosity);
         }
     }
 
@@ -65,7 +67,8 @@ void RelativisticExplicitES::ComputeSpaceChargeField (
 void RelativisticExplicitES::AddSpaceChargeField (
     WarpXParticleContainer& pc,
     ablastr::fields::MultiLevelVectorField& Efield_fp,
-    ablastr::fields::MultiLevelVectorField& Bfield_fp)
+    ablastr::fields::MultiLevelVectorField& Bfield_fp,
+    int const verbosity)
 {
     ABLASTR_PROFILE("RelativisticExplicitES::AddSpaceChargeField");
 
@@ -130,7 +133,7 @@ void RelativisticExplicitES::AddSpaceChargeField (
     computePhi( amrex::GetVecOfPtrs(rho), amrex::GetVecOfPtrs(phi),
                 beta, pc.self_fields_required_precision,
                 pc.self_fields_absolute_tolerance, pc.self_fields_max_iters,
-                pc.self_fields_verbosity, is_igf_2d_slices);
+                verbosity, is_igf_2d_slices);
 
     // Compute the corresponding electric and magnetic field, from the potential phi
     computeE( Efield_fp, amrex::GetVecOfPtrs(phi), beta );

--- a/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
+++ b/Source/FieldSolver/ImplicitSolvers/ImplicitSolver.H
@@ -67,7 +67,8 @@ public:
      */
     virtual int OneStep (amrex::Real  a_time,
                          amrex::Real  a_dt,
-                         int          a_step) = 0;
+                         int          a_step,
+                         bool verbose_step) = 0;
 
     //
     // the following routines are called by the linear and nonlinear solvers

--- a/Source/FieldSolver/ImplicitSolvers/SemiImplicitDarwin.H
+++ b/Source/FieldSolver/ImplicitSolvers/SemiImplicitDarwin.H
@@ -48,7 +48,8 @@ public:
 
     int OneStep ( amrex::Real  start_time,
                   amrex::Real  a_dt,
-                  int          a_step ) override;
+                  int          a_step,
+                  bool verbose_step) override;
 
     /**
      * \brief Not implemented for this solver.

--- a/Source/FieldSolver/ImplicitSolvers/SemiImplicitDarwin.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/SemiImplicitDarwin.cpp
@@ -134,7 +134,8 @@ void SemiImplicitDarwin::PrintParameters () const
 
 int SemiImplicitDarwin::OneStep ( [[maybe_unused]] amrex::Real  start_time,
                                                    amrex::Real  a_dt,
-                                                   int          a_step )
+                                                   int          a_step,
+                                                   bool verbose_step)
 {
     BL_PROFILE("SemiImplicitDarwin::OneStep()");
 
@@ -200,6 +201,8 @@ int SemiImplicitDarwin::OneStep ( [[maybe_unused]] amrex::Real  start_time,
     // where chi is the mass matrix scaled by 2 * mu_0 / dt (see
     // ApplyScaledMassMatrices), i.e. the linear response of the deposited
     // current to the inductive E-field that this solve produces.
+    int const verbosity = verbose_step ? m_linsol_verbose_int : 0;
+    m_linear_solver->setVerbose(verbosity);
     m_linear_solver->solve(m_Z, m_source, m_linsol_rtol, m_linsol_atol);
 
     // AMReX's GMRES::getStatus() returns 0 on convergence and a positive

--- a/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.H
+++ b/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.H
@@ -59,7 +59,8 @@ public:
 
     int OneStep (amrex::Real  start_time,
                  amrex::Real  a_dt,
-                 int          a_step) override;
+                 int          a_step,
+                 bool verbose_step) override;
 
     void ComputeRHS ( WarpXSolverVec&  a_RHS,
                 const WarpXSolverVec&  a_E,

--- a/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/SemiImplicitEM.cpp
@@ -59,7 +59,8 @@ void SemiImplicitEM::PrintParameters () const
 
 int SemiImplicitEM::OneStep (amrex::Real  start_time,
                              amrex::Real  a_dt,
-                             int          a_step)
+                             int          a_step,
+                             bool verbose_step)
 {
     BL_PROFILE("SemiImplicitEM::OneStep()");
 
@@ -88,7 +89,7 @@ int SemiImplicitEM::OneStep (amrex::Real  start_time,
 
     // Solve nonlinear system for Eg at t_{n+1/2}
     // Particles will be advanced to t_{n+1/2}
-    m_nlsolver->Solve(m_E, m_Eold, start_time, m_dt, a_step);
+    m_nlsolver->Solve(m_E, m_Eold, start_time, m_dt, a_step, verbose_step);
 
     const int exit_status = m_nlsolver->GetExitStatus();
     if (exit_status < 0) { return exit_status; }

--- a/Source/FieldSolver/ImplicitSolvers/StrangImplicitSpectralEM.H
+++ b/Source/FieldSolver/ImplicitSolvers/StrangImplicitSpectralEM.H
@@ -60,7 +60,8 @@ public:
 
     int OneStep (amrex::Real  start_time,
                  amrex::Real  a_dt,
-                 int          a_step) override;
+                 int          a_step,
+                 bool verbose_step) override;
 
     void ComputeRHS ( WarpXSolverVec&  a_RHS,
                 const WarpXSolverVec&  a_E,

--- a/Source/FieldSolver/ImplicitSolvers/StrangImplicitSpectralEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/StrangImplicitSpectralEM.cpp
@@ -57,7 +57,8 @@ void StrangImplicitSpectralEM::PrintParameters () const
 
 int StrangImplicitSpectralEM::OneStep (amrex::Real start_time,
                                        amrex::Real a_dt,
-                                       int a_step)
+                                       int a_step,
+                                       bool verbose_step)
 {
     // Fields have E^{n} and B^{n}
     // Particles have p^{n} and x^{n}.
@@ -83,7 +84,7 @@ int StrangImplicitSpectralEM::OneStep (amrex::Real start_time,
 
     // Solve nonlinear system for E at t_{n+1/2}
     // Particles will be advanced to t_{n+1/2}
-    m_nlsolver->Solve(m_E, m_Eold, start_time, m_dt, a_step);
+    m_nlsolver->Solve(m_E, m_Eold, start_time, m_dt, a_step, verbose_step);
 
     const int exit_status = m_nlsolver->GetExitStatus();
     if (exit_status < 0) { return exit_status; }

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.H
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.H
@@ -73,6 +73,7 @@ public:
      * \param[in] start_time The time at the start of the time step
      * \param[in] a_dt The time step size
      * \param[in] a_step The time step number
+     * \param[in] verbose_step whether there is verbose output on this step
      */
     int OneStep (amrex::Real  start_time,
                  amrex::Real  a_dt,

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.H
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.H
@@ -76,7 +76,8 @@ public:
      */
     int OneStep (amrex::Real  start_time,
                  amrex::Real  a_dt,
-                 int          a_step) override;
+                 int          a_step,
+                 bool verbose_step) override;
 
     void ComputeRHS ( WarpXSolverVec&  a_RHS,
                 const WarpXSolverVec&  a_E,

--- a/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/ThetaImplicitEM.cpp
@@ -85,7 +85,8 @@ void ThetaImplicitEM::PrintParameters () const
 
 int ThetaImplicitEM::OneStep (const amrex::Real  start_time,
                               const amrex::Real  a_dt,
-                              const int          a_step)
+                              const int          a_step,
+                              const bool         verbose_step)
 {
     BL_PROFILE("ThetaImplicitEM::OneStep()");
 
@@ -117,7 +118,7 @@ int ThetaImplicitEM::OneStep (const amrex::Real  start_time,
 
     // Solve nonlinear system for Eg at t_{n+theta}
     // Particles will be advanced to t_{n+1/2}
-    m_nlsolver->Solve(m_E, m_Eold, start_time, m_dt, a_step);
+    m_nlsolver->Solve(m_E, m_Eold, start_time, m_dt, a_step, verbose_step);
 
     const int exit_status = m_nlsolver->GetExitStatus();
     if (exit_status < 0) { return exit_status; }

--- a/Source/FieldSolver/WarpXSolveFieldsES.cpp
+++ b/Source/FieldSolver/WarpXSolveFieldsES.cpp
@@ -13,7 +13,8 @@
 
 #include <ablastr/profiler/ProfilerWrapper.H>
 
-void WarpX::ComputeSpaceChargeField (bool const reset_E_field, bool const reset_B_field)
+void WarpX::ComputeSpaceChargeField (bool const reset_E_field, bool const reset_B_field,
+                                     bool const verbose_step)
 {
     ABLASTR_PROFILE("WarpX::ComputeSpaceChargeField");
     using ablastr::fields::Direction;
@@ -32,5 +33,5 @@ void WarpX::ComputeSpaceChargeField (bool const reset_E_field, bool const reset_
     }
 
     m_electrostatic_solver->ComputeSpaceChargeField(
-        m_fields, *mypc, myfl.get(), max_level );
+        m_fields, *mypc, myfl.get(), max_level, verbose_step);
 }

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -907,7 +907,8 @@ WarpX::InitData ()
         {
             bool const reset_E_field = false; // Do not erase previous user-specified values on the grid
             bool const reset_B_field = false; // Do not erase previous user-specified values on the grid
-            ComputeSpaceChargeField(reset_E_field, reset_B_field);
+            bool const verbose_step = true; // Always be verbose during initialization
+            ComputeSpaceChargeField(reset_E_field, reset_B_field, true);
             if (electrostatic_solver_id == ElectrostaticSolverAlgo::LabFrameElectroMagnetostatic) {
                 ComputeMagnetostaticField();
             }

--- a/Source/Initialization/WarpXInitData.cpp
+++ b/Source/Initialization/WarpXInitData.cpp
@@ -908,7 +908,7 @@ WarpX::InitData ()
             bool const reset_E_field = false; // Do not erase previous user-specified values on the grid
             bool const reset_B_field = false; // Do not erase previous user-specified values on the grid
             bool const verbose_step = true; // Always be verbose during initialization
-            ComputeSpaceChargeField(reset_E_field, reset_B_field, true);
+            ComputeSpaceChargeField(reset_E_field, reset_B_field, verbose_step);
             if (electrostatic_solver_id == ElectrostaticSolverAlgo::LabFrameElectroMagnetostatic) {
                 ComputeMagnetostaticField();
             }

--- a/Source/NonlinearSolvers/NewtonSolver.H
+++ b/Source/NonlinearSolvers/NewtonSolver.H
@@ -51,7 +51,8 @@ public:
           const Vec&   a_b,
           amrex::Real  a_time,
           amrex::Real  a_dt,
-          int          a_step) const override;
+          int          a_step,
+          bool verbose_step) const override;
 
     void GetSolverParams (amrex::Real&  a_rtol,
                           amrex::Real&  a_atol,
@@ -313,7 +314,8 @@ void NewtonSolver<Vec,Ops>::Solve (Vec&         a_U,
                              const Vec&         a_b,
                                    amrex::Real  a_time,
                                    amrex::Real  a_dt,
-                                   int          a_step) const
+                                   int          a_step,
+                                   bool verbose_step) const
 {
     BL_PROFILE("NewtonSolver::Solve()");
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
@@ -349,7 +351,7 @@ void NewtonSolver<Vec,Ops>::Solve (Vec&         a_U,
         norm_rel = norm_abs/norm0;
 
         // Check for convergence criteria
-        if (this->m_verbose || iter == m_maxits) {
+        if ((this->m_verbose and verbose_step) || iter == m_maxits) {
             amrex::Print() << "Newton: iteration = " << std::setw(3) << iter <<  ", norm = "
                            << std::scientific << std::setprecision(5) << norm_abs << " (abs.), "
                            << std::scientific << std::setprecision(5) << norm_rel << " (rel.)" << "\n";
@@ -357,7 +359,7 @@ void NewtonSolver<Vec,Ops>::Solve (Vec&         a_U,
 
         if (norm_abs < m_atol) {
             this->m_exit_status = 2;
-            if (this->m_verbose) {
+            if (this->m_verbose and verbose_step) {
                 amrex::Print() << "Newton: exiting at iteration = " << std::setw(3) << iter
                                << ". Satisfied absolute tolerance " << m_atol << "\n";
             }
@@ -366,7 +368,7 @@ void NewtonSolver<Vec,Ops>::Solve (Vec&         a_U,
 
         if (norm_rel < m_rtol) {
             this->m_exit_status = 3;
-            if (this->m_verbose) {
+            if (this->m_verbose and verbose_step) {
                 amrex::Print() << "Newton: exiting at iteration = " << std::setw(3) << iter
                                << ". Satisfied relative tolerance " << m_rtol << "\n";
             }
@@ -400,7 +402,7 @@ void NewtonSolver<Vec,Ops>::Solve (Vec&         a_U,
 
         iter++;
         if (iter >= m_maxits) {
-            if (this->m_verbose) {
+            if (this->m_verbose and verbose_step) {
                 amrex::Print() << "Newton: exiting at iter = " << std::setw(3) << iter
                                << ". Maximum iteration reached: iter = " << m_maxits << "\n";
             }

--- a/Source/NonlinearSolvers/NonlinearSolver.H
+++ b/Source/NonlinearSolvers/NonlinearSolver.H
@@ -62,7 +62,8 @@ public:
                   const Vec&,
                         amrex::Real,
                         amrex::Real,
-                        int) const = 0;
+                        int,
+                        bool) const = 0;
 
     /**
      * \brief Return the nonlinear solver exit status.

--- a/Source/NonlinearSolvers/PETScSNES_Wrapper.H
+++ b/Source/NonlinearSolvers/PETScSNES_Wrapper.H
@@ -63,8 +63,12 @@ class PETScSNES : public NonlinearSolver<Vec,Ops>
                     const Vec& a_b,
                     RT a_time,
                     RT a_dt,
-                    int a_step)  const override
+                    int a_step,
+                    bool verbose_step)  const override
         {
+
+            bool const verbose = verbose_step ? this->m_verbose : 0;
+            m_solver->setVerbose(verbose);
             m_solver->solve(a_U, a_b, a_time, a_dt, a_step);
             this->m_exit_status = m_solver->getStatus();
 

--- a/Source/NonlinearSolvers/PicardSolver.H
+++ b/Source/NonlinearSolvers/PicardSolver.H
@@ -45,7 +45,8 @@ public:
           const Vec&   a_b,
           amrex::Real  a_time,
           amrex::Real  a_dt,
-          int          a_step) const override;
+          int          a_step,
+          bool verbose_step) const override;
 
     void GetSolverParams (amrex::Real&  a_rtol,
                           amrex::Real&  a_atol,
@@ -171,7 +172,8 @@ void PicardSolver<Vec,Ops>::Solve (Vec&         a_U,
                              const Vec&         a_b,
                                    amrex::Real  a_time,
                                    amrex::Real  a_dt,
-                                   int          a_step) const
+                                   int          a_step,
+                                   bool verbose_step) const
 {
     BL_PROFILE("PicardSolver::Solve()");
     WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
@@ -210,7 +212,7 @@ void PicardSolver<Vec,Ops>::Solve (Vec&         a_U,
         iter++;
 
         // Check for convergence criteria
-        if (this->m_verbose || iter == m_maxits) {
+        if ((this->m_verbose and verbose_step) || iter == m_maxits) {
             amrex::Print() << "Picard: iter = " << std::setw(3) << iter <<  ", norm = "
                            << std::scientific << std::setprecision(5) << norm_abs << " (abs.), "
                            << std::scientific << std::setprecision(5) << norm_rel << " (rel.)" << "\n";
@@ -218,7 +220,7 @@ void PicardSolver<Vec,Ops>::Solve (Vec&         a_U,
 
         if (norm_abs < m_atol) {
             this->m_exit_status = 2;
-            if (this->m_verbose) {
+            if (this->m_verbose and verbose_step) {
                 amrex::Print() << "Picard: exiting at iter = " << std::setw(3) << iter
                                << ". Satisfied absolute tolerance " << m_atol << "\n";
             }
@@ -227,7 +229,7 @@ void PicardSolver<Vec,Ops>::Solve (Vec&         a_U,
 
         if (norm_rel < m_rtol) {
             this->m_exit_status = 3;
-            if (this->m_verbose) {
+            if (this->m_verbose and verbose_step) {
                 amrex::Print() << "Picard: exiting at iter = " << std::setw(3) << iter
                                << ". Satisfied relative tolerance " << m_rtol << "\n";
             }
@@ -235,7 +237,7 @@ void PicardSolver<Vec,Ops>::Solve (Vec&         a_U,
         }
 
         if (iter >= m_maxits) {
-            if (this->m_verbose) {
+            if (this->m_verbose and verbose_step) {
                 amrex::Print() << "Picard: exiting at iter = " << std::setw(3) << iter
                                << ". Maximum iteration reached: iter = " << m_maxits << "\n";
             }

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -1095,7 +1095,8 @@ private:
     void OneStep (
         amrex::Real a_cur_time,
         amrex::Real a_dt,
-        int a_step
+        int a_step,
+        bool verbose_step
     );
 
     void OneStep_nosub (

--- a/Source/WarpX.H
+++ b/Source/WarpX.H
@@ -814,7 +814,7 @@ public:
     [[nodiscard]] amrex::IntVect get_numprocs() const {return numprocs;}
 
     /** Electrostatic solve call */
-    void ComputeSpaceChargeField (bool reset_E_field, bool reset_B_field);
+    void ComputeSpaceChargeField (bool reset_E_field, bool reset_B_field, bool verbose_step);
 
     // Magnetostatic Solver Interface
     MagnetostaticSolver::VectorPoissonBoundaryHandler m_vector_poisson_boundary_handler;


### PR DESCRIPTION
When `warpx.limit_verbose_step` is set to true, it limits the printing of the step info, which is useful to reduce verbosity on long simulations. This PR also applies this to the output of the field solvers, so that there is output from them only on the same steps where the step info is printed. This includes both the MLMG solver and the implicit solvers.