### PR TITLE
Cleanly Finalize Implicit & PETSc Solvers

### DIFF
--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -76,10 +76,18 @@ public:
     {
         assertIsDefined( a_solver_vec );
         m_num_amr_levels = a_solver_vec.m_num_amr_levels;
-        Define( WarpXSolverVec::m_WarpX,
+        Define( a_solver_vec.m_WarpX,
                 a_solver_vec.getVectorType(),
                 a_solver_vec.getScalarType() );
     }
+
+    /** \brief Release the DOF map shared by all solver vectors
+     *
+     * The map is built from the grids of a single WarpX instance and is scoped to
+     * its lifetime: WarpX::Finalize() calls this, and the next Define() rebuilds
+     * the map for the new instance.
+     */
+    static void Clear ();
 
     [[nodiscard]] RT dotProduct( const WarpXSolverVec&  a_X ) const;
 
@@ -122,6 +130,10 @@ public:
             m_scalar_vec = std::move(a_solver_vec.m_scalar_vec);
             m_array_type = a_solver_vec.m_array_type;
             m_scalar_type = a_solver_vec.m_scalar_type;
+            m_vector_type_name = a_solver_vec.m_vector_type_name;
+            m_scalar_type_name = a_solver_vec.m_scalar_type_name;
+            m_num_amr_levels = a_solver_vec.m_num_amr_levels;
+            m_WarpX = a_solver_vec.m_WarpX;
             m_is_defined = true;
         }
         return *this;
@@ -332,9 +344,14 @@ private:
     static constexpr int m_ncomp = 1;
     int m_num_amr_levels = 1;
 
-    inline static bool m_warpx_ptr_defined = false;
-    inline static WarpX* m_WarpX = nullptr;
+    /** The WarpX instance whose fields this vector mirrors.
+     *
+     * Set by Define() and scoped to a single vector, so that a process running
+     * several simulations one after another gets the instance it is solving for.
+     */
+    WarpX* m_WarpX = nullptr;
 
+    /** DOF map shared by all solver vectors, see Clear() for its lifetime. */
     static std::unique_ptr<WarpXSolverDOF> m_dofs;
 };
 

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.H
@@ -81,14 +81,6 @@ public:
                 a_solver_vec.getScalarType() );
     }
 
-    /** \brief Release the DOF map shared by all solver vectors
-     *
-     * The map is built from the grids of a single WarpX instance and is scoped to
-     * its lifetime: WarpX::Finalize() calls this, and the next Define() rebuilds
-     * the map for the new instance.
-     */
-    static void Clear ();
-
     [[nodiscard]] RT dotProduct( const WarpXSolverVec&  a_X ) const;
 
     void Copy ( warpx::fields::FieldType  a_array_type,
@@ -351,7 +343,6 @@ private:
      */
     WarpX* m_WarpX = nullptr;
 
-    /** DOF map shared by all solver vectors, see Clear() for its lifetime. */
     static std::unique_ptr<WarpXSolverDOF> m_dofs;
 };
 

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
@@ -29,11 +29,11 @@ void WarpXSolverVec::Define ( WarpX*  a_WarpX,
         !IsDefined(),
         "WarpXSolverVec::Define() called on already defined WarpXSolverVec");
 
-    // Define static member pointer to WarpX
-    if (!m_warpx_ptr_defined) {
-        m_WarpX = a_WarpX;
-        m_warpx_ptr_defined = true;
-    }
+    WARPX_ALWAYS_ASSERT_WITH_MESSAGE(
+        a_WarpX != nullptr,
+        "WarpXSolverVec::Define() called with a nullptr WarpX instance");
+
+    m_WarpX = a_WarpX;
 
     m_num_amr_levels = 1;
 
