### PR TITLE
Fix NewtonSolver with maxiters

### DIFF
--- a/Source/NonlinearSolvers/NewtonSolver.H
+++ b/Source/NonlinearSolvers/NewtonSolver.H
@@ -337,7 +337,7 @@ void NewtonSolver<Vec,Ops>::Solve (Vec&         a_U,
 
     int iter;
     int linear_solver_iters = 0;
-    for (iter = 0; iter < m_maxits;) {
+    for (iter = 0; iter <= m_maxits; iter++) {
 
         // Compute residual: F(U) = U - b - R(U)
         EvalResidual(m_F, a_U, a_b, a_time, iter);
@@ -351,7 +351,7 @@ void NewtonSolver<Vec,Ops>::Solve (Vec&         a_U,
         norm_rel = norm_abs/norm0;
 
         // Check for convergence criteria
-        if ((this->m_verbose and verbose_step) || iter == m_maxits) {
+        if (this->m_verbose and verbose_step) {
             amrex::Print() << "Newton: iteration = " << std::setw(3) << iter <<  ", norm = "
                            << std::scientific << std::setprecision(5) << norm_abs << " (abs.), "
                            << std::scientific << std::setprecision(5) << norm_rel << " (rel.)" << "\n";
@@ -371,6 +371,14 @@ void NewtonSolver<Vec,Ops>::Solve (Vec&         a_U,
             if (this->m_verbose and verbose_step) {
                 amrex::Print() << "Newton: exiting at iteration = " << std::setw(3) << iter
                                << ". Satisfied relative tolerance " << m_rtol << "\n";
+            }
+            break;
+        }
+
+        if (iter == m_maxits) {
+            if (this->m_verbose and verbose_step) {
+                amrex::Print() << "Newton: exiting at iter = " << std::setw(3) << iter
+                               << ". Maximum iteration reached: iter = " << m_maxits << "\n";
             }
             break;
         }
@@ -399,23 +407,15 @@ void NewtonSolver<Vec,Ops>::Solve (Vec&         a_U,
 
         // Update solution
         a_U -= m_dU;
-
-        iter++;
-        if (iter >= m_maxits) {
-            if (this->m_verbose and verbose_step) {
-                amrex::Print() << "Newton: exiting at iter = " << std::setw(3) << iter
-                               << ". Maximum iteration reached: iter = " << m_maxits << "\n";
-            }
-            break;
-        }
-
     }
 
     // Update total iteration count
     m_total_iters += iter;
     m_total_linsol_iters += linear_solver_iters;
 
-    if (m_rtol > 0. && iter == m_maxits) {
+    // Note that the failure warning is skipped in the case when
+    // m_rtol == 0 to allow a fixed number of iterations without a flood of warning.
+    if (norm_rel > m_rtol and norm_abs > m_atol and m_rtol > 0.) {
         std::stringstream convergenceMsg;
         convergenceMsg << "Newton solver failed to converge after " << iter <<
                           " iterations. Relative norm is " << norm_rel <<


### PR DESCRIPTION
In the nonlinear NewtonSolver, there is an issue that if the maximum number of iterations is reached, the residual is not calculated on the last iteration. So, if the last iteration causes the residual error to drop below the tolerance levels, this is not detected and the solver still fails since it hit the maximum number of iterations. This PR fixes the issue, allowing success in this case, when the error drops below the tolerance on the last iteration.

Note that this change is needed for the CI test in PR #7000.