### PR TITLE
Docs: Robust Doxygen Tag File Downloads

### DIFF
--- a/.github/workflows/source/doxygen
+++ b/.github/workflows/source/doxygen
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2020-2023 The WarpX Community
+# Copyright 2020-2026 The WarpX Community
 #
 # License: BSD-3-Clause-LBNL
 # Authors: Axel Huebl
@@ -9,19 +9,51 @@ set -eu -o pipefail
 
 cd Docs
 
-curl -L -o amrex-doxygen-web.tag.xml \
-  https://amrex-codes.github.io/amrex/docs_xml/doxygen/amrex-doxygen-web.tag.xml
+# Doxygen tag files that we could download, in Doxygen's TAGFILES syntax
+tagfiles=()
 
-curl -L -o openpmd-api-doxygen-web.tag.xml \
-  https://openpmd-api.readthedocs.io/en/latest/_static/doxyhtml/openpmd-api-doxygen-web.tag.xml
+# Download a Doxygen tag file to cross-link into an external documentation.
+#
+# Web servers (e.g., Read the Docs behind Cloudflare) occasionally answer
+# requests from CI runners with an HTML error page instead of the file. curl
+# writes such a page to disk just as happily as the real thing and Doxygen then
+# aborts with a rather cryptic XML parser error, e.g.,
+#   warpx-doxygen-web.tag.xml:1: error: Unexpected character `h` found
+# (the `h` of `<!DOCTYPE html>`). Thus, we retry, stop on HTTP errors and check
+# that we actually received XML. Tag files that stay unavailable are skipped:
+# they only add cross-links into external docs, which is not worth a CI failure.
+download_tagfile () {
+    local filename=$1
+    local download_url=$2
+    local docs_url=$3
 
-# Treat all warnings as errors
-if ! grep -q "WARN_AS_ERROR = YES" Doxyfile; then
-    # Add line with the comment
-    echo "" >> Doxyfile
-    echo "# Overwrite value of WARN_AS_ERROR" >> Doxyfile
-    echo "WARN_AS_ERROR = YES" >> Doxyfile
-fi
+    if curl --location --fail --silent --show-error \
+            --retry 5 --retry-delay 5 --retry-all-errors \
+            --user-agent "WarpX-docs-builder" \
+            --output "${filename}" "${download_url}" \
+       && head -c 100 "${filename}" | grep -q "<?xml"
+    then
+        tagfiles+=("${filename}=${docs_url}")
+    else
+        echo "WARNING: no valid tag file at ${download_url}" >&2
+        echo "         Continuing without cross-links into ${docs_url}" >&2
+        rm -f "${filename}"
+    fi
+}
 
-# Run doxygen
-doxygen
+download_tagfile amrex-doxygen-web.tag.xml \
+  https://amrex-codes.github.io/amrex/docs_xml/doxygen/amrex-doxygen-web.tag.xml \
+  https://amrex-codes.github.io/amrex/doxygen/
+
+download_tagfile openpmd-api-doxygen-web.tag.xml \
+  https://openpmd-api.readthedocs.io/en/latest/_static/doxyhtml/openpmd-api-doxygen-web.tag.xml \
+  https://openpmd-api.readthedocs.io/en/latest/_static/doxyhtml/
+
+# Run doxygen, treating all warnings as errors and cross-linking only the tag
+# files that we have. Both options overwrite the values set in the Doxyfile,
+# which we read via stdin to keep the file itself unmodified.
+{
+    cat Doxyfile
+    echo "WARN_AS_ERROR = YES"
+    echo "TAGFILES = ${tagfiles[*]:-}"
+} | doxygen -

--- a/Docs/source/conf.py
+++ b/Docs/source/conf.py
@@ -45,12 +45,20 @@ sys.path.insert(0, _ext_path)
 
 
 def download_with_headers(url, filename):
-    """Download a file with proper User-Agent header to avoid 403 errors."""
+    """Download a Doxygen tag file, with a User-Agent header to avoid 403 errors.
+
+    Web servers sometimes answer with an HTML error page instead of the file.
+    Writing that page to disk would make Doxygen abort reading tag files with a
+    cryptic XML parser error, thus we only keep payloads that start like XML.
+    """
     try:
         req = urllib.request.Request(url, headers={"User-Agent": "WarpX-docs-builder"})
         with urllib.request.urlopen(req) as response:
-            with open(filename, "wb") as f:
-                f.write(response.read())
+            payload = response.read()
+        if not payload.lstrip().startswith(b"<?xml"):
+            raise RuntimeError("downloaded file is not XML")
+        with open(filename, "wb") as f:
+            f.write(payload)
     except Exception as e:
         print(f"Could not download {filename} from {url}: {e}")
         print("Continuing build without cross-reference file...")


### PR DESCRIPTION
The `source` CI job and the Read the Docs build download the Doxygen tag files of AMReX and openPMD-api to cross-link into their documentation. `curl -L -o` writes whatever the server answers to disk, also an HTML error page, and Doxygen then aborts with a rather cryptic XML parser error on a file that looks perfectly fine on the web, e.g.:

```
openpmd-api-doxygen-web.tag.xml:1: error: Unexpected character `h` found
```

(the `h` of `<!DOCTYPE html>`). Read the Docs, behind Cloudflare, does answer CI runners with such pages every now and then, which recently broke ImpactX' `source` job on our published tag file: https://github.com/BLAST-ImpactX/impactx/actions/runs/34435302269

Downloads now retry, stop on HTTP errors (`--fail`) and are checked to actually be XML. A tag file that stays unavailable is skipped instead of failing the run: it only adds cross-links into an external documentation, which is not worth failing CI over a third-party outage.

Internal:
- `.github/workflows/source/doxygen`: retry/validate downloads, skip unavailable tag files via a `TAGFILES` override, and pass the config through stdin (`doxygen -`) so the run no longer modifies `Doxyfile`
- `Docs/source/conf.py`: only write downloaded tag files that are XML


First seen in https://github.com/BLAST-ImpactX/impactx/pull/1658