@@ -105,10 +105,17 @@ void WarpXSolverVec::Define ( WarpX*  a_WarpX,
     if (m_dofs == nullptr) {
         m_dofs = std::make_unique<WarpXSolverDOF>();
         m_dofs->Define(m_WarpX, m_num_amr_levels, m_vector_type_name, m_scalar_type_name);
+        // Backstop for an embedding that tears down AMReX without calling
+        // WarpX::Finalize(): frees the DOF MultiFabs while their Arena is alive
         amrex::ExecOnFinalize([p=&m_dofs] () { p->reset(); });
     }
 
     m_is_defined = true;
+}
+
+void WarpXSolverVec::Clear ()
+{
+    m_dofs.reset();
 }
 
 void WarpXSolverVec::Copy ( warpx::fields::FieldType  a_array_type,

--- a/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
+++ b/Source/FieldSolver/ImplicitSolvers/WarpXSolverVec.cpp
@@ -105,17 +105,10 @@ void WarpXSolverVec::Define ( WarpX*  a_WarpX,
     if (m_dofs == nullptr) {
         m_dofs = std::make_unique<WarpXSolverDOF>();
         m_dofs->Define(m_WarpX, m_num_amr_levels, m_vector_type_name, m_scalar_type_name);
-        // Backstop for an embedding that tears down AMReX without calling
-        // WarpX::Finalize(): frees the DOF MultiFabs while their Arena is alive
         amrex::ExecOnFinalize([p=&m_dofs] () { p->reset(); });
     }
 
     m_is_defined = true;
-}
-
-void WarpXSolverVec::Clear ()
-{
-    m_dofs.reset();
 }
 
 void WarpXSolverVec::Copy ( warpx::fields::FieldType  a_array_type,

--- a/Source/NonlinearSolvers/WarpX_PETSc.H
+++ b/Source/NonlinearSolvers/WarpX_PETSc.H
@@ -231,7 +231,7 @@ class SNES_impl : public PETScSolver_impl
         void solve(VecType&, const VecType&, amrex::Real, amrex::Real, int) const;
 
         //! Evaluate the RHS
-        void computeRHS(VecType&, const VecType&) const;
+        void computeRHS(VecType&, const VecType&);
 
         //! Returns if a preconditioner is being used
         [[nodiscard]] bool usePC() const;
@@ -285,7 +285,7 @@ class SNES_impl : public PETScSolver_impl
          * Scoped to a single solver, so each solver built in a process takes that
          * path exactly once.
          */
-        mutable bool m_rhs_first_call = true;
+        bool m_rhs_first_call = true;
 
         //! Linear operator object
         std::unique_ptr<LinOpType> m_linop;

--- a/Source/NonlinearSolvers/WarpX_PETSc.H
+++ b/Source/NonlinearSolvers/WarpX_PETSc.H
@@ -280,6 +280,13 @@ class SNES_impl : public PETScSolver_impl
         //! Using SNES FD?
         bool m_fd_jac_comput = false;
 
+        /** Whether computeRHS() still has to run its first-call path.
+         *
+         * Scoped to a single solver, so each solver built in a process takes that
+         * path exactly once.
+         */
+        mutable bool m_rhs_first_call = true;
+
         //! Linear operator object
         std::unique_ptr<LinOpType> m_linop;
 

--- a/Source/NonlinearSolvers/WarpX_PETSc.cpp
+++ b/Source/NonlinearSolvers/WarpX_PETSc.cpp
@@ -818,7 +818,7 @@ void SNES_impl::solve (VecType& a_U,
     m_total_linsol_iters += m_niters_l;
 }
 
-void SNES_impl::computeRHS(VecType& a_F, const VecType& a_U) const
+void SNES_impl::computeRHS(VecType& a_F, const VecType& a_U)
 {
     BL_PROFILE("SNES_impl::computeRHS()");
     AMREX_ALWAYS_ASSERT(isDefined());

--- a/Source/NonlinearSolvers/WarpX_PETSc.cpp
+++ b/Source/NonlinearSolvers/WarpX_PETSc.cpp
@@ -824,9 +824,8 @@ void SNES_impl::computeRHS(VecType& a_F, const VecType& a_U) const
     AMREX_ALWAYS_ASSERT(isDefined());
 
     if (m_fd_jac_comput) {
-        static bool first_call = true;
-        m_op->ComputeRHS( a_F, a_U, m_time, m_iter, !first_call);
-        first_call = false;
+        m_op->ComputeRHS( a_F, a_U, m_time, m_iter, !m_rhs_first_call);
+        m_rhs_first_call = false;
     } else {
         m_op->ComputeRHS( a_F, a_U, m_time, m_iter, false);
     }

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -50,7 +50,6 @@
 #include "Utils/WarpXUtil.H"
 
 #include "FieldSolver/ImplicitSolvers/ImplicitSolverLibrary.H"
-#include "FieldSolver/ImplicitSolvers/WarpXSolverVec.H"
 
 #include <ablastr/math/FiniteDifference.H>
 #include <ablastr/math/RandomSeed.H>
@@ -333,10 +332,6 @@ WarpX::Finalize()
 
     // Clear all of the warning messages
     ablastr::warn_manager::WMClear();
-
-    // Release the DOF map that the implicit solvers share: it is built from the
-    // grids of the instance destroyed above
-    WarpXSolverVec::Clear();
 }
 
 WarpX::WarpX ()

--- a/Source/WarpX.cpp
+++ b/Source/WarpX.cpp
@@ -50,6 +50,7 @@
 #include "Utils/WarpXUtil.H"
 
 #include "FieldSolver/ImplicitSolvers/ImplicitSolverLibrary.H"
+#include "FieldSolver/ImplicitSolvers/WarpXSolverVec.H"
 
 #include <ablastr/math/FiniteDifference.H>
 #include <ablastr/math/RandomSeed.H>
@@ -332,6 +333,10 @@ WarpX::Finalize()
 
     // Clear all of the warning messages
     ablastr::warn_manager::WMClear();
+
+    // Release the DOF map that the implicit solvers share: it is built from the
+    // grids of the instance destroyed above
+    WarpXSolverVec::Clear();
 }
 
 WarpX::WarpX ()


### PR DESCRIPTION
Our implicit & non-linear PETSc solvers carried some global variable state to WarpX instances in `static` variables, which were not cleaned up properly on finalize. This causes problems when running another WarpX simulation directly afterwards in the same process, e.g., in Python scripts, optimization loops or PyTest testing.

Also fixes the half-implemented move assignment `operator=` to be complete, to avoid issues in the future.